### PR TITLE
fix: reset all registers when removing multi-register data types

### DIFF
--- a/src/main/modules/mobusServer.ts
+++ b/src/main/modules/mobusServer.ts
@@ -19,6 +19,7 @@ import { ServerTCP } from 'modbus-serial'
 import { Windows } from '@shared'
 import { ValueGenerator } from './modbusServer/valueGenerator'
 import type { IServiceVector, FCallbackVal } from 'modbus-serial'
+import { getRegisterLength } from '@shared'
 import net from 'net'
 
 const getDefaultGenerators = (): ValueGenerators => ({
@@ -322,11 +323,22 @@ export class ModbusServer {
    * Removes a register or value generator for a given server and unitId.
    * Disposes the generator if it exists and resets the register value.
    */
-  public removeRegister = ({ uuid, unitId, registerType, address }: RemoveRegisterParams): void => {
+  public removeRegister = ({
+    uuid,
+    unitId,
+    registerType,
+    address,
+    dataType
+  }: RemoveRegisterParams): void => {
     const perUnitMap = this._ensureInnerMap<ServerDataUnitMap>(this._serverData, uuid)
     const serverData = perUnitMap.get(unitId) ?? getDefaultServerData()
     if (!perUnitMap.has(unitId)) perUnitMap.set(unitId, serverData)
-    serverData[registerType][address] = 0
+
+    // Reset all registers occupied by this data type
+    const registerCount = getRegisterLength(dataType, address)
+    for (let i = 0; i < registerCount; i++) {
+      serverData[registerType][address + i] = 0
+    }
 
     const perUnitGeneratorMap = this._ensureInnerMap<ValueGeneratorsUnitMap>(
       this._generatorMap,

--- a/src/renderer/src/components/server/ServerGrid/ServerRegisters/AddRegister.tsx
+++ b/src/renderer/src/components/server/ServerGrid/ServerRegisters/AddRegister.tsx
@@ -463,7 +463,13 @@ function submitRegister(isEdit: boolean): { address: number; dataType: BaseDataT
   if (isEdit && serverRegisterEdit) {
     const oldAddress = serverRegisterEdit.params.address
     if (oldAddress !== Number(address)) {
-      z.removeRegister({ uuid, unitId, address: oldAddress, registerType })
+      z.removeRegister({
+        uuid,
+        unitId,
+        address: oldAddress,
+        registerType,
+        dataType: serverRegisterEdit.params.dataType
+      })
     }
   }
 
@@ -576,11 +582,16 @@ const DeleteButton = meme(() => {
     const uuid = z.selectedUuid
     const unitId = z.getUnitId(uuid)
 
+    const addr = Number(address)
+    const entry = z.serverRegisters[uuid]?.[unitId]?.[registerType]?.[addr]
+    const dataType = entry?.params?.dataType ?? 'uint16'
+
     z.removeRegister({
       uuid,
       unitId,
-      address: Number(address),
-      registerType
+      address: addr,
+      registerType,
+      dataType
     })
 
     setRegisterType(undefined)

--- a/src/shared/types/server.ts
+++ b/src/shared/types/server.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { BaseDataTypeSchema } from './datatype'
+import { BaseDataType, BaseDataTypeSchema } from './datatype'
 import { RegisterType } from './client'
 import { ValueGenerator } from '../../main/modules/modbusServer/valueGenerator'
 import { unitIds } from './unitid'
@@ -105,6 +105,7 @@ export interface RemoveRegisterParams {
   unitId: UnitIdString
   registerType: NumberRegisters
   address: number
+  dataType: BaseDataType
 }
 
 export interface SyncRegisterValueParams {


### PR DESCRIPTION
## Summary

- `removeRegister` only cleared the start address register, leaving stale data in subsequent registers for multi-register types (int32/uint32/float = 2 regs, int64/uint64/double = 4 regs)
- When editing a register and changing its address, the old registers were not fully cleaned up, causing ghost values in the server data
- Now uses `getRegisterLength(dataType, address)` to compute the full register span and resets all occupied registers

## Changes

| File                                              | Change                                                                       |
| ------------------------------------------------- | ---------------------------------------------------------------------------- |
| `src/shared/types/server.ts`                      | Added `dataType: BaseDataType` to `RemoveRegisterParams`                     |
| `src/main/modules/mobusServer.ts`                 | `removeRegister` now resets all registers based on `getRegisterLength`       |
| `src/renderer/.../AddRegister.tsx`                | Both `removeRegister` call sites now pass `dataType`                         |
| `src/main/modules/__tests__/modbusServer.test.ts` | 2 new tests (int32 + double) verifying all occupied registers are reset to 0 |

## How to reproduce

1. Open server view, add an INT32 register at address 0 with value 70000
2. Edit the register, change address to 10
3. Address 0 is now 0, but address 1 still contains 4464 (the low word of 70000)

## Test plan

- [x] Unit tests pass (`vitest run modbusServer.test.ts`)
- [x] E2E tests pass (full suite)
- [x] Manual test: add INT32 at addr 0, edit to addr 10, verify addr 1 is reset

## Known issues

- E2E tests fail on Windows — this is addressed [here](https://github.com/ploxc/modbux/commit/9ea09f6211d82ed43ad14f91ba89872e946fd465#diff-4c2328a0a6fdd8f2e5e71e0014d533783d6553351c10c9c96fee1e7170728493) but not yet in main