### PR TITLE
Hostname support & RTU server mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Modbux will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.1.0] - 2026-03-13
+## [2.1.0] - 2026-03-14
 
 ### Added
 
@@ -16,6 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - All register types, value generators, and booleans work the same as TCP
 
 - **Hostname/IP support for TCP client** — connection config now accepts any hostname or IP address instead of only `localhost`
+
+- **Linux support** — verified builds and packaging for Linux (`.deb`, `.AppImage`)
+  - Privileged port errors (EACCES on port 502) handled gracefully with clear error messages
+  - Linux icon path configured for correct app icons
+  - README updated with Linux-specific setup notes (unprivileged ports, serial `dialout` group)
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to Modbux will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - 2026-03-13
+
+### Added
+
+- **RTU server mode** — new TCP/RTU toggle lets the server expose registers over a serial port
+  - COM port autocomplete with refresh, baud rate, parity, data bits, and stop bits
+  - Status indicator with click-to-reconnect
+  - Switching between TCP and RTU preserves all register data
+  - All register types, value generators, and booleans work the same as TCP
+
+- **Hostname/IP support for TCP client** — connection config now accepts any hostname or IP address instead of only `localhost`
+
+---
+
 ## [2.0.0] - 2026-02-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -169,9 +169,32 @@ yarn build:win
 # For macOS
 yarn build:mac
 
-# For Linux (not tested — let me know if it works!)
+# For Linux
 yarn build:linux
 ```
+
+> **Linux notes:**
+>
+> The default Modbus port (502) requires elevated access. To allow binding without sudo:
+>
+> ```bash
+> sudo sysctl net.ipv4.ip_unprivileged_port_start=502
+> ```
+>
+> To persist across reboots:
+>
+> ```bash
+> echo 'net.ipv4.ip_unprivileged_port_start=502' | sudo tee /etc/sysctl.d/50-unprivileged-ports.conf
+> sudo sysctl --system
+> ```
+>
+> For serial port access (RTU mode), add your user to the `dialout` group:
+>
+> ```bash
+> sudo usermod -aG dialout $USER
+> ```
+>
+> Log out and back in for it to take effect.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -27,12 +27,13 @@ Available for Windows and macOS
 - Scan Unit IDs and register ranges
 - Big-endian / Little-endian support (swap registers)
 - Scaling factors and linear interpolation
-- Modbus TCP and RTU support with automatic COM port discovery
+- Modbus TCP (with hostname/IP) and RTU support with automatic COM port discovery
 - Configuration save/load (JSON)
 
 **Server Mode:**
 
-- Simulate up to 10 Modbus devices
+- Modbus TCP and RTU server modes (serial port, USB converters, socat virtual pairs)
+- Simulate up to 10 Modbus devices (TCP mode)
 - 256 Unit IDs per server (0-255)
 - 12 data types: numeric registers, bitmap, UTF-8 strings, Unix timestamps, and IEC 870-5 datetime
 - Static or random value generation with configurable intervals

--- a/e2e/specs/01-main/02-input-validation.spec.ts
+++ b/e2e/specs/01-main/02-input-validation.spec.ts
@@ -249,20 +249,22 @@ test.describe.serial('Input validation — AddRegister modal and client inputs',
     await navigateToClient(mainPage)
   })
 
-  test('IP address mask: segments clamped to 255', async ({ mainPage }) => {
+  test('host input accepts hostnames and IP addresses', async ({ mainPage }) => {
     const hostInput = mainPage.getByTestId('tcp-host-input').locator('input')
-    await hostInput.fill('999.999.999.999')
+
+    // Test hostname
+    await hostInput.fill('plc.example.com')
     await mainPage.waitForTimeout(300)
+    expect(await hostInput.inputValue()).toBe('plc.example.com')
 
-    // !changed: a seperator is automatically added when an segment is larger than 255
-    const val = await hostInput.inputValue()
-    expect(val).toBe('99.9.99.99')
+    // Test IP address
+    await hostInput.fill('192.168.1.100')
+    await mainPage.waitForTimeout(300)
+    expect(await hostInput.inputValue()).toBe('192.168.1.100')
 
-    // // Each segment should be clamped to 255
-    // const segments = val.split('.')
-    // for (const seg of segments) {
-    //   expect(Number(seg)).toBe(255)
-    // }
+    // Empty input should be invalid (restore a valid value)
+    await hostInput.fill('127.0.0.1')
+    await mainPage.waitForTimeout(300)
   })
 
   test('port input: clamped to 65535', async ({ mainPage }) => {

--- a/e2e/specs/01-main/23-server-rtu.spec.ts
+++ b/e2e/specs/01-main/23-server-rtu.spec.ts
@@ -24,7 +24,8 @@ const CONFIG_DIR = resolve(__dirname, '../../fixtures/config-files')
 const SERVER_CONFIG = resolve(CONFIG_DIR, 'server-huawei-smartlogger.json')
 const CLIENT_CONFIG = resolve(CONFIG_DIR, 'client-huawei-smartlogger.json')
 
-const SOCAT_PATH = '/usr/local/bin/socat'
+const SOCAT_PATHS = ['/usr/local/bin/socat', '/usr/bin/socat']
+const SOCAT_PATH = SOCAT_PATHS.find((p) => existsSync(p)) ?? SOCAT_PATHS[0]
 const PTY_0 = '/tmp/ttyV0'
 const PTY_1 = '/tmp/ttyV1'
 const hasSocat = existsSync(SOCAT_PATH)

--- a/e2e/specs/01-main/23-server-rtu.spec.ts
+++ b/e2e/specs/01-main/23-server-rtu.spec.ts
@@ -1,0 +1,455 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { test, expect } from '../../fixtures/electron-app'
+import {
+  navigateToServer,
+  navigateToClient,
+  cleanServerState,
+  loadServerConfig,
+  loadClientConfig,
+  connectClientRTU,
+  disconnectClient,
+  enableAdvancedMode,
+  enableReadConfiguration,
+  disableReadConfiguration,
+  readRegisters,
+  cell,
+  expandAllServerPanels,
+  selectRegisterType
+} from '../../fixtures/helpers'
+import { resolve } from 'path'
+import { spawn, type ChildProcess } from 'child_process'
+import { existsSync, unlinkSync } from 'fs'
+
+const CONFIG_DIR = resolve(__dirname, '../../fixtures/config-files')
+const SERVER_CONFIG = resolve(CONFIG_DIR, 'server-huawei-smartlogger.json')
+const CLIENT_CONFIG = resolve(CONFIG_DIR, 'client-huawei-smartlogger.json')
+
+const SOCAT_PATH = '/usr/local/bin/socat'
+const PTY_0 = '/tmp/ttyV0'
+const PTY_1 = '/tmp/ttyV1'
+const hasSocat = existsSync(SOCAT_PATH)
+
+// ─── Block 1: Server RTU UI Elements ─────────────────────────────────────────
+
+test.describe.serial('Server RTU — UI elements', () => {
+  test('navigate to server view', async ({ mainPage }) => {
+    await navigateToServer(mainPage)
+  })
+
+  test('clean server state', async ({ mainPage }) => {
+    await cleanServerState(mainPage)
+  })
+
+  // ─── Mode toggle ───────────────────────────────────────────────────
+
+  test('default server mode is TCP', async ({ mainPage }) => {
+    const tcpBtn = mainPage.getByTestId('server-mode-tcp-btn')
+    await expect(tcpBtn).toBeVisible()
+    await expect(tcpBtn).toHaveClass(/Mui-selected/)
+
+    // TCP elements visible
+    await expect(mainPage.getByTestId('server-port-input')).toBeVisible()
+    await expect(mainPage.getByTestId('select-server-502')).toBeVisible()
+  })
+
+  test('switch to RTU hides TCP elements, shows RTU config', async ({ mainPage }) => {
+    await mainPage.getByTestId('server-mode-rtu-btn').click()
+
+    // TCP elements hidden
+    await expect(mainPage.getByTestId('server-port-input')).not.toBeVisible()
+
+    // RTU config fields visible
+    await expect(mainPage.getByTestId('server-rtu-com-input')).toBeVisible()
+    await expect(mainPage.getByTestId('server-rtu-baudrate-select')).toBeVisible()
+    await expect(mainPage.getByTestId('server-rtu-parity-select')).toBeVisible()
+    await expect(mainPage.getByTestId('server-rtu-databits-select')).toBeVisible()
+    await expect(mainPage.getByTestId('server-rtu-stopbits-select')).toBeVisible()
+    await expect(mainPage.getByTestId('server-rtu-status')).toBeVisible()
+    await expect(mainPage.getByTestId('server-rtu-refresh-btn')).toBeVisible()
+
+    // RTU button selected
+    await expect(mainPage.getByTestId('server-mode-rtu-btn')).toHaveClass(/Mui-selected/)
+  })
+
+  test('SelectServer hidden in RTU mode', async ({ mainPage }) => {
+    await expect(mainPage.getByTestId('select-server-502')).not.toBeVisible()
+    await expect(mainPage.getByTestId('add-server-btn')).not.toBeVisible()
+  })
+
+  test('RTU status shows inactive (no COM)', async ({ mainPage }) => {
+    await expect(mainPage.getByTestId('server-rtu-status')).toHaveAttribute(
+      'title',
+      'RTU server inactive'
+    )
+  })
+
+  test('default RTU serial values', async ({ mainPage }) => {
+    await expect(mainPage.getByTestId('server-rtu-baudrate-select')).toContainText('9600')
+    await expect(mainPage.getByTestId('server-rtu-parity-select')).toContainText('none')
+    await expect(mainPage.getByTestId('server-rtu-databits-select')).toContainText('8')
+    await expect(mainPage.getByTestId('server-rtu-stopbits-select')).toContainText('1')
+  })
+
+  test('unit ID and endian toggle remain visible', async ({ mainPage }) => {
+    await expect(mainPage.getByTestId('server-unitid-select')).toBeVisible()
+    await expect(mainPage.getByTestId('server-endian-be-btn')).toBeVisible()
+  })
+
+  // ─── Serial config fields ─────────────────────────────────────────
+
+  test('refresh COM ports button works', async ({ mainPage }) => {
+    await mainPage.getByTestId('server-rtu-refresh-btn').click()
+    // Page still functional
+    await expect(mainPage.getByTestId('server-rtu-baudrate-select')).toBeVisible()
+    await expect(mainPage.getByTestId('server-rtu-refresh-btn')).toBeVisible()
+  })
+
+  test('baudrate select has all options', async ({ mainPage }) => {
+    await mainPage.getByTestId('server-rtu-baudrate-select').click()
+
+    const expectedRates = ['1200', '2400', '4800', '9600', '19200', '38400', '57600', '115200']
+    for (const rate of expectedRates) {
+      await expect(mainPage.getByRole('option', { name: rate })).toBeVisible()
+    }
+
+    await mainPage.keyboard.press('Escape')
+  })
+
+  test('changing baudrate persists', async ({ mainPage }) => {
+    await mainPage.getByTestId('server-rtu-baudrate-select').click()
+    await mainPage.getByRole('option', { name: '115200' }).click()
+
+    await expect(mainPage.getByTestId('server-rtu-baudrate-select')).toContainText('115200')
+  })
+
+  test('parity, databits, stopbits selects work', async ({ mainPage }) => {
+    // Change parity
+    await mainPage.getByTestId('server-rtu-parity-select').click()
+    await mainPage.getByRole('option', { name: 'even' }).click()
+    await expect(mainPage.getByTestId('server-rtu-parity-select')).toContainText('even')
+
+    // Change databits
+    await mainPage.getByTestId('server-rtu-databits-select').click()
+    await mainPage.getByRole('option', { name: '7' }).click()
+    await expect(mainPage.getByTestId('server-rtu-databits-select')).toContainText('7')
+
+    // Change stopbits
+    await mainPage.getByTestId('server-rtu-stopbits-select').click()
+    await mainPage.getByRole('option', { name: '2' }).click()
+    await expect(mainPage.getByTestId('server-rtu-stopbits-select')).toContainText('2')
+  })
+
+  // ─── Mode switching preserves state ────────────────────────────────
+
+  test('switch back to TCP restores TCP elements', async ({ mainPage }) => {
+    await mainPage.getByTestId('server-mode-tcp-btn').click()
+
+    await expect(mainPage.getByTestId('server-port-input')).toBeVisible()
+    await expect(mainPage.getByTestId('select-server-502')).toBeVisible()
+
+    // RTU config hidden
+    await expect(mainPage.getByTestId('server-rtu-baudrate-select')).not.toBeVisible()
+  })
+
+  test('switching to RTU preserves changed serial values', async ({ mainPage }) => {
+    await mainPage.getByTestId('server-mode-rtu-btn').click()
+
+    // Previously changed values should still be set
+    await expect(mainPage.getByTestId('server-rtu-baudrate-select')).toContainText('115200')
+    await expect(mainPage.getByTestId('server-rtu-parity-select')).toContainText('even')
+    await expect(mainPage.getByTestId('server-rtu-databits-select')).toContainText('7')
+    await expect(mainPage.getByTestId('server-rtu-stopbits-select')).toContainText('2')
+  })
+
+  test('switch to RTU and back preserves server data', async ({ mainPage }) => {
+    // First switch to TCP and load config
+    await mainPage.getByTestId('server-mode-tcp-btn').click()
+    await loadServerConfig(mainPage, SERVER_CONFIG)
+
+    // Check register count
+    const section = mainPage.getByTestId('section-holding_registers')
+    const textBefore = await section.textContent()
+    const matchBefore = textBefore?.match(/\((\d+)\)/)
+    expect(matchBefore).toBeTruthy()
+    const countBefore = Number(matchBefore![1])
+    expect(countBefore).toBeGreaterThanOrEqual(70)
+
+    // Switch to RTU and back
+    await mainPage.getByTestId('server-mode-rtu-btn').click()
+    await mainPage.waitForTimeout(300)
+    await mainPage.getByTestId('server-mode-tcp-btn').click()
+
+    // Register count unchanged
+    const textAfter = await section.textContent()
+    const matchAfter = textAfter?.match(/\((\d+)\)/)
+    expect(matchAfter).toBeTruthy()
+    expect(Number(matchAfter![1])).toBe(countBefore)
+  })
+
+  // ─── Cleanup ───────────────────────────────────────────────────────
+
+  test('cleanup: switch to TCP, expand panels', async ({ mainPage }) => {
+    await mainPage.getByTestId('server-mode-tcp-btn').click()
+    await expect(mainPage.getByTestId('server-port-input')).toBeVisible()
+    await expandAllServerPanels(mainPage)
+  })
+})
+
+// ─── Block 2: RTU Round-Trip via Socat ───────────────────────────────────────
+
+test.describe.serial('Server RTU — round-trip via socat', () => {
+  test.skip(!hasSocat, 'socat not available')
+
+  let socatProcess: ChildProcess | null = null
+
+  // ─── Socat lifecycle ───────────────────────────────────────────────
+
+  test('start socat virtual serial pair', async () => {
+    // Clean up any leftover symlinks
+    try {
+      unlinkSync(PTY_0)
+    } catch {
+      /* ignore */
+    }
+    try {
+      unlinkSync(PTY_1)
+    } catch {
+      /* ignore */
+    }
+
+    socatProcess = spawn(SOCAT_PATH, [
+      '-d',
+      '-d',
+      `pty,raw,echo=0,link=${PTY_0}`,
+      `pty,raw,echo=0,link=${PTY_1}`
+    ])
+
+    // Poll for symlinks to exist (max 2s)
+    const deadline = Date.now() + 2000
+    while (Date.now() < deadline) {
+      if (existsSync(PTY_0) && existsSync(PTY_1)) break
+      await new Promise((r) => setTimeout(r, 100))
+    }
+
+    expect(existsSync(PTY_0)).toBe(true)
+    expect(existsSync(PTY_1)).toBe(true)
+  })
+
+  // ─── Server setup ─────────────────────────────────────────────────
+
+  test('clean server state', async ({ mainPage }) => {
+    await cleanServerState(mainPage)
+  })
+
+  test('load Huawei server config (TCP mode)', async ({ mainPage }) => {
+    test.setTimeout(15_000)
+    await loadServerConfig(mainPage, SERVER_CONFIG)
+    await mainPage.waitForTimeout(500)
+
+    // Verify registers loaded
+    const section = mainPage.getByTestId('section-holding_registers')
+    const text = await section.textContent()
+    const match = text?.match(/\((\d+)\)/)
+    expect(match).toBeTruthy()
+    expect(Number(match![1])).toBeGreaterThanOrEqual(70)
+  })
+
+  test('switch server to RTU mode', async ({ mainPage }) => {
+    await mainPage.getByTestId('server-mode-rtu-btn').click()
+    await expect(mainPage.getByTestId('server-rtu-com-input')).toBeVisible()
+  })
+
+  test('enter server COM port /tmp/ttyV0', async ({ mainPage }) => {
+    const comInput = mainPage.getByTestId('server-rtu-com-input').locator('input')
+    await comInput.fill(PTY_0)
+    await comInput.blur()
+    await mainPage.waitForTimeout(500)
+  })
+
+  test('RTU status shows active', async ({ mainPage }) => {
+    await expect(mainPage.getByTestId('server-rtu-status')).toHaveAttribute(
+      'title',
+      'RTU server active',
+      { timeout: 5000 }
+    )
+  })
+
+  // ─── Client setup ─────────────────────────────────────────────────
+
+  test('navigate to client', async ({ mainPage }) => {
+    await navigateToClient(mainPage)
+  })
+
+  test('configure client RTU', async ({ mainPage }) => {
+    await connectClientRTU(mainPage, '0', '9600', 'none', '8', '1')
+  })
+
+  test('enter client COM /tmp/ttyV1 + connect', async ({ mainPage }) => {
+    const comInput = mainPage.getByTestId('rtu-com-input').locator('input')
+    await comInput.fill(PTY_1)
+
+    await mainPage.getByTestId('connect-btn').click()
+    await expect(mainPage.getByTestId('connect-btn')).toContainText('Disconnect', {
+      timeout: 10_000
+    })
+  })
+
+  test('enable advanced mode', async ({ mainPage }) => {
+    await enableAdvancedMode(mainPage)
+  })
+
+  // ─── Register spot-checks ─────────────────────────────────────────
+
+  test('read time registers (40000-40016)', async ({ mainPage }) => {
+    test.setTimeout(15_000)
+    await selectRegisterType(mainPage, 'Holding Registers')
+    await readRegisters(mainPage, '40000', '17')
+
+    // Year (U16 at 40011) = 2025
+    const year = await cell(mainPage, 40011, 'word_uint16')
+    expect(year).toBe('2025')
+
+    // Month (U16 at 40012) = 6
+    const month = await cell(mainPage, 40012, 'word_uint16')
+    expect(month).toBe('6')
+  })
+
+  test('read power registers (40420-40429)', async ({ mainPage }) => {
+    test.setTimeout(15_000)
+    await readRegisters(mainPage, '40420', '10')
+
+    // Active adjustment % (U16 at 40428) = 990
+    const pct = await cell(mainPage, 40428, 'word_uint16')
+    expect(pct).toBe('990')
+
+    // Power Factor (I16 at 40429) = 30000
+    const pf = await cell(mainPage, 40429, 'word_int16')
+    expect(pf).toBe('30000')
+  })
+
+  test('read generator (40500)', async ({ mainPage }) => {
+    test.setTimeout(15_000)
+    await readRegisters(mainPage, '40500', '1')
+
+    // DC Current generator (I16, range 500-520)
+    const dc = await cell(mainPage, 40500, 'word_int16')
+    const dcVal = Number(dc)
+    expect(dcVal).toBeGreaterThanOrEqual(500)
+    expect(dcVal).toBeLessThanOrEqual(520)
+  })
+
+  test('read energy registers (40560-40567)', async ({ mainPage }) => {
+    test.setTimeout(15_000)
+    await readRegisters(mainPage, '40560', '8')
+
+    // Plant status Xinjiang (U16 at 40566) = 1
+    const status = await cell(mainPage, 40566, 'word_uint16')
+    expect(status).toBe('1')
+  })
+
+  test('read DI bitmap (40700)', async ({ mainPage }) => {
+    test.setTimeout(15_000)
+    await readRegisters(mainPage, '40700', '1')
+
+    // DI status = 37
+    const diStatus = await cell(mainPage, 40700, 'word_uint16')
+    expect(diStatus).toBe('37')
+  })
+
+  test('read alarm bitmaps (50000-50002)', async ({ mainPage }) => {
+    test.setTimeout(15_000)
+    await readRegisters(mainPage, '50000', '3')
+
+    const alarm1 = await cell(mainPage, 50000, 'word_uint16')
+    expect(alarm1).toBe('2048')
+
+    const alarm2 = await cell(mainPage, 50001, 'word_uint16')
+    expect(alarm2).toBe('8')
+
+    const alarm3 = await cell(mainPage, 50002, 'word_uint16')
+    expect(alarm3).toBe('0')
+  })
+
+  test('read public registers (65521-65534)', async ({ mainPage }) => {
+    test.setTimeout(15_000)
+    await readRegisters(mainPage, '65521', '14')
+
+    // Device list change number = 5
+    const changeNum = await cell(mainPage, 65521, 'word_uint16')
+    expect(changeNum).toBe('5')
+
+    // Device connection status = 45057
+    const connStatus = await cell(mainPage, 65534, 'word_uint16')
+    expect(connStatus).toBe('45057')
+  })
+
+  // ─── ReadConfiguration via client config ───────────────────────────
+
+  test('load client config + readConfiguration', async ({ mainPage }) => {
+    test.setTimeout(30_000)
+
+    await loadClientConfig(mainPage, CLIENT_CONFIG)
+    await enableReadConfiguration(mainPage)
+
+    // Trigger a read
+    await mainPage.getByTestId('read-btn').click()
+    await mainPage.waitForTimeout(5000)
+
+    // Grid should have rows
+    const rowCount = await mainPage.locator('.MuiDataGrid-row').count()
+    expect(rowCount).toBeGreaterThan(0)
+
+    // Spot-check: year = 2025
+    const year = await cell(mainPage, 40011, 'word_uint16')
+    expect(year).toBe('2025')
+
+    // Spot-check: active adjustment = 990
+    const pct = await cell(mainPage, 40428, 'word_uint16')
+    expect(pct).toBe('990')
+
+    await disableReadConfiguration(mainPage)
+  })
+
+  // ─── Cleanup ───────────────────────────────────────────────────────
+
+  test('disconnect client', async ({ mainPage }) => {
+    await disconnectClient(mainPage)
+  })
+
+  test('switch client back to TCP', async ({ mainPage }) => {
+    await mainPage.getByTestId('protocol-tcp-btn').click()
+    await expect(mainPage.getByTestId('tcp-host-input')).toBeVisible()
+  })
+
+  test('switch server back to TCP', async ({ mainPage }) => {
+    await navigateToServer(mainPage)
+    await mainPage.getByTestId('server-mode-tcp-btn').click()
+    await expect(mainPage.getByTestId('server-port-input')).toBeVisible()
+  })
+
+  test('cleanup: expand panels', async ({ mainPage }) => {
+    await expandAllServerPanels(mainPage)
+  })
+
+  test('stop socat + remove symlinks', async () => {
+    if (socatProcess) {
+      socatProcess.kill()
+      socatProcess = null
+    }
+
+    try {
+      unlinkSync(PTY_0)
+    } catch {
+      /* ignore */
+    }
+    try {
+      unlinkSync(PTY_1)
+    } catch {
+      /* ignore */
+    }
+
+    // Verify cleanup
+    expect(existsSync(PTY_0)).toBe(false)
+    expect(existsSync(PTY_1)).toBe(false)
+  })
+})

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -42,6 +42,7 @@ linux:
     - AppImage
     - snap
     - deb
+  icon: build/icons/png
   maintainer: deketelaerejens@gmail.com
   category: Utility
 appImage:

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "test:watch": "vitest",
     "test:e2e": "electron-vite build && playwright test",
     "presentation": "npx playwright test --config playwright.presentation.config.ts",
-    "checkup": "yarn lint && yarn typecheck && yarn test && yarn test:e2e"
+    "checkup": "yarn lint && yarn typecheck && yarn test && yarn test:e2e",
+    "socat": "socat -d -d pty,raw,echo=0,link=/tmp/ttyV0 pty,raw,echo=0,link=/tmp/ttyV1"
   },
   "dependencies": {
     "@ant-design/icons": "^5.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "modbux",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "A Modbus Client/Server tool",
   "main": "./out/main/index.js",
   "author": {

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -88,6 +88,11 @@ export const initIpc: InitIpcFn = (app, state, client, server) => {
   ipcHandle('create_server', (_, params) => server.createServer(params))
   ipcHandle('delete_server', (_, uuid) => server.deleteServer(uuid))
 
+  // RTU Server
+  ipcHandle('start_rtu_server', (_, params) => server.startRtuServer(params))
+  ipcHandle('stop_rtu_server', () => server.stopRtuServer())
+  ipcHandle('stop_all_tcp_servers', () => server.stopAllTcpServers())
+
   // App Version
   ipcHandle('get_app_version', () => app.getVersion())
 

--- a/src/main/modules/__tests__/modbusServer.test.ts
+++ b/src/main/modules/__tests__/modbusServer.test.ts
@@ -11,6 +11,16 @@ vi.mock('modbus-serial', () => ({
   // Must use `function` (not arrow) so it can be called with `new`
   ServerTCP: vi.fn().mockImplementation(function () {
     return { close: vi.fn((cb: (err: Error | null) => void) => cb(null)) }
+  }),
+  ServerSerial: vi.fn().mockImplementation(function () {
+    const handlers: Record<string, (...args: unknown[]) => void> = {}
+    return {
+      on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+        handlers[event] = handler
+      }),
+      close: vi.fn((cb: (err: Error | null) => void) => cb(null)),
+      _handlers: handlers
+    }
   })
 }))
 
@@ -38,7 +48,7 @@ vi.mock('net', () => ({
 }))
 
 import { ModbusServer, SERVER_DEVICE_FAILURE, ILLEGAL_DATA_ADDRESS } from '../mobusServer'
-import { ServerTCP } from 'modbus-serial'
+import { ServerTCP, ServerSerial } from 'modbus-serial'
 
 const createMockWindows = (): Windows => ({ send: vi.fn() }) as unknown as Windows
 
@@ -52,6 +62,7 @@ describe('ModbusServer', () => {
     vi.useFakeTimers()
     portAvailableResults = []
     vi.mocked(ServerTCP).mockClear()
+    vi.mocked(ServerSerial).mockClear()
     windows = createMockWindows()
     server = new ModbusServer({ windows })
   })
@@ -981,6 +992,235 @@ describe('ModbusServer', () => {
       const port = await server.setPort({ uuid, port: 5020 })
       expect(port).toBe(5020)
       expect(ServerTCP).toHaveBeenCalled()
+    })
+  })
+
+  describe('startRtuServer', () => {
+    const serialConfig = {
+      com: '/dev/ttyUSB0',
+      options: { baudRate: '9600' as const, dataBits: 8, stopBits: 1, parity: 'none' as const }
+    }
+
+    it('creates a ServerSerial with correct config', async () => {
+      await server.startRtuServer({ uuid, serialConfig })
+
+      expect(ServerSerial).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({
+          path: '/dev/ttyUSB0',
+          baudRate: 9600,
+          dataBits: 8,
+          stopBits: 1,
+          parity: 'none'
+        })
+      )
+    })
+
+    it('emits success message and status on initialized event', async () => {
+      await server.startRtuServer({ uuid, serialConfig })
+
+      const instance = vi.mocked(ServerSerial).mock.results.at(-1)!.value
+      instance._handlers['initialized']()
+
+      const statusCalls = getWindowCalls('rtu_server_status')
+      expect(statusCalls.some((c) => c[1].active === true)).toBe(true)
+
+      const messageCalls = getWindowCalls('backend_message')
+      expect(messageCalls.some((c) => c[1].message.includes('/dev/ttyUSB0'))).toBe(true)
+    })
+
+    it('emits error status on error event', async () => {
+      await server.startRtuServer({ uuid, serialConfig })
+
+      const instance = vi.mocked(ServerSerial).mock.results.at(-1)!.value
+      instance._handlers['error'](new Error('port gone'))
+
+      const statusCalls = getWindowCalls('rtu_server_status')
+      expect(statusCalls.some((c) => c[1].active === false)).toBe(true)
+
+      const messageCalls = getWindowCalls('backend_message')
+      expect(messageCalls.some((c) => c[1].message.includes('port gone'))).toBe(true)
+    })
+
+    it('skips start when COM port is empty', async () => {
+      await server.startRtuServer({
+        uuid,
+        serialConfig: { ...serialConfig, com: '  ' }
+      })
+
+      expect(ServerSerial).not.toHaveBeenCalled()
+    })
+
+    it('stops existing RTU server before starting new one', async () => {
+      await server.startRtuServer({ uuid, serialConfig })
+      const firstInstance = vi.mocked(ServerSerial).mock.results[0].value
+
+      await server.startRtuServer({ uuid, serialConfig })
+      expect(firstInstance.close).toHaveBeenCalled()
+      expect(vi.mocked(ServerSerial).mock.calls.length).toBe(2)
+    })
+
+    it('shares register data with TCP server via same vector', async () => {
+      // Add data, then start RTU — vector references same _serverData
+      server.addRegister({
+        uuid,
+        unitId,
+        littleEndian: false,
+        params: {
+          address: 0,
+          registerType: 'holding_registers',
+          dataType: 'uint16',
+          comment: '',
+          value: 42,
+          min: undefined,
+          max: undefined,
+          interval: undefined
+        }
+      })
+
+      await server.startRtuServer({ uuid, serialConfig })
+
+      // The vector passed to ServerSerial should read the same data
+      const vector = vi.mocked(ServerSerial).mock.calls.at(-1)![0] as IServiceVector
+      const cb = vi.fn()
+      await vector.getHoldingRegister!(0, 1, cb)
+      expect(cb).toHaveBeenCalledWith(null, 42)
+    })
+  })
+
+  describe('stopRtuServer', () => {
+    const serialConfig = {
+      com: '/dev/ttyUSB0',
+      options: { baudRate: '9600' as const, dataBits: 8, stopBits: 1, parity: 'none' as const }
+    }
+
+    it('does nothing when no RTU server is running', async () => {
+      await server.stopRtuServer()
+      // No error, no events
+      expect(getWindowCalls('rtu_server_status').length).toBe(0)
+    })
+
+    it('closes the RTU server and emits inactive status', async () => {
+      await server.startRtuServer({ uuid, serialConfig })
+      const instance = vi.mocked(ServerSerial).mock.results.at(-1)!.value
+
+      await server.stopRtuServer()
+      expect(instance.close).toHaveBeenCalled()
+
+      const statusCalls = getWindowCalls('rtu_server_status')
+      expect(statusCalls.at(-1)![1].active).toBe(false)
+    })
+
+    it('emits warning message only when server was active', async () => {
+      await server.startRtuServer({ uuid, serialConfig })
+      const instance = vi.mocked(ServerSerial).mock.results.at(-1)!.value
+
+      // Simulate initialized → wasActive = true
+      instance._handlers['initialized']()
+      ;(windows.send as ReturnType<typeof vi.fn>).mockClear()
+
+      await server.stopRtuServer()
+      const messageCalls = getWindowCalls('backend_message')
+      expect(messageCalls.some((c) => c[1].message === 'RTU server stopped')).toBe(true)
+    })
+
+    it('does not emit warning when server never became active', async () => {
+      await server.startRtuServer({ uuid, serialConfig })
+      // Don't trigger initialized event
+      ;(windows.send as ReturnType<typeof vi.fn>).mockClear()
+
+      await server.stopRtuServer()
+      const messageCalls = getWindowCalls('backend_message')
+      expect(messageCalls.some((c) => c[1].message === 'RTU server stopped')).toBe(false)
+    })
+
+    it('silently ignores "Port is not open" errors', async () => {
+      await server.startRtuServer({ uuid, serialConfig })
+      const instance = vi.mocked(ServerSerial).mock.results.at(-1)!.value
+      instance.close.mockImplementation((cb: (err: Error | null) => void) =>
+        cb(new Error('Port is not open'))
+      )
+
+      await server.stopRtuServer()
+      // No error message emitted
+      const messageCalls = getWindowCalls('backend_message')
+      expect(messageCalls.some((c) => c[1].variant === 'error')).toBe(false)
+    })
+  })
+
+  describe('stopAllTcpServers', () => {
+    it('closes all TCP servers and clears port map', async () => {
+      await server.createServer({ uuid, port: 5020 })
+      await server.createServer({ uuid: 'uuid-2', port: 5021 })
+
+      await server.stopAllTcpServers()
+
+      // Both servers closed
+      const instances = vi.mocked(ServerTCP).mock.results
+      expect(instances[0].value.close).toHaveBeenCalled()
+      // Recreating should work without close call on old server
+      vi.mocked(ServerTCP).mockClear()
+      await server.createServer({ uuid, port: 5020 })
+      expect(vi.mocked(ServerTCP).mock.results[0].value.close).not.toHaveBeenCalled()
+    })
+
+    it('preserves server data after stopping all TCP servers', async () => {
+      await server.createServer({ uuid, port: 5020 })
+
+      server.addRegister({
+        uuid,
+        unitId,
+        littleEndian: false,
+        params: {
+          address: 0,
+          registerType: 'holding_registers',
+          dataType: 'uint16',
+          comment: '',
+          value: 42,
+          min: undefined,
+          max: undefined,
+          interval: undefined
+        }
+      })
+
+      await server.stopAllTcpServers()
+
+      // Start RTU on same UUID — data should still be accessible
+      await server.startRtuServer({
+        uuid,
+        serialConfig: {
+          com: '/dev/ttyUSB0',
+          options: { baudRate: '9600', dataBits: 8, stopBits: 1, parity: 'none' }
+        }
+      })
+
+      const vector = vi.mocked(ServerSerial).mock.calls.at(-1)![0] as IServiceVector
+      const cb = vi.fn()
+      await vector.getHoldingRegister!(0, 1, cb)
+      expect(cb).toHaveBeenCalledWith(null, 42)
+    })
+
+    it('handles empty server list', async () => {
+      await server.stopAllTcpServers()
+      // No error
+    })
+  })
+
+  describe('deleteServer with RTU', () => {
+    it('stops RTU server when deleting the RTU UUID', async () => {
+      await server.createServer({ uuid, port: 5020 })
+      await server.startRtuServer({
+        uuid,
+        serialConfig: {
+          com: '/dev/ttyUSB0',
+          options: { baudRate: '9600', dataBits: 8, stopBits: 1, parity: 'none' }
+        }
+      })
+
+      const rtuInstance = vi.mocked(ServerSerial).mock.results.at(-1)!.value
+
+      await server.deleteServer(uuid)
+      expect(rtuInstance.close).toHaveBeenCalled()
     })
   })
 

--- a/src/main/modules/__tests__/modbusServer.test.ts
+++ b/src/main/modules/__tests__/modbusServer.test.ts
@@ -4,7 +4,8 @@ import type { UnitIdString, Windows } from '@shared'
 import type { IServiceVector } from 'modbus-serial/ServerTCP'
 
 // Configurable port availability for net mock
-let portAvailableResults: boolean[] = []
+// Each entry is either a boolean (true=available) or a string error code (e.g. 'EACCES', 'EADDRINUSE')
+let portAvailableResults: (boolean | string)[] = []
 
 // Mock modbus-serial before importing ModbusServer
 vi.mock('modbus-serial', () => ({
@@ -34,11 +35,13 @@ vi.mock('net', () => ({
           handlers[event] = handler
         }),
         listen: vi.fn(() => {
-          const available = portAvailableResults.length > 0 ? portAvailableResults.shift()! : true
-          if (available && handlers['listening']) {
+          const entry = portAvailableResults.length > 0 ? portAvailableResults.shift()! : true
+          if (entry === true && handlers['listening']) {
             handlers['listening']()
           } else if (handlers['error']) {
-            handlers['error']()
+            const errorCode = typeof entry === 'string' ? entry : 'EADDRINUSE'
+            const err = Object.assign(new Error(`listen ${errorCode}`), { code: errorCode })
+            handlers['error'](err)
           }
         }),
         close: vi.fn((cb: () => void) => cb())
@@ -884,11 +887,10 @@ describe('ModbusServer', () => {
       expect(messages.some((m) => m[1].message === 'Error closing server')).toBe(true)
     })
 
-    it('throws when no port available after 100 attempts', async () => {
-      portAvailableResults = new Array(100).fill(false)
-      await expect(server.createServer({ uuid, port: 5020 })).rejects.toThrow(
-        'No available port found'
-      )
+    it('emits error and returns port when no port available after max attempts', async () => {
+      portAvailableResults = new Array(10000).fill(false)
+      const port = await server.createServer({ uuid, port: 5020 })
+      expect(port).toBe(15020) // 5020 + 10000
       const messages = getWindowCalls('backend_message')
       expect(messages.some((m) => m[1].message === 'No available port found')).toBe(true)
     })
@@ -988,10 +990,56 @@ describe('ModbusServer', () => {
   })
 
   describe('setPort', () => {
-    it('delegates to createServer', async () => {
+    it('sets the exact port when available', async () => {
       const port = await server.setPort({ uuid, port: 5020 })
       expect(port).toBe(5020)
-      expect(ServerTCP).toHaveBeenCalled()
+      expect(ServerTCP).toHaveBeenCalledWith(expect.any(Object), {
+        host: '0.0.0.0',
+        port: 5020
+      })
+    })
+
+    it('emits EACCES error and returns current port for privileged port', async () => {
+      // First create a server on a working port
+      await server.createServer({ uuid, port: 5020 })
+      ;(windows.send as ReturnType<typeof vi.fn>).mockClear()
+
+      portAvailableResults = ['EACCES']
+      const port = await server.setPort({ uuid, port: 502 })
+      expect(port).toBe(5020) // Returns current port, not requested
+      const messages = getWindowCalls('backend_message')
+      expect(messages.some((m) => m[1].message === 'Port 502 requires elevated privileges')).toBe(
+        true
+      )
+    })
+
+    it('emits EADDRINUSE error and returns current port when port is taken', async () => {
+      await server.createServer({ uuid, port: 5020 })
+      ;(windows.send as ReturnType<typeof vi.fn>).mockClear()
+
+      portAvailableResults = ['EADDRINUSE']
+      const port = await server.setPort({ uuid, port: 5021 })
+      expect(port).toBe(5020) // Returns current port
+      const messages = getWindowCalls('backend_message')
+      expect(messages.some((m) => m[1].message === 'Port 5021 is already in use')).toBe(true)
+    })
+
+    it('does not auto-increment on unavailable port', async () => {
+      portAvailableResults = [false]
+      const port = await server.setPort({ uuid, port: 5020 })
+      expect(port).toBe(5020) // Returns requested port (no current server)
+      // ServerTCP should never have been called
+      expect(ServerTCP).not.toHaveBeenCalled()
+      const messages = getWindowCalls('backend_message')
+      expect(messages.some((m) => m[1].message === 'Port 5020 is already in use')).toBe(true)
+    })
+
+    it('closes existing server before binding new port', async () => {
+      await server.createServer({ uuid, port: 5020 })
+      const firstInstance = vi.mocked(ServerTCP).mock.results[0].value
+
+      await server.setPort({ uuid, port: 5021 })
+      expect(firstInstance.close).toHaveBeenCalled()
     })
   })
 

--- a/src/main/modules/mobusServer.ts
+++ b/src/main/modules/mobusServer.ts
@@ -488,6 +488,20 @@ export class ModbusServer {
       })
       this._rtuUuid = uuid
 
+      // Catch open errors on _serverPath (SerialPort) — prevents unhandled promise rejection
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const serverPath = (this._rtuServer as any)._serverPath
+      if (serverPath && typeof serverPath.on === 'function') {
+        serverPath.on('error', (err: Error) => {
+          this._rtuActive = false
+          this._emitMessage({
+            message: `RTU server error: ${err?.message ?? err}`,
+            variant: 'error'
+          })
+          this._windows.send('rtu_server_status', { active: false })
+        })
+      }
+
       this._rtuServer.on('initialized', () => {
         this._rtuActive = true
         this._emitMessage({

--- a/src/main/modules/mobusServer.ts
+++ b/src/main/modules/mobusServer.ts
@@ -14,9 +14,10 @@ import {
   UnitIdString,
   UnitIdStringSchema,
   BooleanRegisters,
-  NumberRegisters
+  NumberRegisters,
+  StartRtuServerParams
 } from '@shared'
-import { ServerTCP } from 'modbus-serial'
+import { ServerTCP, ServerSerial } from 'modbus-serial'
 import { Windows } from '@shared'
 import { ValueGenerator } from './modbusServer/valueGenerator'
 import type { IServiceVector, FCallbackVal } from 'modbus-serial'
@@ -69,6 +70,9 @@ export interface ServerParams {
 export class ModbusServer {
   private _port: Map<string, number> = new Map()
   private _servers: Map<string, ServerTCP> = new Map()
+  private _rtuServer: ServerSerial | null = null
+  private _rtuUuid: string | null = null
+  private _rtuActive: boolean = false
   private _windows: Windows
 
   // Map to store server data for each unit ID of a server UUID
@@ -219,6 +223,11 @@ export class ModbusServer {
    * Deletes a Modbus TCP server for the given UUID, cleaning up all resources.
    */
   public deleteServer = async (uuid: string): Promise<void> => {
+    // Clean up RTU server if this UUID is the RTU server
+    if (this._rtuUuid === uuid) {
+      await this.stopRtuServer()
+    }
+
     const server = this._servers.get(uuid)
     if (!server) {
       this._emitMessage({ message: `No server found for UUID ${uuid}`, variant: 'error' })
@@ -459,6 +468,101 @@ export class ModbusServer {
       serverData['discrete_inputs'][index] = value
     })
     this._setServerData(uuid, unitId, serverData)
+  }
+
+  /**
+   * Starts an RTU server on a serial port for the given UUID.
+   * Closes any existing RTU server first.
+   */
+  public startRtuServer = async ({ uuid, serialConfig }: StartRtuServerParams): Promise<void> => {
+    if (!serialConfig.com.trim()) return
+    await this.stopRtuServer()
+
+    try {
+      this._rtuServer = new ServerSerial(this._getVector(uuid), {
+        path: serialConfig.com,
+        baudRate: Number(serialConfig.options.baudRate),
+        dataBits: serialConfig.options.dataBits as 8 | 7 | 6 | 5,
+        stopBits: serialConfig.options.stopBits as 1 | 2,
+        parity: serialConfig.options.parity ?? 'none'
+      })
+      this._rtuUuid = uuid
+
+      this._rtuServer.on('initialized', () => {
+        this._rtuActive = true
+        this._emitMessage({
+          message: `RTU server started on ${serialConfig.com}`,
+          variant: 'success'
+        })
+        this._windows.send('rtu_server_status', { active: true })
+      })
+
+      this._rtuServer.on('error', (err) => {
+        this._rtuActive = false
+        this._emitMessage({
+          message: `RTU server error: ${err?.message ?? err}`,
+          variant: 'error'
+        })
+        this._windows.send('rtu_server_status', { active: false })
+      })
+    } catch (err) {
+      this._emitMessage({
+        message: `Failed to start RTU server: ${(err as Error)?.message ?? err}`,
+        variant: 'error'
+      })
+    }
+  }
+
+  /**
+   * Stops the active RTU server if one is running.
+   */
+  public stopRtuServer = async (): Promise<void> => {
+    if (!this._rtuServer) return
+    const server = this._rtuServer
+    const wasActive = this._rtuActive
+    this._rtuServer = null
+    this._rtuUuid = null
+    this._rtuActive = false
+    this._windows.send('rtu_server_status', { active: false })
+    if (wasActive) {
+      this._emitMessage({ message: 'RTU server stopped', variant: 'warning' })
+    }
+    try {
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => {
+          if (err) reject(err)
+          else resolve()
+        })
+      })
+    } catch (err) {
+      const error = err as Error
+      // "Port is not open" is expected when the serial port never connected — ignore silently
+      if (error?.message?.includes('Port is not open')) return
+      console.error('Error closing RTU server:', error?.message, error?.stack)
+      this._emitMessage({
+        message: `Error closing RTU server: ${error?.message ?? err}`,
+        variant: 'error',
+        error
+      })
+    }
+  }
+
+  /**
+   * Stops all running TCP servers. Does NOT clear server data or generators
+   * so registers are preserved for restore when switching back to TCP.
+   */
+  public stopAllTcpServers = async (): Promise<void> => {
+    for (const [, server] of this._servers) {
+      await new Promise<void>((resolve) => {
+        server.close((err) => {
+          if (err)
+            this._emitMessage({ message: 'Error closing server', variant: 'error', error: err })
+          resolve()
+        })
+      })
+    }
+    this._servers.clear()
+    this._port.clear()
   }
 
   /**

--- a/src/main/modules/mobusServer.ts
+++ b/src/main/modules/mobusServer.ts
@@ -151,15 +151,18 @@ export class ModbusServer {
 
   /**
    * Checks if a TCP port is available for binding.
+   * Returns an object with availability and optional error code (e.g. EACCES, EADDRINUSE).
    */
-  private async _isPortAvailable(port: number): Promise<boolean> {
+  private async _isPortAvailable(
+    port: number
+  ): Promise<{ available: boolean; errorCode?: string }> {
     return new Promise((resolve) => {
       const tester = net.createServer()
-      tester.once('error', () => {
-        resolve(false)
+      tester.once('error', (err: NodeJS.ErrnoException) => {
+        resolve({ available: false, errorCode: err.code })
       })
       tester.once('listening', () => {
-        tester.close(() => resolve(true))
+        tester.close(() => resolve({ available: true }))
       })
       tester.listen(port, '0.0.0.0')
     })
@@ -173,7 +176,7 @@ export class ModbusServer {
    */
   public createServer = async ({ uuid, port }: CreateServerParams): Promise<number> => {
     let actualPort = port ?? DEFAULT_MOBUS_PORT
-    const maxAttempts = 100
+    const maxAttempts = 10000
     let server: ServerTCP | undefined
 
     const existingServer = this._servers.get(uuid)
@@ -190,8 +193,8 @@ export class ModbusServer {
     }
 
     for (let i = 0; i < maxAttempts; i++) {
-      const isAvailable = await this._isPortAvailable(actualPort)
-      if (isAvailable) {
+      const result = await this._isPortAvailable(actualPort)
+      if (result.available) {
         server = new ServerTCP(this._getVector(uuid), {
           host: '0.0.0.0',
           port: actualPort
@@ -216,7 +219,7 @@ export class ModbusServer {
       variant: 'error',
       error: undefined
     })
-    throw new Error('No available port found')
+    return actualPort
   }
 
   /**
@@ -580,11 +583,43 @@ export class ModbusServer {
   }
 
   /**
-   * Sets the port for a given server UUID by recreating the server on the new port.
-   * Returns the actual port used (may differ from requested if taken).
+   * Sets the port for a given server UUID. Strict: only tries the exact port,
+   * no auto-increment. Emits error message on failure and returns the current port.
    */
   public setPort = async ({ uuid, port }: CreateServerParams): Promise<number> => {
-    return this.createServer({ uuid, port })
+    const requestedPort = port ?? DEFAULT_MOBUS_PORT
+    const currentPort = this._port.get(uuid) ?? requestedPort
+    const result = await this._isPortAvailable(requestedPort)
+    if (!result.available) {
+      const message =
+        result.errorCode === 'EACCES'
+          ? `Port ${requestedPort} requires elevated privileges`
+          : `Port ${requestedPort} is already in use`
+      this._emitMessage({ message, variant: 'error' })
+      return currentPort
+    }
+
+    // Port is confirmed available — now close the existing server
+    const existingServer = this._servers.get(uuid)
+    if (existingServer) {
+      await new Promise<void>((resolve) => {
+        existingServer.close((err) => {
+          if (err)
+            this._emitMessage({ message: 'Error closing server', variant: 'error', error: err })
+          resolve()
+        })
+      })
+      this._servers.delete(uuid)
+      this._port.delete(uuid)
+    }
+
+    const server = new ServerTCP(this._getVector(uuid), {
+      host: '0.0.0.0',
+      port: requestedPort
+    })
+    this._servers.set(uuid, server)
+    this._port.set(uuid, requestedPort)
+    return requestedPort
   }
 
   // -------------------------------------------------------------------------

--- a/src/main/modules/modbusClient.ts
+++ b/src/main/modules/modbusClient.ts
@@ -75,7 +75,11 @@ export class ModbusClient {
       .on('error', (error) => {
         this._clientState.connectState = 'disconnected'
         this._sendClientState()
-        this._emitMessage({ message: (error as Error).message, variant: 'error', error: error })
+        this._emitMessage({
+          message: (error as Error).message || 'Connection error',
+          variant: 'error',
+          error: error
+        })
       })
       .on('close', () => {
         // If we were connected, go to 'connecting' and try to reconnect

--- a/src/renderer/src/components/client/ConnectionConfig/RtuConfig/RtuConfig.tsx
+++ b/src/renderer/src/components/client/ConnectionConfig/RtuConfig/RtuConfig.tsx
@@ -1,116 +1,19 @@
-import {
-  Autocomplete,
-  Box,
-  CircularProgress,
-  FormControl,
-  InputLabel,
-  MenuItem,
-  Select,
-  TextField,
-  ToggleButton,
-  ToggleButtonGroup
-} from '@mui/material'
+import { Autocomplete, Box, CircularProgress, ToggleButton, ToggleButtonGroup } from '@mui/material'
 import { CheckCircleOutline, Refresh } from '@mui/icons-material'
 import { meme } from '@renderer/components/shared/inputs/meme'
+import {
+  BaudRateSelect,
+  ComOption,
+  ComTextField,
+  DataBitsSelect,
+  ParitySelect,
+  StopBitsSelect,
+  useComInputWidth
+} from '@renderer/components/shared/inputs/SerialPortInputs'
 import { useRootZustand } from '@renderer/context/root.zustand'
-import { ModbusBaudRate, ModbusBaudRateSchema } from '@shared'
-import { SerialPortOptions } from 'modbus-serial/ModbusRTU'
-import { AutocompleteRenderInputParams } from '@mui/material'
+import type { SerialPortOptions } from 'modbus-serial/ModbusRTU'
 import { useSnackbar } from 'notistack'
-import { useEffect, useMemo } from 'react'
-
-const measureTextWidth = (
-  text: string,
-  font: string = '400 0.85rem Roboto, sans-serif'
-): number => {
-  const canvas = document.createElement('canvas')
-  const context = canvas.getContext('2d')
-  if (context) {
-    context.font = font
-    return context.measureText(text).width
-  }
-  return 0
-}
-
-const ComTextField = meme((params: AutocompleteRenderInputParams) => {
-  const comValid = useRootZustand((z) => z.valid.com)
-  const loading = useRootZustand((z) => z.serialPortsLoading)
-
-  return (
-    <TextField
-      {...params}
-      label="COM Port"
-      variant="outlined"
-      size="small"
-      title={params.inputProps.value as string}
-      sx={{
-        '& .MuiOutlinedInput-root': {
-          borderTopRightRadius: 0,
-          borderBottomRightRadius: 0
-        },
-        '& .MuiOutlinedInput-input': {
-          overflow: 'hidden',
-          textOverflow: 'ellipsis'
-        }
-      }}
-      error={!comValid}
-      slotProps={{
-        input: {
-          ...params.InputProps,
-          endAdornment: (
-            <>
-              {loading ? <CircularProgress size={16} /> : null}
-              {params.InputProps.endAdornment}
-            </>
-          )
-        }
-      }}
-    />
-  )
-})
-
-//
-//
-// COM Port Option
-const ComOption = meme(
-  ({ option, ...props }: { option: string } & React.HTMLAttributes<HTMLLIElement>) => {
-    const manufacturer = useRootZustand(
-      (z) => z.serialPorts.find((p) => p.path === option)?.manufacturer
-    )
-
-    return (
-      <li {...props} key={option}>
-        <Box sx={{ width: '100%' }} title={option}>
-          <Box
-            sx={{
-              fontSize: '0.85rem',
-              whiteSpace: 'nowrap',
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-              width: '100%'
-            }}
-          >
-            {option}
-          </Box>
-          {manufacturer && (
-            <Box
-              sx={{
-                fontSize: '0.75rem',
-                color: 'text.secondary',
-                whiteSpace: 'nowrap',
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                width: '100%'
-              }}
-            >
-              {manufacturer}
-            </Box>
-          )}
-        </Box>
-      </li>
-    )
-  }
-)
+import { useEffect } from 'react'
 
 //
 //
@@ -118,18 +21,10 @@ const ComOption = meme(
 const ComInput = meme(() => {
   const disabled = useRootZustand((z) => z.clientState.connectState !== 'disconnected')
   const com = useRootZustand((z) => z.connectionConfig.rtu.com)
+  const comValid = useRootZustand((z) => z.valid.com)
+  const loading = useRootZustand((z) => z.serialPortsLoading)
   const ports = useRootZustand((z) => z.serialPorts)
-
-  const inputWidth = useMemo(() => {
-    let textWidth = 60
-
-    for (const port of ports) {
-      const newTextWidth = measureTextWidth(port.path || 'COM Port')
-      if (newTextWidth > textWidth) textWidth = newTextWidth
-    }
-
-    return Math.max(60, textWidth + 60)
-  }, [ports])
+  const inputWidth = useComInputWidth(ports)
 
   return (
     <Autocomplete
@@ -145,8 +40,13 @@ const ComInput = meme(() => {
         if (newValue) useRootZustand.getState().setCom(newValue, true)
       }}
       sx={{ width: inputWidth, maxWidth: 220 }}
-      renderInput={(params) => <ComTextField {...params} />}
-      renderOption={(props, option) => <ComOption {...props} option={option} />}
+      renderInput={(params) => (
+        <ComTextField {...params} comLabel="COM Port" comError={!comValid} comLoading={loading} />
+      )}
+      renderOption={(props, option) => {
+        const manufacturer = ports.find((p) => p.path === option)?.manufacturer
+        return <ComOption {...props} option={option} manufacturer={manufacturer} />
+      }}
     />
   )
 })
@@ -233,155 +133,56 @@ const Com = (): JSX.Element => {
 
 //
 //
-// Baud Rate
-const BaudRateSelect = meme(() => {
+// Selects (thin wrappers over shared components)
+const ClientBaudRateSelect = meme(() => {
   const disabled = useRootZustand((z) => z.clientState.connectState !== 'disconnected')
-
-  const labelId = 'baud-rate-select'
   const baudRate = useRootZustand((z) => z.connectionConfig.rtu.options.baudRate)
   const setBaudRate = useRootZustand((z) => z.setBaudRate)
 
-  return (
-    <FormControl size="small">
-      <InputLabel id={labelId}>Baud Rate</InputLabel>
-
-      <Select
-        disabled={disabled}
-        size="small"
-        labelId={labelId}
-        value={baudRate}
-        label="Baud Rate"
-        onChange={(e) => setBaudRate(e.target.value as ModbusBaudRate)}
-        sx={{ width: 100 }}
-        data-testid="rtu-baudrate-select"
-      >
-        {ModbusBaudRateSchema.options.map((value) => (
-          <MenuItem key={`baud_rate_${value}`} value={value}>
-            {value}
-          </MenuItem>
-        ))}
-      </Select>
-    </FormControl>
-  )
+  return <BaudRateSelect value={baudRate} onChange={setBaudRate} disabled={disabled} />
 })
 
-//
-//
-// Parity
-const parityOptions: SerialPortOptions['parity'][] = ['none', 'even', 'odd', 'mark', 'space']
-
-const ParitySelect = meme(() => {
+const ClientParitySelect = meme(() => {
   const disabled = useRootZustand((z) => z.clientState.connectState !== 'disconnected')
-
-  const labelId = 'parity-select'
-  const parity = useRootZustand((z) => z.connectionConfig.rtu.options.parity)
+  const parity = useRootZustand((z) => z.connectionConfig.rtu.options.parity ?? 'none')
   const setParity = useRootZustand((z) => z.setParity)
 
   return (
-    <FormControl size="small">
-      <InputLabel id={labelId}>Parity</InputLabel>
-
-      <Select
-        disabled={disabled}
-        size="small"
-        labelId={labelId}
-        value={parity}
-        label="Parity"
-        onChange={(e) => setParity(e.target.value as SerialPortOptions['parity'])}
-        sx={{ width: 85 }}
-        data-testid="rtu-parity-select"
-      >
-        {parityOptions.map((option) => (
-          <MenuItem key={`parity_${option}`} value={option}>
-            {option}
-          </MenuItem>
-        ))}
-      </Select>
-    </FormControl>
+    <ParitySelect
+      value={parity}
+      onChange={(v) => setParity(v as SerialPortOptions['parity'])}
+      disabled={disabled}
+    />
   )
 })
 
-//
-//
-// Data Bits
-const databitsOptions: SerialPortOptions['dataBits'][] = [8, 7, 6, 5]
-
-const DataBitsSelect = meme(() => {
+const ClientDataBitsSelect = meme(() => {
   const disabled = useRootZustand((z) => z.clientState.connectState !== 'disconnected')
-
-  const labelId = 'databits-select'
   const dataBits = useRootZustand((z) => z.connectionConfig.rtu.options.dataBits)
   const setDataBits = useRootZustand((z) => z.setDataBits)
 
-  return (
-    <FormControl size="small">
-      <InputLabel id={labelId}>Data</InputLabel>
-
-      <Select
-        disabled={disabled}
-        size="small"
-        labelId={labelId}
-        value={dataBits}
-        label="Data Bits"
-        onChange={(e) => setDataBits(Number(e.target.value))}
-        sx={{ width: 55 }}
-        data-testid="rtu-databits-select"
-      >
-        {databitsOptions.map((option) => (
-          <MenuItem key={`databits_${option}`} value={option}>
-            {option}
-          </MenuItem>
-        ))}
-      </Select>
-    </FormControl>
-  )
+  return <DataBitsSelect value={dataBits} onChange={setDataBits} disabled={disabled} />
 })
 
-//
-//
-// Stop Bits
-const StopBitsOptions: SerialPortOptions['stopBits'][] = [1, 2]
-const StopBitsSelect = meme(() => {
+const ClientStopBitsSelect = meme(() => {
   const disabled = useRootZustand((z) => z.clientState.connectState !== 'disconnected')
-
-  const labelId = 'stopbits-select'
   const stopBits = useRootZustand((z) => z.connectionConfig.rtu.options.stopBits)
   const setStopBits = useRootZustand((z) => z.setStopBits)
 
-  return (
-    <FormControl size="small">
-      <InputLabel id={labelId}>Stop</InputLabel>
-      <Select
-        disabled={disabled}
-        size="small"
-        labelId={labelId}
-        value={stopBits}
-        label="Stop Bits"
-        onChange={(e) => setStopBits(Number(e.target.value))}
-        sx={{ width: 55 }}
-        data-testid="rtu-stopbits-select"
-      >
-        {StopBitsOptions.map((option) => (
-          <MenuItem key={`stopbits_${option}`} value={option}>
-            {option}
-          </MenuItem>
-        ))}
-      </Select>
-    </FormControl>
-  )
+  return <StopBitsSelect value={stopBits} onChange={setStopBits} disabled={disabled} />
 })
 
 const RtuConfig = (): JSX.Element => {
   return (
-    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2 }}>
-      <Box sx={{ display: 'flex', flexWrap: 'no-wrap', gap: 2 }}>
+    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+      <Box sx={{ display: 'flex', flexWrap: 'no-wrap', gap: 1 }}>
         <Com />
-        <BaudRateSelect />
+        <ClientBaudRateSelect />
       </Box>
-      <Box sx={{ display: 'flex', flexWrap: 'no-wrap', gap: 2 }}>
-        <ParitySelect />
-        <DataBitsSelect />
-        <StopBitsSelect />
+      <Box sx={{ display: 'flex', flexWrap: 'no-wrap', gap: 1 }}>
+        <ClientParitySelect />
+        <ClientDataBitsSelect />
+        <ClientStopBitsSelect />
       </Box>
     </Box>
   )

--- a/src/renderer/src/components/client/ConnectionConfig/TcpConfig/TcpConfig.tsx
+++ b/src/renderer/src/components/client/ConnectionConfig/TcpConfig/TcpConfig.tsx
@@ -16,10 +16,10 @@ const Host = meme(() => {
   return (
     <TextField
       disabled={disabled}
-      label="IP Address"
+      label="Host"
       variant="outlined"
       size="small"
-      sx={{ width: 130 }}
+      sx={{ width: 180 }}
       error={!hostValid}
       value={host}
       data-testid="tcp-host-input"
@@ -28,11 +28,6 @@ const Host = meme(() => {
           inputComponent: HostInput as unknown as ElementType<InputBaseComponentProps, 'input'>,
           inputProps: maskInputProps({ set: setHost })
         }
-      }}
-      onBlur={async () => {
-        // On blur, make sure the host is synced with the server
-        const connectionConfig = await window.api.getConnectionConfig()
-        setHost(connectionConfig.tcp.host, true)
       }}
     />
   )

--- a/src/renderer/src/components/server/OpenSaveClear/OpenSaveClear.tsx
+++ b/src/renderer/src/components/server/OpenSaveClear/OpenSaveClear.tsx
@@ -185,7 +185,7 @@ const OpenSaveClear = meme(() => {
   }, [])
 
   return (
-    <Box sx={{ display: 'flex', gap: 1 }}>
+    <Box sx={{ display: 'flex', gap: 0 }}>
       <div>
         {!opening && (
           <input
@@ -206,7 +206,7 @@ const OpenSaveClear = meme(() => {
             component="span"
             title="Open configuration"
           >
-            <FileOpen />
+            <FileOpen fontSize="small" />
           </IconButton>
         </label>
       </div>
@@ -218,7 +218,7 @@ const OpenSaveClear = meme(() => {
         disabled={opening}
         onClick={save}
       >
-        <Save />
+        <Save fontSize="small" />
       </IconButton>
       <IconButton
         data-testid="server-clear-btn"
@@ -228,7 +228,7 @@ const OpenSaveClear = meme(() => {
         disabled={opening}
         onClick={clear}
       >
-        <Delete />
+        <Delete fontSize="small" />
       </IconButton>
     </Box>
   )

--- a/src/renderer/src/components/server/SelectServer/SelectServer.tsx
+++ b/src/renderer/src/components/server/SelectServer/SelectServer.tsx
@@ -20,6 +20,7 @@ const SelectServerToggle = meme(({ uuid }: { uuid: string }) => {
 })
 
 const SelectServer = meme(() => {
+  const serverMode = useServerZustand((z) => z.serverMode ?? 'tcp')
   const serverUuids = useServerZustand((z) => z.uuids)
   const selectedUuid = useServerZustand((z) => z.selectedUuid)
   const addDisabled = useServerZustand((z) => Object.keys(z.uuids).length >= 10)
@@ -35,6 +36,8 @@ const SelectServer = meme(() => {
     const z = useServerZustand.getState()
     z.deleteServer(z.selectedUuid)
   }, [])
+
+  if (serverMode === 'rtu') return null
 
   return (
     <Box sx={{ display: 'flex', gap: 2, alignItems: 'center' }}>

--- a/src/renderer/src/components/server/ServerConfig/ServerConfig.tsx
+++ b/src/renderer/src/components/server/ServerConfig/ServerConfig.tsx
@@ -1,25 +1,94 @@
-//
-//
-
 import FormControl from '@mui/material/FormControl'
 import {
   TextField,
   Box,
   InputBaseComponentProps,
   ToggleButtonGroup,
-  ToggleButton
+  ToggleButton,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogContentText,
+  DialogActions,
+  Button
 } from '@mui/material'
 import InputLabel from '@mui/material/InputLabel'
 import { meme } from '@renderer/components/shared/inputs/meme'
 import { MaskInputProps, maskInputProps } from '@renderer/components/shared/inputs/types'
 import { useServerZustand } from '@renderer/context/server.zustand'
-import { checkHasConfig } from '@shared'
+import { checkHasConfig, ServerMode } from '@shared'
 import { ElementType, forwardRef } from 'react'
 import { IMaskInput, IMask } from 'react-imask'
 import Select from '@mui/material/Select'
 import { UnitIdString, UnitIdStringSchema } from '@shared'
 import MenuItem from '@mui/material/MenuItem'
 import React, { useState } from 'react'
+import ServerRtuConfig from './ServerRtuConfig'
+
+const ModeToggle = meme(() => {
+  const serverMode = useServerZustand((z) => z.serverMode ?? 'tcp')
+  const mainPort = useServerZustand((z) => z.port[z.uuids[0]] ?? '502')
+  const [confirmOpen, setConfirmOpen] = useState(false)
+
+  const handleModeChange = async (_: React.MouseEvent, value: ServerMode | null): Promise<void> => {
+    if (!value || value === serverMode) return
+    if (value === 'rtu') {
+      setConfirmOpen(true)
+    } else {
+      await useServerZustand.getState().switchToTcp()
+    }
+  }
+
+  const handleConfirm = async (): Promise<void> => {
+    setConfirmOpen(false)
+    await useServerZustand.getState().switchToRtu()
+  }
+
+  return (
+    <>
+      <ToggleButtonGroup
+        size="small"
+        exclusive
+        color="primary"
+        value={serverMode}
+        onChange={handleModeChange}
+      >
+        <ToggleButton
+          data-testid="server-mode-tcp-btn"
+          aria-label="TCP Mode"
+          value="tcp"
+          sx={{ whiteSpace: 'nowrap', px: 1.5 }}
+        >
+          TCP
+        </ToggleButton>
+        <ToggleButton
+          data-testid="server-mode-rtu-btn"
+          aria-label="RTU Mode"
+          value="rtu"
+          sx={{ px: 1.5 }}
+        >
+          RTU
+        </ToggleButton>
+      </ToggleButtonGroup>
+      <Dialog open={confirmOpen} onClose={() => setConfirmOpen(false)}>
+        <DialogTitle>Switch to RTU Server Mode</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            The main server (port {mainPort}) will be used as the RTU server. All TCP servers will
+            be stopped. Other server configurations will be preserved and restored when switching
+            back to TCP mode.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setConfirmOpen(false)}>Cancel</Button>
+          <Button onClick={handleConfirm} variant="contained" autoFocus>
+            Switch to RTU
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  )
+})
 
 const EndianToggle = meme(() => {
   const selectedUuid = useServerZustand((z) => z.selectedUuid)
@@ -106,7 +175,6 @@ const UnitId = meme(() => {
           const result = UnitIdStringSchema.safeParse(e.target.value)
           if (result.success) useServerZustand.getState().setUnitId(result.data)
         }}
-        // sx={{ width: 80 }}
         slotProps={{ input: { sx: { pr: 0, pl: 1 } } }}
       >
         {UnitIdStringSchema.options.map((unitId) => (
@@ -185,11 +253,14 @@ const Port = meme(() => {
 //
 // Server Config
 const ServerConfig = (): JSX.Element => {
+  const serverMode = useServerZustand((z) => z.serverMode ?? 'tcp')
+
   return (
     <Box sx={{ display: 'flex', gap: 2, ml: 'auto' }}>
+      <ModeToggle />
       <EndianToggle />
       <UnitId />
-      <Port />
+      {serverMode === 'tcp' ? <Port /> : <ServerRtuConfig />}
     </Box>
   )
 }

--- a/src/renderer/src/components/server/ServerConfig/ServerConfig.tsx
+++ b/src/renderer/src/components/server/ServerConfig/ServerConfig.tsx
@@ -4,13 +4,7 @@ import {
   Box,
   InputBaseComponentProps,
   ToggleButtonGroup,
-  ToggleButton,
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogContentText,
-  DialogActions,
-  Button
+  ToggleButton
 } from '@mui/material'
 import InputLabel from '@mui/material/InputLabel'
 import { meme } from '@renderer/components/shared/inputs/meme'
@@ -27,66 +21,31 @@ import ServerRtuConfig from './ServerRtuConfig'
 
 const ModeToggle = meme(() => {
   const serverMode = useServerZustand((z) => z.serverMode ?? 'tcp')
-  const mainPort = useServerZustand((z) => z.port[z.uuids[0]] ?? '502')
-  const [confirmOpen, setConfirmOpen] = useState(false)
 
   const handleModeChange = async (_: React.MouseEvent, value: ServerMode | null): Promise<void> => {
     if (!value || value === serverMode) return
     if (value === 'rtu') {
-      setConfirmOpen(true)
+      await useServerZustand.getState().switchToRtu()
     } else {
       await useServerZustand.getState().switchToTcp()
     }
   }
 
-  const handleConfirm = async (): Promise<void> => {
-    setConfirmOpen(false)
-    await useServerZustand.getState().switchToRtu()
-  }
-
   return (
-    <>
-      <ToggleButtonGroup
-        size="small"
-        exclusive
-        color="primary"
-        value={serverMode}
-        onChange={handleModeChange}
-      >
-        <ToggleButton
-          data-testid="server-mode-tcp-btn"
-          aria-label="TCP Mode"
-          value="tcp"
-          sx={{ whiteSpace: 'nowrap', px: 1.5 }}
-        >
-          TCP
-        </ToggleButton>
-        <ToggleButton
-          data-testid="server-mode-rtu-btn"
-          aria-label="RTU Mode"
-          value="rtu"
-          sx={{ px: 1.5 }}
-        >
-          RTU
-        </ToggleButton>
-      </ToggleButtonGroup>
-      <Dialog open={confirmOpen} onClose={() => setConfirmOpen(false)}>
-        <DialogTitle>Switch to RTU Server Mode</DialogTitle>
-        <DialogContent>
-          <DialogContentText>
-            The main server (port {mainPort}) will be used as the RTU server. All TCP servers will
-            be stopped. Other server configurations will be preserved and restored when switching
-            back to TCP mode.
-          </DialogContentText>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setConfirmOpen(false)}>Cancel</Button>
-          <Button onClick={handleConfirm} variant="contained" autoFocus>
-            Switch to RTU
-          </Button>
-        </DialogActions>
-      </Dialog>
-    </>
+    <ToggleButtonGroup
+      size="small"
+      exclusive
+      color="primary"
+      value={serverMode}
+      onChange={handleModeChange}
+    >
+      <ToggleButton data-testid="server-mode-tcp-btn" value="tcp">
+        TCP
+      </ToggleButton>
+      <ToggleButton data-testid="server-mode-rtu-btn" value="rtu">
+        RTU
+      </ToggleButton>
+    </ToggleButtonGroup>
   )
 })
 
@@ -163,7 +122,7 @@ const UnitId = meme(() => {
   const labelId = 'unit-id-select'
 
   return (
-    <FormControl size="small">
+    <FormControl size="small" sx={{ minWidth: 80 }}>
       <InputLabel id={labelId}>Unit ID</InputLabel>
       <Select
         data-testid="server-unitid-select"
@@ -256,11 +215,11 @@ const ServerConfig = (): JSX.Element => {
   const serverMode = useServerZustand((z) => z.serverMode ?? 'tcp')
 
   return (
-    <Box sx={{ display: 'flex', gap: 2, ml: 'auto' }}>
+    <Box sx={{ display: 'flex', gap: 2, ml: 'auto', alignItems: 'flex-start' }}>
+      {serverMode === 'tcp' ? <Port /> : <ServerRtuConfig />}
       <ModeToggle />
       <EndianToggle />
       <UnitId />
-      {serverMode === 'tcp' ? <Port /> : <ServerRtuConfig />}
     </Box>
   )
 }

--- a/src/renderer/src/components/server/ServerConfig/ServerConfig.tsx
+++ b/src/renderer/src/components/server/ServerConfig/ServerConfig.tsx
@@ -169,9 +169,10 @@ const PortInput = forwardRef<HTMLInputElement, MaskInputProps>((props, ref) => {
         setLocalPort(value)
       }}
       onBlur={() => {
-        // Only call set if the value is different from the store
         if (localPort !== portFromStore) {
-          set(localPort, localPort.length > 0)
+          set(localPort)
+          // Reset to store value — the store will update if backend succeeds
+          setLocalPort(portFromStore)
         }
       }}
     />
@@ -185,12 +186,10 @@ PortInput.displayName = 'PortInput'
 // Port
 const Port = meme(() => {
   const port = useServerZustand((z) => z.port[z.selectedUuid])
-  const portValid = useServerZustand((z) => z.portValid[z.selectedUuid])
 
   return (
     <TextField
       data-testid="server-port-input"
-      error={!portValid}
       label={`Port ${port}`}
       variant="outlined"
       size="small"

--- a/src/renderer/src/components/server/ServerConfig/ServerRtuConfig.tsx
+++ b/src/renderer/src/components/server/ServerConfig/ServerRtuConfig.tsx
@@ -1,0 +1,358 @@
+import {
+  Autocomplete,
+  Box,
+  CircularProgress,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  TextField,
+  ToggleButton,
+  ToggleButtonGroup
+} from '@mui/material'
+import { Refresh } from '@mui/icons-material'
+import { meme } from '@renderer/components/shared/inputs/meme'
+import { useServerZustand } from '@renderer/context/server.zustand'
+import { ModbusBaudRate, ModbusBaudRateSchema } from '@shared'
+import { AutocompleteRenderInputParams } from '@mui/material'
+import React, { useEffect, useMemo, useState } from 'react'
+
+const measureTextWidth = (
+  text: string,
+  font: string = '400 0.85rem Roboto, sans-serif'
+): number => {
+  const canvas = document.createElement('canvas')
+  const context = canvas.getContext('2d')
+  if (context) {
+    context.font = font
+    return context.measureText(text).width
+  }
+  return 0
+}
+
+const ComTextField = meme(
+  (params: AutocompleteRenderInputParams & { comLabel: string; comError: boolean }) => {
+    const { comLabel, comError, ...rest } = params
+    const loading = useServerZustand((z) => z.serverSerialPortsLoading)
+
+    return (
+      <TextField
+        {...rest}
+        label={comLabel}
+        variant="outlined"
+        size="small"
+        title={rest.inputProps.value as string}
+        error={comError}
+        sx={{
+          '& .MuiOutlinedInput-root': {
+            borderTopRightRadius: 0,
+            borderBottomRightRadius: 0
+          },
+          '& .MuiOutlinedInput-input': {
+            overflow: 'hidden',
+            textOverflow: 'ellipsis'
+          }
+        }}
+        slotProps={{
+          input: {
+            ...rest.InputProps,
+            endAdornment: (
+              <>
+                {loading ? <CircularProgress size={16} /> : null}
+                {rest.InputProps.endAdornment}
+              </>
+            )
+          }
+        }}
+      />
+    )
+  }
+)
+
+const ComOption = meme(
+  ({ option, ...props }: { option: string } & React.HTMLAttributes<HTMLLIElement>) => {
+    const manufacturer = useServerZustand(
+      (z) => z.serverSerialPorts.find((p) => p.path === option)?.manufacturer
+    )
+
+    return (
+      <li {...props} key={option}>
+        <Box sx={{ width: '100%' }} title={option}>
+          <Box
+            sx={{
+              fontSize: '0.85rem',
+              whiteSpace: 'nowrap',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              width: '100%'
+            }}
+          >
+            {option}
+          </Box>
+          {manufacturer && (
+            <Box
+              sx={{
+                fontSize: '0.75rem',
+                color: 'text.secondary',
+                whiteSpace: 'nowrap',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                width: '100%'
+              }}
+            >
+              {manufacturer}
+            </Box>
+          )}
+        </Box>
+      </li>
+    )
+  }
+)
+
+const ComInput = meme(() => {
+  const comFromStore = useServerZustand((z) => z.serialConfig?.com ?? '')
+  const ports = useServerZustand((z) => z.serverSerialPorts)
+  const [localCom, setLocalCom] = useState(comFromStore)
+
+  // Sync local with store when store changes externally
+  React.useEffect(() => {
+    setLocalCom(comFromStore)
+  }, [comFromStore])
+
+  const inputWidth = useMemo(() => {
+    let textWidth = 60
+    for (const port of ports) {
+      const newTextWidth = measureTextWidth(port.path || 'COM Port')
+      if (newTextWidth > textWidth) textWidth = newTextWidth
+    }
+    return Math.max(60, textWidth + 60)
+  }, [ports])
+
+  const applyOnBlur = (): void => {
+    if (localCom !== comFromStore) {
+      useServerZustand.getState().setServerCom(localCom)
+      useServerZustand.getState().applyServerCom()
+    }
+  }
+
+  const comLabel = comFromStore ? `COM ${comFromStore}` : 'COM Port'
+  const comError = !comFromStore || comFromStore.trim().length === 0
+
+  return (
+    <Autocomplete
+      freeSolo
+      options={ports.map((p) => p.path)}
+      value={localCom}
+      data-testid="server-rtu-com-input"
+      onInputChange={(_event, newValue) => setLocalCom(newValue)}
+      onChange={(_event, newValue) => {
+        if (newValue) {
+          setLocalCom(newValue)
+          // Dropdown selection: apply immediately
+          useServerZustand.getState().setServerCom(newValue)
+          useServerZustand.getState().applyServerCom()
+        }
+      }}
+      onBlur={applyOnBlur}
+      sx={{ width: inputWidth, maxWidth: 220 }}
+      renderInput={(params) => <ComTextField {...params} comLabel={comLabel} comError={comError} />}
+      renderOption={(props, option) => <ComOption {...props} option={option} />}
+    />
+  )
+})
+
+const RtuStatus = meme(() => {
+  const active = useServerZustand((z) => z.rtuServerActive)
+  return (
+    <Box
+      data-testid="server-rtu-status"
+      title={active ? 'RTU server active' : 'RTU server inactive'}
+      sx={{
+        width: 10,
+        height: 10,
+        borderRadius: '50%',
+        backgroundColor: active ? 'success.main' : 'action.disabled',
+        alignSelf: 'center',
+        ml: 0.5,
+        flexShrink: 0
+      }}
+    />
+  )
+})
+
+const ComActions = meme(() => {
+  const loading = useServerZustand((z) => z.serverSerialPortsLoading)
+
+  const onRefresh = (): void => {
+    useServerZustand.getState().refreshServerSerialPorts()
+  }
+
+  return (
+    <ToggleButtonGroup
+      size="small"
+      sx={{
+        '& .MuiToggleButton-root:first-of-type': {
+          borderTopLeftRadius: 0,
+          borderBottomLeftRadius: 0,
+          borderLeft: 'none'
+        }
+      }}
+    >
+      <ToggleButton
+        value="refresh"
+        onClick={onRefresh}
+        disabled={loading}
+        data-testid="server-rtu-refresh-btn"
+        aria-label="Refresh COM ports"
+        title="Refresh COM ports"
+        sx={{ width: 32 }}
+      >
+        {loading ? <CircularProgress size={16} /> : <Refresh fontSize="small" />}
+      </ToggleButton>
+    </ToggleButtonGroup>
+  )
+})
+
+const Com = (): JSX.Element => {
+  useEffect(() => {
+    useServerZustand.getState().refreshServerSerialPorts()
+  }, [])
+
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center' }}>
+      <ComInput />
+      <ComActions />
+      <RtuStatus />
+    </Box>
+  )
+}
+
+const BaudRateSelect = meme(() => {
+  const labelId = 'server-baud-rate-select'
+  const baudRate = useServerZustand((z) => z.serialConfig?.options.baudRate ?? '9600')
+
+  return (
+    <FormControl size="small">
+      <InputLabel id={labelId}>Baud Rate</InputLabel>
+      <Select
+        size="small"
+        labelId={labelId}
+        value={baudRate}
+        label="Baud Rate"
+        onChange={(e) =>
+          useServerZustand.getState().setServerBaudRate(e.target.value as ModbusBaudRate)
+        }
+        sx={{ width: 100 }}
+        data-testid="server-rtu-baudrate-select"
+      >
+        {ModbusBaudRateSchema.options.map((value) => (
+          <MenuItem key={`server_baud_rate_${value}`} value={value}>
+            {value}
+          </MenuItem>
+        ))}
+      </Select>
+    </FormControl>
+  )
+})
+
+const parityOptions = ['none', 'even', 'odd', 'mark', 'space'] as const
+
+const ParitySelect = meme(() => {
+  const labelId = 'server-parity-select'
+  const parity = useServerZustand((z) => z.serialConfig?.options.parity ?? 'none')
+
+  return (
+    <FormControl size="small">
+      <InputLabel id={labelId}>Parity</InputLabel>
+      <Select
+        size="small"
+        labelId={labelId}
+        value={parity}
+        label="Parity"
+        onChange={(e) => useServerZustand.getState().setServerParity(e.target.value)}
+        sx={{ width: 85 }}
+        data-testid="server-rtu-parity-select"
+      >
+        {parityOptions.map((option) => (
+          <MenuItem key={`server_parity_${option}`} value={option}>
+            {option}
+          </MenuItem>
+        ))}
+      </Select>
+    </FormControl>
+  )
+})
+
+const databitsOptions = [8, 7, 6, 5] as const
+
+const DataBitsSelect = meme(() => {
+  const labelId = 'server-databits-select'
+  const dataBits = useServerZustand((z) => z.serialConfig?.options.dataBits ?? 8)
+
+  return (
+    <FormControl size="small">
+      <InputLabel id={labelId}>Data</InputLabel>
+      <Select
+        size="small"
+        labelId={labelId}
+        value={dataBits}
+        label="Data Bits"
+        onChange={(e) => useServerZustand.getState().setServerDataBits(Number(e.target.value))}
+        sx={{ width: 55 }}
+        data-testid="server-rtu-databits-select"
+      >
+        {databitsOptions.map((option) => (
+          <MenuItem key={`server_databits_${option}`} value={option}>
+            {option}
+          </MenuItem>
+        ))}
+      </Select>
+    </FormControl>
+  )
+})
+
+const stopBitsOptions = [1, 2] as const
+
+const StopBitsSelect = meme(() => {
+  const labelId = 'server-stopbits-select'
+  const stopBits = useServerZustand((z) => z.serialConfig?.options.stopBits ?? 1)
+
+  return (
+    <FormControl size="small">
+      <InputLabel id={labelId}>Stop</InputLabel>
+      <Select
+        size="small"
+        labelId={labelId}
+        value={stopBits}
+        label="Stop Bits"
+        onChange={(e) => useServerZustand.getState().setServerStopBits(Number(e.target.value))}
+        sx={{ width: 55 }}
+        data-testid="server-rtu-stopbits-select"
+      >
+        {stopBitsOptions.map((option) => (
+          <MenuItem key={`server_stopbits_${option}`} value={option}>
+            {option}
+          </MenuItem>
+        ))}
+      </Select>
+    </FormControl>
+  )
+})
+
+const ServerRtuConfig = (): JSX.Element => {
+  return (
+    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2 }}>
+      <Box sx={{ display: 'flex', flexWrap: 'nowrap', gap: 2 }}>
+        <Com />
+        <BaudRateSelect />
+      </Box>
+      <Box sx={{ display: 'flex', flexWrap: 'nowrap', gap: 2 }}>
+        <ParitySelect />
+        <DataBitsSelect />
+        <StopBitsSelect />
+      </Box>
+    </Box>
+  )
+}
+
+export default ServerRtuConfig

--- a/src/renderer/src/components/server/ServerConfig/ServerRtuConfig.tsx
+++ b/src/renderer/src/components/server/ServerConfig/ServerRtuConfig.tsx
@@ -1,132 +1,40 @@
 import {
+  alpha,
   Autocomplete,
   Box,
   CircularProgress,
-  FormControl,
-  InputLabel,
-  MenuItem,
-  Select,
-  TextField,
   ToggleButton,
   ToggleButtonGroup
 } from '@mui/material'
-import { Refresh } from '@mui/icons-material'
+import { Refresh, Usb, UsbOff } from '@mui/icons-material'
 import { meme } from '@renderer/components/shared/inputs/meme'
+import {
+  BaudRateSelect,
+  ComOption,
+  ComTextField,
+  DataBitsSelect,
+  ParitySelect,
+  StopBitsSelect,
+  useComInputWidth
+} from '@renderer/components/shared/inputs/SerialPortInputs'
 import { useServerZustand } from '@renderer/context/server.zustand'
-import { ModbusBaudRate, ModbusBaudRateSchema } from '@shared'
-import { AutocompleteRenderInputParams } from '@mui/material'
-import React, { useEffect, useMemo, useState } from 'react'
+import { ModbusBaudRate } from '@shared'
+import React, { useEffect, useState } from 'react'
 
-const measureTextWidth = (
-  text: string,
-  font: string = '400 0.85rem Roboto, sans-serif'
-): number => {
-  const canvas = document.createElement('canvas')
-  const context = canvas.getContext('2d')
-  if (context) {
-    context.font = font
-    return context.measureText(text).width
-  }
-  return 0
-}
-
-const ComTextField = meme(
-  (params: AutocompleteRenderInputParams & { comLabel: string; comError: boolean }) => {
-    const { comLabel, comError, ...rest } = params
-    const loading = useServerZustand((z) => z.serverSerialPortsLoading)
-
-    return (
-      <TextField
-        {...rest}
-        label={comLabel}
-        variant="outlined"
-        size="small"
-        title={rest.inputProps.value as string}
-        error={comError}
-        sx={{
-          '& .MuiOutlinedInput-root': {
-            borderTopRightRadius: 0,
-            borderBottomRightRadius: 0
-          },
-          '& .MuiOutlinedInput-input': {
-            overflow: 'hidden',
-            textOverflow: 'ellipsis'
-          }
-        }}
-        slotProps={{
-          input: {
-            ...rest.InputProps,
-            endAdornment: (
-              <>
-                {loading ? <CircularProgress size={16} /> : null}
-                {rest.InputProps.endAdornment}
-              </>
-            )
-          }
-        }}
-      />
-    )
-  }
-)
-
-const ComOption = meme(
-  ({ option, ...props }: { option: string } & React.HTMLAttributes<HTMLLIElement>) => {
-    const manufacturer = useServerZustand(
-      (z) => z.serverSerialPorts.find((p) => p.path === option)?.manufacturer
-    )
-
-    return (
-      <li {...props} key={option}>
-        <Box sx={{ width: '100%' }} title={option}>
-          <Box
-            sx={{
-              fontSize: '0.85rem',
-              whiteSpace: 'nowrap',
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-              width: '100%'
-            }}
-          >
-            {option}
-          </Box>
-          {manufacturer && (
-            <Box
-              sx={{
-                fontSize: '0.75rem',
-                color: 'text.secondary',
-                whiteSpace: 'nowrap',
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                width: '100%'
-              }}
-            >
-              {manufacturer}
-            </Box>
-          )}
-        </Box>
-      </li>
-    )
-  }
-)
-
+//
+//
+// COM Port Input (onBlur pattern)
 const ComInput = meme(() => {
   const comFromStore = useServerZustand((z) => z.serialConfig?.com ?? '')
+  const loading = useServerZustand((z) => z.serverSerialPortsLoading)
   const ports = useServerZustand((z) => z.serverSerialPorts)
   const [localCom, setLocalCom] = useState(comFromStore)
+  const inputWidth = useComInputWidth(ports)
 
   // Sync local with store when store changes externally
   React.useEffect(() => {
     setLocalCom(comFromStore)
   }, [comFromStore])
-
-  const inputWidth = useMemo(() => {
-    let textWidth = 60
-    for (const port of ports) {
-      const newTextWidth = measureTextWidth(port.path || 'COM Port')
-      if (newTextWidth > textWidth) textWidth = newTextWidth
-    }
-    return Math.max(60, textWidth + 60)
-  }, [ports])
 
   const applyOnBlur = (): void => {
     if (localCom !== comFromStore) {
@@ -155,31 +63,50 @@ const ComInput = meme(() => {
       }}
       onBlur={applyOnBlur}
       sx={{ width: inputWidth, maxWidth: 220 }}
-      renderInput={(params) => <ComTextField {...params} comLabel={comLabel} comError={comError} />}
-      renderOption={(props, option) => <ComOption {...props} option={option} />}
+      renderInput={(params) => (
+        <ComTextField {...params} comLabel={comLabel} comError={comError} comLoading={loading} />
+      )}
+      renderOption={(props, option) => {
+        const manufacturer = ports.find((p) => p.path === option)?.manufacturer
+        return <ComOption {...props} option={option} manufacturer={manufacturer} />
+      }}
     />
   )
 })
 
+//
+//
+// RTU Status Dot
 const RtuStatus = meme(() => {
   const active = useServerZustand((z) => z.rtuServerActive)
   return (
     <Box
       data-testid="server-rtu-status"
       title={active ? 'RTU server active' : 'RTU server inactive'}
-      sx={{
-        width: 10,
-        height: 10,
-        borderRadius: '50%',
-        backgroundColor: active ? 'success.main' : 'action.disabled',
+      sx={(theme) => ({
         alignSelf: 'center',
-        ml: 0.5,
-        flexShrink: 0
-      }}
-    />
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        ml: 1,
+        mr: -1,
+        flexShrink: 0,
+        width: 24,
+        height: 24,
+        borderRadius: 24,
+        backgroundColor: active
+          ? alpha(theme.palette.success.main, 0.1)
+          : alpha(theme.palette.text.primary, 0.08)
+      })}
+    >
+      {active ? <Usb color="success" fontSize={'small'} /> : <UsbOff fontSize="small" />}
+    </Box>
   )
 })
 
+//
+//
+// COM Port Actions
 const ComActions = meme(() => {
   const loading = useServerZustand((z) => z.serverSerialPortsLoading)
 
@@ -213,13 +140,16 @@ const ComActions = meme(() => {
   )
 })
 
+//
+//
+// COM Port (composite)
 const Com = (): JSX.Element => {
   useEffect(() => {
     useServerZustand.getState().refreshServerSerialPorts()
   }, [])
 
   return (
-    <Box sx={{ display: 'flex', alignItems: 'center' }}>
+    <Box sx={{ display: 'flex' }}>
       <ComInput />
       <ComActions />
       <RtuStatus />
@@ -227,115 +157,54 @@ const Com = (): JSX.Element => {
   )
 }
 
-const BaudRateSelect = meme(() => {
-  const labelId = 'server-baud-rate-select'
+//
+//
+// Selects (thin wrappers over shared components)
+const ServerBaudRateSelect = meme(() => {
   const baudRate = useServerZustand((z) => z.serialConfig?.options.baudRate ?? '9600')
 
   return (
-    <FormControl size="small">
-      <InputLabel id={labelId}>Baud Rate</InputLabel>
-      <Select
-        size="small"
-        labelId={labelId}
-        value={baudRate}
-        label="Baud Rate"
-        onChange={(e) =>
-          useServerZustand.getState().setServerBaudRate(e.target.value as ModbusBaudRate)
-        }
-        sx={{ width: 100 }}
-        data-testid="server-rtu-baudrate-select"
-      >
-        {ModbusBaudRateSchema.options.map((value) => (
-          <MenuItem key={`server_baud_rate_${value}`} value={value}>
-            {value}
-          </MenuItem>
-        ))}
-      </Select>
-    </FormControl>
+    <BaudRateSelect
+      value={baudRate as ModbusBaudRate}
+      onChange={(v) => useServerZustand.getState().setServerBaudRate(v)}
+      testId="server-rtu-baudrate-select"
+    />
   )
 })
 
-const parityOptions = ['none', 'even', 'odd', 'mark', 'space'] as const
-
-const ParitySelect = meme(() => {
-  const labelId = 'server-parity-select'
+const ServerParitySelect = meme(() => {
   const parity = useServerZustand((z) => z.serialConfig?.options.parity ?? 'none')
 
   return (
-    <FormControl size="small">
-      <InputLabel id={labelId}>Parity</InputLabel>
-      <Select
-        size="small"
-        labelId={labelId}
-        value={parity}
-        label="Parity"
-        onChange={(e) => useServerZustand.getState().setServerParity(e.target.value)}
-        sx={{ width: 85 }}
-        data-testid="server-rtu-parity-select"
-      >
-        {parityOptions.map((option) => (
-          <MenuItem key={`server_parity_${option}`} value={option}>
-            {option}
-          </MenuItem>
-        ))}
-      </Select>
-    </FormControl>
+    <ParitySelect
+      value={parity}
+      onChange={(v) => useServerZustand.getState().setServerParity(v)}
+      testId="server-rtu-parity-select"
+    />
   )
 })
 
-const databitsOptions = [8, 7, 6, 5] as const
-
-const DataBitsSelect = meme(() => {
-  const labelId = 'server-databits-select'
+const ServerDataBitsSelect = meme(() => {
   const dataBits = useServerZustand((z) => z.serialConfig?.options.dataBits ?? 8)
 
   return (
-    <FormControl size="small">
-      <InputLabel id={labelId}>Data</InputLabel>
-      <Select
-        size="small"
-        labelId={labelId}
-        value={dataBits}
-        label="Data Bits"
-        onChange={(e) => useServerZustand.getState().setServerDataBits(Number(e.target.value))}
-        sx={{ width: 55 }}
-        data-testid="server-rtu-databits-select"
-      >
-        {databitsOptions.map((option) => (
-          <MenuItem key={`server_databits_${option}`} value={option}>
-            {option}
-          </MenuItem>
-        ))}
-      </Select>
-    </FormControl>
+    <DataBitsSelect
+      value={dataBits}
+      onChange={(v) => useServerZustand.getState().setServerDataBits(v)}
+      testId="server-rtu-databits-select"
+    />
   )
 })
 
-const stopBitsOptions = [1, 2] as const
-
-const StopBitsSelect = meme(() => {
-  const labelId = 'server-stopbits-select'
+const ServerStopBitsSelect = meme(() => {
   const stopBits = useServerZustand((z) => z.serialConfig?.options.stopBits ?? 1)
 
   return (
-    <FormControl size="small">
-      <InputLabel id={labelId}>Stop</InputLabel>
-      <Select
-        size="small"
-        labelId={labelId}
-        value={stopBits}
-        label="Stop Bits"
-        onChange={(e) => useServerZustand.getState().setServerStopBits(Number(e.target.value))}
-        sx={{ width: 55 }}
-        data-testid="server-rtu-stopbits-select"
-      >
-        {stopBitsOptions.map((option) => (
-          <MenuItem key={`server_stopbits_${option}`} value={option}>
-            {option}
-          </MenuItem>
-        ))}
-      </Select>
-    </FormControl>
+    <StopBitsSelect
+      value={stopBits}
+      onChange={(v) => useServerZustand.getState().setServerStopBits(v)}
+      testId="server-rtu-stopbits-select"
+    />
   )
 })
 
@@ -344,12 +213,12 @@ const ServerRtuConfig = (): JSX.Element => {
     <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2 }}>
       <Box sx={{ display: 'flex', flexWrap: 'nowrap', gap: 2 }}>
         <Com />
-        <BaudRateSelect />
+        <ServerBaudRateSelect />
       </Box>
       <Box sx={{ display: 'flex', flexWrap: 'nowrap', gap: 2 }}>
-        <ParitySelect />
-        <DataBitsSelect />
-        <StopBitsSelect />
+        <ServerParitySelect />
+        <ServerDataBitsSelect />
+        <ServerStopBitsSelect />
       </Box>
     </Box>
   )

--- a/src/renderer/src/components/server/ServerConfig/ServerRtuConfig.tsx
+++ b/src/renderer/src/components/server/ServerConfig/ServerRtuConfig.tsx
@@ -79,10 +79,19 @@ const ComInput = meme(() => {
 // RTU Status Dot
 const RtuStatus = meme(() => {
   const active = useServerZustand((z) => z.rtuServerActive)
+  const [hovered, setHovered] = useState(false)
+
+  const handleClick = (): void => {
+    useServerZustand.getState().applyServerCom()
+  }
+
   return (
     <Box
       data-testid="server-rtu-status"
       title={active ? 'RTU server active' : 'RTU server inactive'}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      onClick={handleClick}
       sx={(theme) => ({
         alignSelf: 'center',
         display: 'flex',
@@ -91,15 +100,22 @@ const RtuStatus = meme(() => {
         ml: 1,
         mr: -1,
         flexShrink: 0,
-        width: 24,
-        height: 24,
-        borderRadius: 24,
+        width: 28,
+        height: 28,
+        borderRadius: 28,
+        cursor: 'pointer',
         backgroundColor: active
           ? alpha(theme.palette.success.main, 0.1)
           : alpha(theme.palette.text.primary, 0.08)
       })}
     >
-      {active ? <Usb color="success" fontSize={'small'} /> : <UsbOff fontSize="small" />}
+      {hovered ? (
+        <Refresh fontSize="small" color={active ? 'success' : 'inherit'} />
+      ) : active ? (
+        <Usb color="success" fontSize="small" />
+      ) : (
+        <UsbOff fontSize="small" />
+      )}
     </Box>
   )
 })

--- a/src/renderer/src/components/shared/inputs/HostInput.tsx
+++ b/src/renderer/src/components/shared/inputs/HostInput.tsx
@@ -1,77 +1,15 @@
-import { IMaskInput, IMask } from 'react-imask'
 import { forwardRef } from 'react'
 import { MaskInputProps } from './types'
 
 const HostInput = forwardRef<HTMLInputElement, MaskInputProps>((props, ref) => {
   const { set, ...other } = props
   return (
-    <IMaskInput
+    <input
       {...other}
-      mask="IP.IP.IP.IP"
-      blocks={{
-        IP: {
-          mask: IMask.MaskedNumber,
-          min: 0,
-          max: 255,
-          scale: 0
-        }
-      }}
-      inputRef={ref}
-      prepare={(char, mask) => {
-        // // Only accept numbers and dots.
-        // // When entering an invalid character it would fill the input with the remaining dots
-        // // without any numbers inbetween the dots.
-        // const isValidChar = /[\d\.]/.test(char)
-        // if (!isValidChar) return ''
-
-        // // No number can lead with a zero
-        // // not 00.04.012.001
-        // // but 0.4.12.1
-        // const parts = mask.displayValue.split('.')
-        // const lastPart = parts.at(-1)
-        // if (lastPart && lastPart.length === 1 && lastPart === '0') {
-        //   return parts.length < 4 ? `.${char}` : ''
-        // }
-
-        // return char
-
-        // !
-
-        // Allow only digits and dots
-        const isValidChar = /[\d.]/.test(char)
-        if (!isValidChar) return ''
-
-        const value = mask.value
-
-        // Prevent double dots: if the last character is already a dot, ignore a second dot
-        if (char === '.' && value.endsWith('.')) {
-          return ''
-        }
-
-        // Split the current value into IP segments
-        const parts = value.split('.')
-
-        // Prevent entering more than 3 dots (IPv4 has 4 parts = 3 dots)
-        const dotCount = (value.match(/\./g) ?? []).length
-        if (char === '.' && dotCount >= 3) {
-          return ''
-        }
-
-        // Allow typing '0' as a single segment, like in "0.0.0.0"
-        // But prevent situations like "00.123.001.1"
-        const lastPart = parts[parts.length - 1]
-
-        if (lastPart === '0' && char !== '.') {
-          // Prevent adding extra digits after a leading zero
-          // Only allow the dot to close the segment
-          return ''
-        }
-
-        // All other cases: allow the character
-        return char
-      }}
-      onAccept={(value) => {
-        set(value, /\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/.test(value))
+      ref={ref}
+      onChange={(e) => {
+        const value = e.target.value
+        set(value, value.trim().length > 0)
       }}
     />
   )

--- a/src/renderer/src/components/shared/inputs/SerialPortInputs.tsx
+++ b/src/renderer/src/components/shared/inputs/SerialPortInputs.tsx
@@ -1,0 +1,276 @@
+import {
+  AutocompleteRenderInputParams,
+  Box,
+  CircularProgress,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  TextField
+} from '@mui/material'
+import { meme } from './meme'
+import { ModbusBaudRate, ModbusBaudRateSchema } from '@shared'
+import React, { useMemo } from 'react'
+
+export const measureTextWidth = (
+  text: string,
+  font: string = '400 0.85rem Roboto, sans-serif'
+): number => {
+  const canvas = document.createElement('canvas')
+  const context = canvas.getContext('2d')
+  if (context) {
+    context.font = font
+    return context.measureText(text).width
+  }
+  return 0
+}
+
+export const useComInputWidth = (ports: { path: string }[]): number =>
+  useMemo(() => {
+    let textWidth = 60
+    for (const port of ports) {
+      const newTextWidth = measureTextWidth(port.path || 'COM Port')
+      if (newTextWidth > textWidth) textWidth = newTextWidth
+    }
+    return Math.max(60, textWidth + 60)
+  }, [ports])
+
+export const ComTextField = meme(
+  (
+    params: AutocompleteRenderInputParams & {
+      comLabel: string
+      comError: boolean
+      comLoading: boolean
+    }
+  ) => {
+    const { comLabel, comError, comLoading, ...rest } = params
+
+    return (
+      <TextField
+        {...rest}
+        label={comLabel}
+        variant="outlined"
+        size="small"
+        title={rest.inputProps.value as string}
+        error={comError}
+        sx={{
+          '& .MuiOutlinedInput-root': {
+            borderTopRightRadius: 0,
+            borderBottomRightRadius: 0
+          },
+          '& .MuiOutlinedInput-input': {
+            overflow: 'hidden',
+            textOverflow: 'ellipsis'
+          }
+        }}
+        slotProps={{
+          input: {
+            ...rest.InputProps,
+            endAdornment: (
+              <>
+                {comLoading ? <CircularProgress size={16} /> : null}
+                {rest.InputProps.endAdornment}
+              </>
+            )
+          }
+        }}
+      />
+    )
+  }
+)
+
+export const ComOption = meme(
+  ({
+    option,
+    manufacturer,
+    ...props
+  }: { option: string; manufacturer?: string } & React.HTMLAttributes<HTMLLIElement>) => (
+    <li {...props} key={option}>
+      <Box sx={{ width: '100%' }} title={option}>
+        <Box
+          sx={{
+            fontSize: '0.85rem',
+            whiteSpace: 'nowrap',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            width: '100%'
+          }}
+        >
+          {option}
+        </Box>
+        {manufacturer && (
+          <Box
+            sx={{
+              fontSize: '0.75rem',
+              color: 'text.secondary',
+              whiteSpace: 'nowrap',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              width: '100%'
+            }}
+          >
+            {manufacturer}
+          </Box>
+        )}
+      </Box>
+    </li>
+  )
+)
+
+export const BaudRateSelect = meme(
+  ({
+    value,
+    onChange,
+    disabled,
+    testId = 'rtu-baudrate-select'
+  }: {
+    value: ModbusBaudRate
+    onChange: (value: ModbusBaudRate) => void
+    disabled?: boolean
+    testId?: string
+  }) => {
+    const labelId = `${testId}-label`
+
+    return (
+      <FormControl size="small">
+        <InputLabel id={labelId}>Baud Rate</InputLabel>
+        <Select
+          disabled={disabled}
+          size="small"
+          labelId={labelId}
+          value={value}
+          label="Baud Rate"
+          onChange={(e) => onChange(e.target.value as ModbusBaudRate)}
+          sx={{ width: 100 }}
+          data-testid={testId}
+        >
+          {ModbusBaudRateSchema.options.map((v) => (
+            <MenuItem key={`baud_rate_${v}`} value={v}>
+              {v}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+    )
+  }
+)
+
+const parityOptions = ['none', 'even', 'odd', 'mark', 'space'] as const
+
+export const ParitySelect = meme(
+  ({
+    value,
+    onChange,
+    disabled,
+    testId = 'rtu-parity-select'
+  }: {
+    value: string
+    onChange: (value: string) => void
+    disabled?: boolean
+    testId?: string
+  }) => {
+    const labelId = `${testId}-label`
+
+    return (
+      <FormControl size="small">
+        <InputLabel id={labelId}>Parity</InputLabel>
+        <Select
+          disabled={disabled}
+          size="small"
+          labelId={labelId}
+          value={value}
+          label="Parity"
+          onChange={(e) => onChange(e.target.value)}
+          sx={{ width: 85 }}
+          data-testid={testId}
+        >
+          {parityOptions.map((option) => (
+            <MenuItem key={`parity_${option}`} value={option}>
+              {option}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+    )
+  }
+)
+
+const databitsOptions = [8, 7, 6, 5] as const
+
+export const DataBitsSelect = meme(
+  ({
+    value,
+    onChange,
+    disabled,
+    testId = 'rtu-databits-select'
+  }: {
+    value: number
+    onChange: (value: number) => void
+    disabled?: boolean
+    testId?: string
+  }) => {
+    const labelId = `${testId}-label`
+
+    return (
+      <FormControl size="small">
+        <InputLabel id={labelId}>Data</InputLabel>
+        <Select
+          disabled={disabled}
+          size="small"
+          labelId={labelId}
+          value={value}
+          label="Data Bits"
+          onChange={(e) => onChange(Number(e.target.value))}
+          sx={{ width: 55 }}
+          data-testid={testId}
+        >
+          {databitsOptions.map((option) => (
+            <MenuItem key={`databits_${option}`} value={option}>
+              {option}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+    )
+  }
+)
+
+const stopBitsOptions = [1, 2] as const
+
+export const StopBitsSelect = meme(
+  ({
+    value,
+    onChange,
+    disabled,
+    testId = 'rtu-stopbits-select'
+  }: {
+    value: number
+    onChange: (value: number) => void
+    disabled?: boolean
+    testId?: string
+  }) => {
+    const labelId = `${testId}-label`
+
+    return (
+      <FormControl size="small">
+        <InputLabel id={labelId}>Stop</InputLabel>
+        <Select
+          disabled={disabled}
+          size="small"
+          labelId={labelId}
+          value={value}
+          label="Stop Bits"
+          onChange={(e) => onChange(Number(e.target.value))}
+          sx={{ width: 55 }}
+          data-testid={testId}
+        >
+          {stopBitsOptions.map((option) => (
+            <MenuItem key={`stopbits_${option}`} value={option}>
+              {option}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+    )
+  }
+)

--- a/src/renderer/src/containers/Server.tsx
+++ b/src/renderer/src/containers/Server.tsx
@@ -15,7 +15,7 @@ const ServerName = meme(() => {
   return (
     <TextField
       data-testid="server-name-input"
-      sx={{ flex: 1, minWidth: 200 }}
+      sx={{ flex: 1, minWidth: 160 }}
       size="small"
       // variant="filled"
       color="primary"

--- a/src/renderer/src/context/server.zustand.ts
+++ b/src/renderer/src/context/server.zustand.ts
@@ -19,9 +19,12 @@ import {
   UnitIdString,
   UnitIdStringSchema,
   migrateServerRegistersState,
+  migrateServerModeState,
   migrateBoolShape,
   CURRENT_SERVER_ZUSTAND_VERSION,
-  getRegisterLength
+  getRegisterLength,
+  ServerSerialConfig,
+  ModbusBaudRate
 } from '@shared'
 import { onEvent } from '@renderer/events'
 import { enqueueSnackbar } from 'notistack'
@@ -39,10 +42,26 @@ const getDefaultServerRegisters = (): ServerRegisters => ({
   holding_registers: {}
 })
 
+const defaultSerialConfig: ServerSerialConfig = {
+  com: '',
+  options: { baudRate: '9600', dataBits: 8, stopBits: 1, parity: 'none' }
+}
+
 const getDefaultUsedAddresses = (): UsedAddresses => ({
   input_registers: [],
   holding_registers: []
 })
+
+/** Restart RTU server only if in RTU mode and COM port is set */
+const restartRtuIfActive = (get: () => ServerZustand): void => {
+  const state = get()
+  if (state.serverMode !== 'rtu') return
+  const serialConfig = state.serialConfig ?? defaultSerialConfig
+  if (!serialConfig.com.trim()) return
+  window.api.stopRtuServer().then(() => {
+    window.api.startRtuServer({ uuid: MAIN_SERVER_UUID, serialConfig })
+  })
+}
 
 export const useServerZustand = create<
   ServerZustand,
@@ -60,6 +79,11 @@ export const useServerZustand = create<
       usedAddresses: { [MAIN_SERVER_UUID]: undefined },
       name: { [MAIN_SERVER_UUID]: undefined },
       littleEndian: { [MAIN_SERVER_UUID]: false },
+      serverMode: 'tcp' as const,
+      serialConfig: defaultSerialConfig,
+      serverSerialPorts: [],
+      serverSerialPortsLoading: false,
+      rtuServerActive: false,
       clean: (uuid) =>
         set((state) => {
           state.unitId[uuid] = '0'
@@ -127,6 +151,7 @@ export const useServerZustand = create<
           else for (const u of state.uuids) state.ready[u] = false
         })
         const state = get()
+        const mode = state.serverMode ?? 'tcp'
 
         // Ensure every uuid has a unitId and littleEndian entry (for backward compatibility)
         set((state) => {
@@ -140,18 +165,21 @@ export const useServerZustand = create<
           }
         })
 
-        // Determine which uuid should be initialized when provided
-        const uuidsToSync = uuid ? [uuid] : state.uuids
+        if (mode === 'rtu') {
+          // RTU mode: start RTU server with main server UUID
+          const serialConfig = state.serialConfig ?? defaultSerialConfig
+          const syncUuid = MAIN_SERVER_UUID
 
-        for (const syncUuid of uuidsToSync) {
-          const port = Number(state.port[syncUuid])
-          const actualPort = await window.api.setServerPort({ uuid: syncUuid, port })
+          // Only start if COM port is configured
+          if (serialConfig.com.trim()) {
+            try {
+              await window.api.startRtuServer({ uuid: syncUuid, serialConfig })
+            } catch {
+              // Error is reported via backend_message event
+            }
+          }
 
-          set((state) => {
-            state.port[syncUuid] = String(actualPort)
-          })
-
-          // Check if server registers are present in the state for the uuid (there should be)
+          // Sync registers for main server
           let serverRegisters = state.serverRegisters[syncUuid]
           if (!serverRegisters) {
             serverRegisters = {}
@@ -161,12 +189,8 @@ export const useServerZustand = create<
           }
 
           const unitIdsWithData = extractUnitIdsWithData(serverRegisters)
-
           for (const unitId of unitIdsWithData) {
-            // Synchronize the boolean states with the server from persisted state
             await syncBoolsWithBackend(serverRegisters, unitId, syncUuid)
-
-            // Synchronize the value generators/registers with the server from persisted state
             const littleEndian = !!state.littleEndian[syncUuid]
             const { inputRegisterRegisterValues, holdingRegisterRegisterValues } =
               await syncRegistersWithBackend(serverRegisters, unitId, syncUuid, littleEndian)
@@ -184,15 +208,59 @@ export const useServerZustand = create<
 
           set((state) => {
             state.ready[syncUuid] = true
+            state.selectedUuid = syncUuid
           })
-        }
+        } else {
+          // TCP mode: existing flow
+          const uuidsToSync = uuid ? [uuid] : state.uuids
 
-        if (state.uuids.length === 0) {
-          // Create the main server if no server exists in persisted state
-          state.createServer({ port: 502, uuid: MAIN_SERVER_UUID })
-          set((state) => {
-            state.ready[MAIN_SERVER_UUID] = true
-          })
+          for (const syncUuid of uuidsToSync) {
+            const port = Number(state.port[syncUuid])
+            const actualPort = await window.api.setServerPort({ uuid: syncUuid, port })
+
+            set((state) => {
+              state.port[syncUuid] = String(actualPort)
+            })
+
+            let serverRegisters = state.serverRegisters[syncUuid]
+            if (!serverRegisters) {
+              serverRegisters = {}
+              set((state) => {
+                state.serverRegisters[syncUuid] = {}
+              })
+            }
+
+            const unitIdsWithData = extractUnitIdsWithData(serverRegisters)
+
+            for (const unitId of unitIdsWithData) {
+              await syncBoolsWithBackend(serverRegisters, unitId, syncUuid)
+              const littleEndian = !!state.littleEndian[syncUuid]
+              const { inputRegisterRegisterValues, holdingRegisterRegisterValues } =
+                await syncRegistersWithBackend(serverRegisters, unitId, syncUuid, littleEndian)
+
+              const inputUsedAddresses = getUsedAddresses(inputRegisterRegisterValues)
+              const holdingUsedAddresses = getUsedAddresses(holdingRegisterRegisterValues)
+
+              set((state) => {
+                if (!state.usedAddresses[syncUuid]) state.usedAddresses[syncUuid] = {}
+                if (!state.usedAddresses[syncUuid][unitId])
+                  state.usedAddresses[syncUuid][unitId] = {}
+                state.usedAddresses[syncUuid][unitId]['input_registers'] = inputUsedAddresses
+                state.usedAddresses[syncUuid][unitId]['holding_registers'] = holdingUsedAddresses
+              })
+            }
+
+            set((state) => {
+              state.ready[syncUuid] = true
+            })
+          }
+
+          if (state.uuids.length === 0) {
+            state.createServer({ port: 502, uuid: MAIN_SERVER_UUID })
+            set((state) => {
+              state.ready[MAIN_SERVER_UUID] = true
+            })
+          }
         }
 
         get().cleanOrphanedServerState()
@@ -438,6 +506,78 @@ export const useServerZustand = create<
           state.serverRegisters[uuid][unitId] = registers
         })
       },
+      switchToRtu: async () => {
+        await window.api.stopAllTcpServers()
+        set((state) => {
+          state.serverMode = 'rtu'
+        })
+        await get().init()
+      },
+      switchToTcp: async () => {
+        await window.api.stopRtuServer()
+        set((state) => {
+          state.serverMode = 'tcp'
+        })
+        await get().init()
+      },
+      setServerCom: (com) => {
+        set((state) => {
+          if (!state.serialConfig) state.serialConfig = { ...defaultSerialConfig }
+          state.serialConfig.com = com
+        })
+        // State-only — applied on blur via applyServerCom
+      },
+      applyServerCom: async () => {
+        const currentState = get()
+        if (currentState.serverMode !== 'rtu') return
+        const serialConfig = currentState.serialConfig ?? defaultSerialConfig
+        if (!serialConfig.com.trim()) return
+        await window.api.stopRtuServer()
+        await window.api.startRtuServer({ uuid: MAIN_SERVER_UUID, serialConfig })
+      },
+      setServerBaudRate: (baudRate: ModbusBaudRate) => {
+        set((state) => {
+          if (!state.serialConfig) state.serialConfig = { ...defaultSerialConfig }
+          state.serialConfig.options.baudRate = baudRate
+        })
+        restartRtuIfActive(get)
+      },
+      setServerParity: (parity) => {
+        set((state) => {
+          if (!state.serialConfig) state.serialConfig = { ...defaultSerialConfig }
+          state.serialConfig.options.parity = parity as 'none' | 'even' | 'odd' | 'mark' | 'space'
+        })
+        restartRtuIfActive(get)
+      },
+      setServerDataBits: (dataBits) => {
+        set((state) => {
+          if (!state.serialConfig) state.serialConfig = { ...defaultSerialConfig }
+          state.serialConfig.options.dataBits = dataBits
+        })
+        restartRtuIfActive(get)
+      },
+      setServerStopBits: (stopBits) => {
+        set((state) => {
+          if (!state.serialConfig) state.serialConfig = { ...defaultSerialConfig }
+          state.serialConfig.options.stopBits = stopBits
+        })
+        restartRtuIfActive(get)
+      },
+      refreshServerSerialPorts: async () => {
+        set((state) => {
+          state.serverSerialPortsLoading = true
+        })
+        try {
+          const ports = await window.api.listSerialPorts()
+          set((state) => {
+            state.serverSerialPorts = ports
+          })
+        } finally {
+          set((state) => {
+            state.serverSerialPortsLoading = false
+          })
+        }
+      },
       getUnitId: (uuid: string): UnitIdString => {
         const state = get()
         let unitId = state.unitId[uuid]
@@ -454,18 +594,25 @@ export const useServerZustand = create<
       name: `server.zustand`,
       version: CURRENT_SERVER_ZUSTAND_VERSION,
       migrate: (persistedState, version) => {
+        let state = persistedState as Record<string, unknown>
+
         // Version 0/1 (old format with littleEndian per register)
         if (version < 2) {
-          return migrateServerRegistersState(
-            persistedState as Record<string, unknown>
-          ) as PersistedServerZustand
+          state = migrateServerRegistersState(state)
         }
-        // Already v2 — still convert old boolean shape if needed
-        const state = persistedState as PersistedServerZustand
-        migrateBoolShape(
-          state.serverRegisters as Record<string, Record<string, unknown> | undefined> | undefined
-        )
-        return state
+
+        // v2→v3: add serverMode and serialConfig
+        if (version < 3) {
+          state = migrateServerModeState(state)
+          // Also convert old boolean shape if needed
+          migrateBoolShape(
+            (state as Record<string, unknown>).serverRegisters as
+              | Record<string, Record<string, unknown> | undefined>
+              | undefined
+          )
+        }
+
+        return state as PersistedServerZustand
       },
       partialize: (state) => ({
         name: state.name,
@@ -476,7 +623,9 @@ export const useServerZustand = create<
         unitId: state.unitId,
         usedAddresses: state.usedAddresses,
         uuids: state.uuids,
-        littleEndian: state.littleEndian
+        littleEndian: state.littleEndian,
+        serverMode: state.serverMode,
+        serialConfig: state.serialConfig
       })
     }
   )
@@ -727,4 +876,9 @@ onEvent('boolean_value', ({ uuid, unitId, registerType, address, value }) => {
     })
     delayedSetBool()
   }
+})
+
+// RTU server status
+onEvent('rtu_server_status', ({ active }) => {
+  useServerZustand.setState({ rtuServerActive: active })
 })

--- a/src/renderer/src/context/server.zustand.ts
+++ b/src/renderer/src/context/server.zustand.ts
@@ -531,9 +531,10 @@ export const useServerZustand = create<
         const currentState = get()
         if (currentState.serverMode !== 'rtu') return
         const serialConfig = currentState.serialConfig ?? defaultSerialConfig
-        if (!serialConfig.com.trim()) return
         await window.api.stopRtuServer()
-        await window.api.startRtuServer({ uuid: MAIN_SERVER_UUID, serialConfig })
+        if (serialConfig.com.trim()) {
+          await window.api.startRtuServer({ uuid: MAIN_SERVER_UUID, serialConfig })
+        }
       },
       setServerBaudRate: (baudRate: ModbusBaudRate) => {
         set((state) => {

--- a/src/renderer/src/context/server.zustand.ts
+++ b/src/renderer/src/context/server.zustand.ts
@@ -73,7 +73,6 @@ export const useServerZustand = create<
       selectedUuid: MAIN_SERVER_UUID,
       uuids: [MAIN_SERVER_UUID],
       port: { [MAIN_SERVER_UUID]: '502' },
-      portValid: { [MAIN_SERVER_UUID]: true },
       unitId: { [MAIN_SERVER_UUID]: undefined },
       serverRegisters: { [MAIN_SERVER_UUID]: undefined },
       usedAddresses: { [MAIN_SERVER_UUID]: undefined },
@@ -104,7 +103,6 @@ export const useServerZustand = create<
           Object.keys(state.port).forEach((uuid) => {
             if (!uuids.includes(uuid)) {
               delete state.port[uuid]
-              delete state.portValid[uuid]
               delete state.unitId[uuid]
               delete state.serverRegisters[uuid]
               delete state.usedAddresses[uuid]
@@ -123,7 +121,6 @@ export const useServerZustand = create<
 
         set((state) => {
           state.port[uuid] = String(actualPort)
-          state.portValid[uuid] = true
           state.ready[uuid] = true
           get().clean(uuid)
           state.uuids.push(uuid)
@@ -137,7 +134,6 @@ export const useServerZustand = create<
           state.uuids = state.uuids.filter((u) => u !== uuid)
           if (state.selectedUuid === uuid) state.selectedUuid = state.uuids[0]
           delete state.port[uuid]
-          delete state.portValid[uuid]
           delete state.unitId[uuid]
           delete state.serverRegisters[uuid]
           delete state.usedAddresses[uuid]
@@ -216,7 +212,7 @@ export const useServerZustand = create<
 
           for (const syncUuid of uuidsToSync) {
             const port = Number(state.port[syncUuid])
-            const actualPort = await window.api.setServerPort({ uuid: syncUuid, port })
+            const actualPort = await window.api.createServer({ uuid: syncUuid, port })
 
             set((state) => {
               state.port[syncUuid] = String(actualPort)
@@ -444,28 +440,20 @@ export const useServerZustand = create<
           state.usedAddresses[uuid][unitId][registerType] = []
         })
       },
-      setPort: async (port, valid) => {
+      setPort: async (port) => {
         const currentState = get()
         const uuid = currentState.selectedUuid
         if (!currentState.ready[uuid]) return
 
-        const { port: currentPorts, selectedUuid } = get() // removed unused uuids
+        const { port: currentPorts, selectedUuid } = get()
 
         get().cleanOrphanedServerState()
 
-        // Port cannot be already used for a server
+        // Port cannot be already used for another server
         const portAlreadyExists = Object.values(currentPorts).includes(port)
         const portIsMyPort = port === currentPorts[selectedUuid]
-
-        console.log({ portAlreadyExists, portIsMyPort, port, selectedUuid, currentPorts })
-
-        if (portIsMyPort) valid = true // If this is my port, it is always valid
-        if (portAlreadyExists && !portIsMyPort) valid = false
-
-        set((state) => {
-          state.portValid[uuid] = !!valid
-        })
-        if (!valid) return
+        if (portAlreadyExists && !portIsMyPort) return
+        if (portIsMyPort) return
 
         // Only update port from backend response
         const actualPort = await window.api.setServerPort({ uuid, port: Number(port) })
@@ -618,7 +606,6 @@ export const useServerZustand = create<
       partialize: (state) => ({
         name: state.name,
         port: state.port,
-        portValid: state.portValid,
         selectedUuid: state.selectedUuid,
         serverRegisters: state.serverRegisters,
         unitId: state.unitId,

--- a/src/renderer/src/context/server.zustand.types.ts
+++ b/src/renderer/src/context/server.zustand.types.ts
@@ -8,7 +8,11 @@ import {
   AddRegisterParams,
   UnitIdStringSchema,
   UnitIdString,
-  ServerRegistersPerUnitSchema
+  ServerRegistersPerUnitSchema,
+  ServerModeSchema,
+  ServerSerialConfigSchema,
+  SerialPortInfo,
+  ModbusBaudRate
 } from '@shared'
 import { MaskSetFn } from './root.zustand.types'
 import { z } from 'zod'
@@ -28,7 +32,9 @@ export const PersistedServerZustandSchema = z.object({
   unitId: z.record(z.string(), z.union([UnitIdStringSchema, z.undefined()])),
   name: z.record(z.string(), z.string().optional()),
   portValid: z.record(z.string(), z.boolean()),
-  littleEndian: z.record(z.string(), z.boolean())
+  littleEndian: z.record(z.string(), z.boolean()),
+  serverMode: ServerModeSchema.optional(),
+  serialConfig: ServerSerialConfigSchema.optional()
 })
 
 export type PersistedServerZustand = z.infer<typeof PersistedServerZustandSchema>
@@ -77,4 +83,17 @@ export type ServerZustand = {
   replaceServerRegisters: (unitId: UnitIdString, registers: ServerRegisters) => void
   setName: (name: string) => void
   getUnitId: (uuid: string) => UnitIdString
+  // RTU server mode
+  switchToRtu: () => Promise<void>
+  switchToTcp: () => Promise<void>
+  setServerCom: (com: string) => void
+  applyServerCom: () => Promise<void>
+  setServerBaudRate: (baudRate: ModbusBaudRate) => void
+  setServerParity: (parity: string) => void
+  setServerDataBits: (dataBits: number) => void
+  setServerStopBits: (stopBits: number) => void
+  serverSerialPorts: SerialPortInfo[]
+  serverSerialPortsLoading: boolean
+  refreshServerSerialPorts: () => Promise<void>
+  rtuServerActive: boolean
 } & PersistedServerZustand

--- a/src/renderer/src/context/server.zustand.types.ts
+++ b/src/renderer/src/context/server.zustand.types.ts
@@ -31,7 +31,6 @@ export const PersistedServerZustandSchema = z.object({
   port: z.record(z.string(), z.string()),
   unitId: z.record(z.string(), z.union([UnitIdStringSchema, z.undefined()])),
   name: z.record(z.string(), z.string().optional()),
-  portValid: z.record(z.string(), z.boolean()),
   littleEndian: z.record(z.string(), z.boolean()),
   serverMode: ServerModeSchema.optional(),
   serialConfig: ServerSerialConfigSchema.optional()

--- a/src/shared/__tests__/serverUtils.test.ts
+++ b/src/shared/__tests__/serverUtils.test.ts
@@ -60,11 +60,11 @@ describe('findAvailablePort', () => {
   })
 
   it('wraps around when high ports are taken but low ports are free', () => {
-    expect(findAvailablePort([999, 1000])).toBe(502)
+    expect(findAvailablePort([10501, 10502])).toBe(502)
   })
 
-  it('returns undefined when all ports 502-1000 are taken', () => {
-    const allPorts = Array.from({ length: 499 }, (_, i) => 502 + i)
+  it('returns undefined when all ports 502-10502 are taken', () => {
+    const allPorts = Array.from({ length: 10502 - 502 + 1 }, (_, i) => 502 + i)
     expect(findAvailablePort(allPorts)).toBeUndefined()
   })
 
@@ -73,7 +73,7 @@ describe('findAvailablePort', () => {
   })
 
   it('clamps start to MAX_PORT when used ports exceed range', () => {
-    expect(findAvailablePort([2000, 3000])).toBe(1000)
+    expect(findAvailablePort([20000, 30000])).toBe(10502)
   })
 })
 

--- a/src/shared/migrations/index.ts
+++ b/src/shared/migrations/index.ts
@@ -2,6 +2,7 @@ export type { MigrationResult } from './types'
 export { migrateServerConfig, CURRENT_SERVER_CONFIG_VERSION } from './server/config'
 export {
   migrateServerRegistersState,
+  migrateServerModeState,
   migrateBoolShape,
   CURRENT_SERVER_ZUSTAND_VERSION
 } from './server/zustand'

--- a/src/shared/migrations/server/config.ts
+++ b/src/shared/migrations/server/config.ts
@@ -36,8 +36,7 @@ function migrateServerV1toV2(v1Config: unknown): ServerConfig & { wasMixedEndian
     // Convert old boolean shape to { value: boolean } entries
     const migratedCoils: Record<string, ServerBoolEntry> = {}
     for (const [address, value] of Object.entries(serverRegisters.coils ?? {})) {
-      migratedCoils[address] =
-        typeof value === 'boolean' ? { value } : (value as ServerBoolEntry)
+      migratedCoils[address] = typeof value === 'boolean' ? { value } : (value as ServerBoolEntry)
     }
     const migratedDiscreteInputs: Record<string, ServerBoolEntry> = {}
     for (const [address, value] of Object.entries(serverRegisters.discrete_inputs ?? {})) {

--- a/src/shared/migrations/server/zustand.ts
+++ b/src/shared/migrations/server/zustand.ts
@@ -1,6 +1,6 @@
 import { V1RegisterParams, V1ServerRegistersPerUnit, extractGlobalEndianness } from './shared'
 
-export const CURRENT_SERVER_ZUSTAND_VERSION = 2
+export const CURRENT_SERVER_ZUSTAND_VERSION = 3
 
 interface V1ZustandServerState {
   serverRegisters?: Record<string, V1ServerRegistersPerUnit | undefined>
@@ -35,6 +35,28 @@ export function migrateBoolShape(
       }
     }
   }
+}
+
+/**
+ * Migrate server Zustand state from v1 (littleEndian per register) to v2 (global littleEndian).
+ * Also converts old boolean shape to { value: boolean } entries.
+ * Used by Zustand persist middleware.
+ */
+/**
+ * Migrate server Zustand state from v2 to v3: add serverMode and serialConfig defaults.
+ */
+export function migrateServerModeState(state: Record<string, unknown>): Record<string, unknown> {
+  const migrated = { ...state }
+  if (!migrated.serverMode) {
+    migrated.serverMode = 'tcp'
+  }
+  if (!migrated.serialConfig) {
+    migrated.serialConfig = {
+      com: '',
+      options: { baudRate: '9600', dataBits: 8, stopBits: 1, parity: 'none' }
+    }
+  }
+  return migrated
 }
 
 /**

--- a/src/shared/types/ipc.ts
+++ b/src/shared/types/ipc.ts
@@ -23,7 +23,8 @@ import type {
   WindowsOpen,
   AddressGroup,
   SerialPortInfo,
-  SerialPortValidationResult
+  SerialPortValidationResult,
+  StartRtuServerParams
 } from '@shared'
 import { SharedProps } from 'notistack'
 
@@ -69,7 +70,10 @@ export const IPC_CHANNELS = [
   'reset_server',
   'list_serial_ports',
   'validate_serial_port',
-  'set_read_configuration'
+  'set_read_configuration',
+  'start_rtu_server',
+  'stop_rtu_server',
+  'stop_all_tcp_servers'
 ] as const
 
 export type IpcChannel = (typeof IPC_CHANNELS)[number]
@@ -263,6 +267,24 @@ export interface IpcHandlerSpec {
     args: [boolean]
     return: void
   }
+
+  /** Start RTU server on a UUID with serial config */
+  ['start_rtu_server']: {
+    args: [StartRtuServerParams]
+    return: void
+  }
+
+  /** Stop the active RTU server */
+  ['stop_rtu_server']: {
+    args: []
+    return: void
+  }
+
+  /** Stop all running TCP servers (cleanup before RTU switch) */
+  ['stop_all_tcp_servers']: {
+    args: []
+    return: void
+  }
 }
 
 export type IpcHandlerMap = {
@@ -283,7 +305,8 @@ export const IPC_EVENTS = [
   'boolean_value',
   'window_update',
   'open_server_window',
-  'address_groups'
+  'address_groups',
+  'rtu_server_status'
 ] as const
 
 export type IpcEvent = (typeof IPC_EVENTS)[number]
@@ -300,6 +323,7 @@ export interface IpcEventPayloadMap {
   ['window_update']: [WindowsOpen]
   ['open_server_window']: []
   ['address_groups']: [AddressGroup[]]
+  ['rtu_server_status']: [{ active: boolean }]
 }
 
 export interface BackendMessage {

--- a/src/shared/types/server.ts
+++ b/src/shared/types/server.ts
@@ -1,9 +1,25 @@
 import { z } from 'zod'
 import { BaseDataType, BaseDataTypeSchema } from './datatype'
 import { BitMapConfigSchema } from './bitmap'
-import { RegisterType } from './client'
+import { RegisterType, SerialPortOptionsSchema } from './client'
 import { ValueGenerator } from '../../main/modules/modbusServer/valueGenerator'
 import { unitIds } from './unitid'
+
+// Server mode (global: TCP or RTU)
+export const ServerModeSchema = z.enum(['tcp', 'rtu'])
+export type ServerMode = z.infer<typeof ServerModeSchema>
+
+// Server serial config for RTU mode
+export const ServerSerialConfigSchema = z.object({
+  com: z.string(),
+  options: SerialPortOptionsSchema
+})
+export type ServerSerialConfig = z.infer<typeof ServerSerialConfigSchema>
+
+export interface StartRtuServerParams {
+  uuid: string
+  serialConfig: ServerSerialConfig
+}
 
 // Zod schema for boolean register types
 export const BooleanRegistersSchema = z.enum(['coils', 'discrete_inputs'])

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -203,7 +203,7 @@ export function getAddressFitError(
 
 export const findAvailablePort = (usedPorts: number[]): number | undefined => {
   const MIN_PORT = 502
-  const MAX_PORT = 1000
+  const MAX_PORT = 10502
 
   const usedSet = new Set(usedPorts)
 

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -157,11 +157,11 @@ export const notEmpty = (value: number | string): boolean =>
 
 export const humanizeSerialError = (error: Error, port?: string): string => {
   const prefix = port ? `${port}: ` : ''
-  const msg = error.message.toLowerCase()
+  const msg = (error.message || '').toLowerCase()
   if (msg.includes('file not found')) return `${prefix}Port not found or not available`
   if (msg.includes('access denied') || msg.includes('permission denied'))
     return `${prefix}Port access denied (already in use?)`
-  return error.message
+  return error.message || `Connection failed${error['code'] ? ` (${error['code']})` : ''}`
 }
 
 export const getUsedAddresses = (registers: RegisterParams[]): number[] => {


### PR DESCRIPTION
# PR: Hostname support, RTU server mode & Linux support

## Summary

- Hostname/IP input for TCP client connections
- RTU server mode — serve Modbus registers over a serial port with status indicator and click-to-reconnect
- Linux build support with privileged port handling and correct icon paths
- Shared serial port components extracted between client and server RTU configs
- Unit tests and e2e tests for RTU server

## What's changed

### Features

**Hostname support for TCP client** — the client connection config now accepts a hostname or IP address instead of being limited to `localhost`.

**RTU server mode** — a new server mode toggle (TCP / RTU) lets the server expose registers over a serial port. Includes COM port autocomplete with refresh, baud rate, parity, data bits, and stop bits configuration. Switching between TCP and RTU preserves all register data. Status indicator with click-to-reconnect for manual recovery. Error listener on `_serverPath` prevents unhandled promise rejections when the serial port fails to open.

**Linux support** — verified builds and packaging on Linux (`.deb`, `.AppImage`). Privileged port errors (EACCES on port 502) are handled gracefully with clear error messages and automatic port fallback. Linux icon path configured in electron-builder. README updated with Linux-specific setup notes for unprivileged ports and serial `dialout` group access.

### Refactoring

**Shared serial port components** — `BaudRateSelect`, `ParitySelect`, `DataBitsSelect`, `StopBitsSelect`, `ComTextField`, and `ComOption` extracted to `SerialPortInputs.tsx` for reuse between client RTU config and server RTU config.

**Strict setPort** — port validation rejects non-numeric input; EACCES and EADDRINUSE errors show clear messages and retry on the next available port.

### Tests

- 242 new lines in `modbusServer.test.ts` covering RTU server start/stop, error handling, privileged port errors, and vector sharing
- New `23-server-rtu.spec.ts` e2e suite (39 tests): UI elements, serial config persistence, and full round-trip (on unix based systems) via socat virtual serial pair

## Test plan

- [x] `yarn lint` — no errors
- [x] `yarn typecheck` — no errors
- [x] `yarn test` — 442 unit tests pass
- [x] `yarn test:e2e` — 498 pass (RTU socat: 39/39 in isolation)
- [x] `yarn test:e2e -- e2e/specs/02-standalone e2e/specs/03-presentation e2e/specs/99-hardware` — 78 pass
- [x] Manual: `yarn dev` → server RTU → enter `/tmp/ttyV0` → error shown, status inactive → `yarn socat` → click refresh → status active
- [x] Manual: hover RTU status → click refresh → reconnect works in both active and inactive states
- [x] `yarn build:mac` — produces x64 and arm64 DMGs
- [x] Linux build — `.deb` installs and runs on Linux Mint