### PR TITLE
RTU over TCP client mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Modbux will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.2.0] - 2026-08-06
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **RTU over TCP client mode** — new "RTU over TCP" option for serial-to-Ethernet gateways
-  (encapsulated RTU: a full RTU frame with CRC sent over a TCP socket)
+- **RTU over TCP client mode** — connect to serial-to-Ethernet gateways that carry
+  encapsulated RTU (a full RTU frame with CRC sent over a TCP socket)
   - Enabled via a checkbox in the ⚙ options menu, shown only when TCP is selected
   - Reuses the TCP host/port inputs and the unit ID field
-  - Connects via `connectTcpRTUBuffered`, which serialises polling more reliably than Telnet
 
 ## [2.1.0] - 2026-03-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to Modbux will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **RTU over TCP client mode** — new "RTU over TCP" option for serial-to-Ethernet gateways
+  (encapsulated RTU: a full RTU frame with CRC sent over a TCP socket)
+  - Enabled via a checkbox in the ⚙ options menu, shown only when TCP is selected
+  - Reuses the TCP host/port inputs and the unit ID field
+  - Connects via `connectTcpRTUBuffered`, which serialises polling more reliably than Telnet
+
 ## [2.1.0] - 2026-03-14
 
 ### Added

--- a/e2e/specs/01-main/21-bitmap-settings.spec.ts
+++ b/e2e/specs/01-main/21-bitmap-settings.spec.ts
@@ -28,6 +28,16 @@ test.describe.serial('Bitmap settings — color, invert & config persistence', (
     await expect(row).toBeVisible()
   })
 
+  // With readConfiguration on, the register list comes from the loaded config,
+  // so the manual address/length inputs are disabled. Asserted explicitly
+  // because it also bites across specs: the app fixture is worker-scoped, so a
+  // spec that leaves readConfiguration enabled silently breaks any later spec
+  // that fills these fields (see the cleanup test at the end).
+  test('readConfiguration disables the manual address and length inputs', async ({ mainPage }) => {
+    await expect(mainPage.getByTestId('reg-address-input').locator('input')).toBeDisabled()
+    await expect(mainPage.getByTestId('reg-length-input').locator('input')).toBeDisabled()
+  })
+
   test('load dummy data so bits have values', async ({ mainPage }) => {
     await disableReadConfiguration(mainPage)
     await loadDummyData(mainPage, '0', '1')
@@ -246,5 +256,18 @@ test.describe.serial('Server bitmap — expand, bit toggle & comment', () => {
 
     // Detail panel should no longer be visible
     await expect(mainPage.getByTestId('server-bitmap-detail-100')).not.toBeVisible()
+  })
+
+  // ─── Cleanup ────────────────────────────────────────────────────
+
+  // Turning readConfiguration back off restores the manual inputs — and keeps
+  // the state clean for the rest of the run. Without this, later specs that
+  // fill the address field (e.g. 23-server-rtu) fail on a disabled input.
+  test('cleanup: disabling readConfiguration re-enables the inputs', async ({ mainPage }) => {
+    await navigateToClient(mainPage)
+    await disableReadConfiguration(mainPage)
+
+    await expect(mainPage.getByTestId('reg-address-input').locator('input')).toBeEnabled()
+    await expect(mainPage.getByTestId('reg-length-input').locator('input')).toBeEnabled()
   })
 })

--- a/e2e/specs/01-main/24-client-rtu-over-tcp.spec.ts
+++ b/e2e/specs/01-main/24-client-rtu-over-tcp.spec.ts
@@ -1,0 +1,189 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { test, expect } from '../../fixtures/electron-app'
+import {
+  navigateToServer,
+  navigateToClient,
+  cleanServerState,
+  loadServerConfig,
+  disconnectClient,
+  readRegisters,
+  cell,
+  selectRegisterType
+} from '../../fixtures/helpers'
+import { resolve } from 'path'
+import { spawn, type ChildProcess } from 'child_process'
+import { existsSync, unlinkSync } from 'fs'
+
+const CONFIG_DIR = resolve(__dirname, '../../fixtures/config-files')
+const SERVER_CONFIG = resolve(CONFIG_DIR, 'server-basic.json')
+
+const SOCAT_PATHS = ['/usr/local/bin/socat', '/usr/bin/socat']
+const SOCAT_PATH = SOCAT_PATHS.find((p) => existsSync(p)) ?? SOCAT_PATHS[0]
+const hasSocat = existsSync(SOCAT_PATH)
+
+// A serial-to-Ethernet gateway in transparent mode passes raw RTU frames (with
+// CRC) between a TCP socket and a serial line. A single socat instance emulates
+// exactly that: one side is a PTY the Modbux RTU server listens on, the other
+// is a TCP listener the Modbux "RTU over TCP" client connects to. socat relays
+// the bytes verbatim, so the RTU framing matches end to end.
+//
+//   Modbux RTU server ──(pty /tmp/ttyVRTU)── socat ──(tcp 15020)── Modbux RTU-over-TCP client
+//
+// This is the only way to exercise the RTU-over-TCP transport for real: it
+// cannot be validated against Modbux's own ServerTCP, which speaks MBAP.
+const PTY = '/tmp/ttyVRTU'
+const TCP_PORT = '15020'
+
+test.describe.serial('Client RTU over TCP — round-trip via socat gateway', () => {
+  test.skip(!hasSocat, 'socat not available')
+
+  let socatProcess: ChildProcess | null = null
+
+  // ─── socat gateway lifecycle ───────────────────────────────────────
+
+  test('start socat TCP↔serial gateway', async () => {
+    try {
+      unlinkSync(PTY)
+    } catch {
+      /* ignore */
+    }
+
+    // address1 (pty) opens immediately so the RTU server can attach before any
+    // client connects; address2 (tcp-listen) blocks on accept until the client
+    // dials in.
+    socatProcess = spawn(SOCAT_PATH, [
+      '-d',
+      '-d',
+      `pty,raw,echo=0,link=${PTY}`,
+      `tcp-listen:${TCP_PORT},reuseaddr`
+    ])
+
+    // Poll for the pty symlink to appear (max 2s)
+    const deadline = Date.now() + 2000
+    while (Date.now() < deadline) {
+      if (existsSync(PTY)) break
+      await new Promise((r) => setTimeout(r, 100))
+    }
+
+    expect(existsSync(PTY)).toBe(true)
+  })
+
+  // ─── Server setup (RTU on the pty side) ────────────────────────────
+
+  test('clean server state', async ({ mainPage }) => {
+    await cleanServerState(mainPage)
+  })
+
+  test('load basic server config', async ({ mainPage }) => {
+    await loadServerConfig(mainPage, SERVER_CONFIG)
+    await mainPage.waitForTimeout(500)
+
+    await expect(mainPage.getByTestId('section-holding_registers')).toContainText('(2)')
+    await expect(mainPage.getByTestId('section-input_registers')).toContainText('(1)')
+  })
+
+  test('switch server to RTU mode on the pty', async ({ mainPage }) => {
+    await mainPage.getByTestId('server-mode-rtu-btn').click()
+    const comInput = mainPage.getByTestId('server-rtu-com-input').locator('input')
+    await expect(comInput).toBeVisible()
+    await comInput.fill(PTY)
+    await comInput.blur()
+  })
+
+  test('RTU server reports active', async ({ mainPage }) => {
+    await expect(mainPage.getByTestId('server-rtu-status')).toHaveAttribute(
+      'title',
+      'RTU server active',
+      { timeout: 5000 }
+    )
+  })
+
+  // ─── Client setup (RTU over TCP on the socket side) ────────────────
+
+  test('navigate to client and enable RTU over TCP', async ({ mainPage }) => {
+    await navigateToClient(mainPage)
+
+    // Ensure a TCP baseline (state persists across specs in the same worker),
+    // then enable RTU over TCP + advanced mode from the ⚙ options menu. Both
+    // must be set while disconnected — the RTU-over-TCP toggle is disabled once
+    // connected. `.check()` is idempotent, so prior state can't flip it off.
+    await mainPage.getByTestId('protocol-tcp-btn').click()
+    await expect(mainPage.getByTestId('tcp-host-input')).toBeVisible()
+
+    await selectRegisterType(mainPage, 'Holding Registers')
+
+    await mainPage.getByTestId('menu-btn').click()
+    await mainPage.getByTestId('rtu-over-tcp-checkbox').locator('input').check()
+    await mainPage.getByTestId('advanced-mode-checkbox').locator('input').check()
+    await mainPage.keyboard.press('Escape')
+  })
+
+  test('connect to the gateway over TCP', async ({ mainPage }) => {
+    await mainPage.getByTestId('tcp-host-input').locator('input').fill('127.0.0.1')
+    await mainPage.getByTestId('tcp-port-input').locator('input').fill(TCP_PORT)
+    await mainPage.getByTestId('client-unitid-input').locator('input').fill('0')
+
+    await mainPage.getByTestId('connect-btn').click()
+    await expect(mainPage.getByTestId('connect-btn')).toContainText('Disconnect', {
+      timeout: 10_000
+    })
+  })
+
+  // ─── Round-trip reads ──────────────────────────────────────────────
+
+  test('read holding registers 0-1', async ({ mainPage }) => {
+    test.setTimeout(15_000)
+    await selectRegisterType(mainPage, 'Holding Registers')
+    await readRegisters(mainPage, '0', '2')
+
+    // setpoint (int16 @ 0) = 100
+    expect(await cell(mainPage, 0, 'hex')).toBe('0064')
+    expect(await cell(mainPage, 0, 'word_int16')).toBe('100')
+
+    // counter (uint16 @ 1) = 500
+    expect(await cell(mainPage, 1, 'hex')).toBe('01F4')
+    expect(await cell(mainPage, 1, 'word_uint16')).toBe('500')
+  })
+
+  test('read input register 0', async ({ mainPage }) => {
+    test.setTimeout(15_000)
+    await selectRegisterType(mainPage, 'Input Registers')
+    await readRegisters(mainPage, '0', '1')
+
+    // temperature (int16 @ 0) = 200
+    expect(await cell(mainPage, 0, 'hex')).toBe('00C8')
+    expect(await cell(mainPage, 0, 'word_int16')).toBe('200')
+  })
+
+  // ─── Cleanup ───────────────────────────────────────────────────────
+
+  test('disconnect client', async ({ mainPage }) => {
+    await disconnectClient(mainPage)
+  })
+
+  test('disable RTU over TCP (back to plain TCP)', async ({ mainPage }) => {
+    await mainPage.getByTestId('menu-btn').click()
+    await mainPage.getByTestId('rtu-over-tcp-checkbox').locator('input').uncheck()
+    await mainPage.keyboard.press('Escape')
+    await expect(mainPage.getByTestId('protocol-tcp-btn')).toHaveClass(/Mui-selected/)
+  })
+
+  test('switch server back to TCP', async ({ mainPage }) => {
+    await navigateToServer(mainPage)
+    await mainPage.getByTestId('server-mode-tcp-btn').click()
+    await expect(mainPage.getByTestId('server-port-input')).toBeVisible()
+  })
+
+  test('stop socat + remove symlink', async () => {
+    if (socatProcess) {
+      socatProcess.kill()
+      socatProcess = null
+    }
+    try {
+      unlinkSync(PTY)
+    } catch {
+      /* ignore */
+    }
+    expect(existsSync(PTY)).toBe(false)
+  })
+})

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "modbux",
-  "version": "2.2.0-beta.1",
+  "version": "2.2.0",
   "description": "A Modbus Client/Server tool",
   "main": "./out/main/index.js",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "modbux",
-  "version": "2.1.0",
+  "version": "2.2.0-beta.1",
   "description": "A Modbus Client/Server tool",
   "main": "./out/main/index.js",
   "author": {

--- a/src/main/modules/__tests__/modbusClient.test.ts
+++ b/src/main/modules/__tests__/modbusClient.test.ts
@@ -17,7 +17,7 @@ const createMockModbusRTU = () => ({
   setID: vi.fn(),
   connectTCP: vi.fn().mockResolvedValue(undefined),
   connectRTUBuffered: vi.fn().mockResolvedValue(undefined),
-  connectTcpRTUBuffered: vi.fn().mockResolvedValue(undefined),
+  connectTelnet: vi.fn().mockResolvedValue(undefined),
   close: vi.fn((cb: () => void) => cb()),
   destroy: vi.fn((cb: () => void) => cb()),
   readCoils: vi.fn().mockResolvedValue(undefined),
@@ -155,14 +155,17 @@ describe('ModbusClient', () => {
       expect(mockModbusRTU.connectTCP).not.toHaveBeenCalled()
     })
 
-    it('uses encapsulated RTU over TCP when protocol is ModbusRtuOverTcp', async () => {
+    it('uses encapsulated RTU over TCP (raw RTU frames via connectTelnet) when protocol is ModbusRtuOverTcp', async () => {
       appState.updateConnectionConfig({ protocol: 'ModbusRtuOverTcp' })
-      mockModbusRTU.connectTcpRTUBuffered.mockResolvedValue(undefined)
+      mockModbusRTU.connectTelnet.mockResolvedValue(undefined)
 
       await client.connect()
 
-      expect(mockModbusRTU.connectTcpRTUBuffered).toHaveBeenCalledWith('192.168.1.10', {
-        port: 502
+      // connectTelnet sends the RTU frame (with CRC) unchanged over TCP.
+      // connectTCP / connectTcpRTUBuffered would speak MBAP (plain Modbus TCP).
+      expect(mockModbusRTU.connectTelnet).toHaveBeenCalledWith('192.168.1.10', {
+        port: 502,
+        timeout: 5000
       })
       expect(mockModbusRTU.connectTCP).not.toHaveBeenCalled()
       expect(mockModbusRTU.connectRTUBuffered).not.toHaveBeenCalled()

--- a/src/main/modules/__tests__/modbusClient.test.ts
+++ b/src/main/modules/__tests__/modbusClient.test.ts
@@ -17,6 +17,7 @@ const createMockModbusRTU = () => ({
   setID: vi.fn(),
   connectTCP: vi.fn().mockResolvedValue(undefined),
   connectRTUBuffered: vi.fn().mockResolvedValue(undefined),
+  connectTcpRTUBuffered: vi.fn().mockResolvedValue(undefined),
   close: vi.fn((cb: () => void) => cb()),
   destroy: vi.fn((cb: () => void) => cb()),
   readCoils: vi.fn().mockResolvedValue(undefined),
@@ -152,6 +153,19 @@ describe('ModbusClient', () => {
 
       expect(mockModbusRTU.connectRTUBuffered).toHaveBeenCalled()
       expect(mockModbusRTU.connectTCP).not.toHaveBeenCalled()
+    })
+
+    it('uses encapsulated RTU over TCP when protocol is ModbusRtuOverTcp', async () => {
+      appState.updateConnectionConfig({ protocol: 'ModbusRtuOverTcp' })
+      mockModbusRTU.connectTcpRTUBuffered.mockResolvedValue(undefined)
+
+      await client.connect()
+
+      expect(mockModbusRTU.connectTcpRTUBuffered).toHaveBeenCalledWith('192.168.1.10', {
+        port: 502
+      })
+      expect(mockModbusRTU.connectTCP).not.toHaveBeenCalled()
+      expect(mockModbusRTU.connectRTUBuffered).not.toHaveBeenCalled()
     })
 
     it('emits "Already connected" warning if client is open', async () => {

--- a/src/main/modules/modbusClient.ts
+++ b/src/main/modules/modbusClient.ts
@@ -213,14 +213,22 @@ export class ModbusClient {
     rtuOptions['autoOpen'] = true
 
     try {
-      protocol === 'ModbusTcp'
-        ? await this._client.connectTCP(host, tcpOptions)
-        : await this._client.connectRTUBuffered(com, {
-            baudRate: Number(rtuOptions.baudRate),
-            dataBits: rtuOptions.dataBits,
-            stopBits: rtuOptions.stopBits,
-            parity: rtuOptions.parity
-          })
+      if (protocol === 'ModbusTcp') {
+        await this._client.connectTCP(host, tcpOptions)
+      } else if (protocol === 'ModbusRtuOverTcp') {
+        // Encapsulated RTU: a full RTU frame (with CRC) over a TCP socket,
+        // used with serial-to-Ethernet gateways in transparent mode.
+        // Prefer connectTcpRTUBuffered over connectTelnet, which throws
+        // TransactionTimedOutError under repeated/multi-register polling.
+        await this._client.connectTcpRTUBuffered(host, { port: tcp.options.port })
+      } else {
+        await this._client.connectRTUBuffered(com, {
+          baudRate: Number(rtuOptions.baudRate),
+          dataBits: rtuOptions.dataBits,
+          stopBits: rtuOptions.stopBits,
+          parity: rtuOptions.parity
+        })
+      }
       if (this._reconnectTriggered) {
         this._emitMessage({
           message: `Reconnected to server`,

--- a/src/main/modules/modbusClient.ts
+++ b/src/main/modules/modbusClient.ts
@@ -220,7 +220,7 @@ export class ModbusClient {
         // used with serial-to-Ethernet gateways in transparent mode.
         // Prefer connectTcpRTUBuffered over connectTelnet, which throws
         // TransactionTimedOutError under repeated/multi-register polling.
-        await this._client.connectTcpRTUBuffered(host, { port: tcp.options.port })
+        await this._client.connectTcpRTUBuffered(host, { port: tcpOptions.port })
       } else {
         await this._client.connectRTUBuffered(com, {
           baudRate: Number(rtuOptions.baudRate),

--- a/src/main/modules/modbusClient.ts
+++ b/src/main/modules/modbusClient.ts
@@ -216,11 +216,15 @@ export class ModbusClient {
       if (protocol === 'ModbusTcp') {
         await this._client.connectTCP(host, tcpOptions)
       } else if (protocol === 'ModbusRtuOverTcp') {
-        // Encapsulated RTU: a full RTU frame (with CRC) over a TCP socket,
-        // used with serial-to-Ethernet gateways in transparent mode.
-        // Prefer connectTcpRTUBuffered over connectTelnet, which throws
-        // TransactionTimedOutError under repeated/multi-register polling.
-        await this._client.connectTcpRTUBuffered(host, { port: tcpOptions.port })
+        // Encapsulated RTU: a full RTU frame (with CRC) sent raw over a TCP
+        // socket, for serial-to-Ethernet gateways in transparent mode.
+        // connectTelnet writes the RTU frame unchanged; connectTcpRTUBuffered
+        // would instead rewrap it as MBAP (i.e. plain Modbus TCP), which is
+        // not RTU over TCP.
+        await this._client.connectTelnet(host, {
+          port: tcpOptions.port,
+          timeout: tcpOptions.timeout
+        })
       } else {
         await this._client.connectRTUBuffered(com, {
           baudRate: Number(rtuOptions.baudRate),

--- a/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/MenuButton/MenuButton.tsx
+++ b/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/MenuButton/MenuButton.tsx
@@ -14,8 +14,8 @@ import Popover from '@mui/material/Popover'
 const MenuContent = meme(({ setAnchor }: SetAnchorProps) => {
   return (
     <FormGroup>
-      <MenuConnectionOptions />
       <MenuRegisterOptions />
+      <MenuConnectionOptions />
       <ScanUnitIds />
       <ScanRegistersButton setAnchor={setAnchor} />
       <LoadDummyDataButton setAnchor={setAnchor} />

--- a/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/MenuButton/MenuButton.tsx
+++ b/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/MenuButton/MenuButton.tsx
@@ -2,6 +2,7 @@ import { useScanRegistersZustand } from '@renderer/components/client/ClientGrids
 import { meme } from '@renderer/components/shared/inputs/meme'
 import { useRef, useState } from 'react'
 import LoadDummyDataButton from './LoadDummyDataButton/LoadDummyDataButton'
+import MenuConnectionOptions from './MenuConnectionOptions/MenuConnectionOptions'
 import MenuRegisterOptions from './MenuRegisterOptions/MenuRegisterOptions'
 import ScanRegistersButton, { SetAnchorProps } from './ScanRegistersButton/ScanRegistersButton'
 import ScanUnitIds from './ScanUnitIds/ScanUnitIds'
@@ -13,6 +14,7 @@ import Popover from '@mui/material/Popover'
 const MenuContent = meme(({ setAnchor }: SetAnchorProps) => {
   return (
     <FormGroup>
+      <MenuConnectionOptions />
       <MenuRegisterOptions />
       <ScanUnitIds />
       <ScanRegistersButton setAnchor={setAnchor} />

--- a/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/MenuButton/MenuConnectionOptions/MenuConnectionOptions.tsx
+++ b/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/MenuButton/MenuConnectionOptions/MenuConnectionOptions.tsx
@@ -1,7 +1,6 @@
-import Box from '@mui/material/Box'
 import Checkbox from '@mui/material/Checkbox'
+import Divider from '@mui/material/Divider'
 import FormControlLabel from '@mui/material/FormControlLabel'
-import Typography from '@mui/material/Typography'
 import { useRootZustand } from '@renderer/context/root.zustand'
 
 // RTU over TCP (encapsulated RTU) is a niche, TCP-family transport, so it lives
@@ -16,7 +15,7 @@ const MenuConnectionOptions = (): JSX.Element | null => {
   const rtuOverTcp = protocol === 'ModbusRtuOverTcp'
 
   return (
-    <Box>
+    <>
       <FormControlLabel
         disabled={disabled}
         control={
@@ -33,14 +32,8 @@ const MenuConnectionOptions = (): JSX.Element | null => {
         }
         label="RTU over TCP"
       />
-      <Typography
-        variant="caption"
-        color="text.secondary"
-        sx={{ display: 'block', mt: -0.75, ml: 4, mb: 0.5 }}
-      >
-        For serial-to-Ethernet gateways / encapsulated RTU
-      </Typography>
-    </Box>
+      <Divider sx={{ my: 1 }} />
+    </>
   )
 }
 

--- a/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/MenuButton/MenuConnectionOptions/MenuConnectionOptions.tsx
+++ b/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/MenuButton/MenuConnectionOptions/MenuConnectionOptions.tsx
@@ -1,0 +1,47 @@
+import Box from '@mui/material/Box'
+import Checkbox from '@mui/material/Checkbox'
+import FormControlLabel from '@mui/material/FormControlLabel'
+import Typography from '@mui/material/Typography'
+import { useRootZustand } from '@renderer/context/root.zustand'
+
+// RTU over TCP (encapsulated RTU) is a niche, TCP-family transport, so it lives
+// here in the options menu rather than as a third connection toggle. Only shown
+// when TCP is selected; serial RTU has no use for it.
+const MenuConnectionOptions = (): JSX.Element | null => {
+  const protocol = useRootZustand((z) => z.connectionConfig.protocol)
+  const disabled = useRootZustand((z) => z.clientState.connectState !== 'disconnected')
+
+  if (protocol === 'ModbusRtu') return null
+
+  const rtuOverTcp = protocol === 'ModbusRtuOverTcp'
+
+  return (
+    <Box>
+      <FormControlLabel
+        disabled={disabled}
+        control={
+          <Checkbox
+            size="small"
+            checked={rtuOverTcp}
+            onChange={(e) =>
+              useRootZustand
+                .getState()
+                .setProtocol(e.target.checked ? 'ModbusRtuOverTcp' : 'ModbusTcp')
+            }
+            data-testid="rtu-over-tcp-checkbox"
+          />
+        }
+        label="RTU over TCP"
+      />
+      <Typography
+        variant="caption"
+        color="text.secondary"
+        sx={{ display: 'block', mt: -0.75, ml: 4, mb: 0.5 }}
+      >
+        For serial-to-Ethernet gateways / encapsulated RTU
+      </Typography>
+    </Box>
+  )
+}
+
+export default MenuConnectionOptions

--- a/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/MenuButton/MenuRegisterOptions/MenuRegisterOptions.tsx
+++ b/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/MenuButton/MenuRegisterOptions/MenuRegisterOptions.tsx
@@ -1,4 +1,5 @@
 import Checkbox from '@mui/material/Checkbox'
+import Divider from '@mui/material/Divider'
 import FormControlLabel from '@mui/material/FormControlLabel'
 import { useRootZustand } from '@renderer/context/root.zustand'
 
@@ -36,6 +37,7 @@ const MenuRegisterOptions = (): JSX.Element | null => {
         }
         label="Show 64 bit values"
       />
+      <Divider sx={{ my: 1 }} />
     </>
   )
 }

--- a/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/MenuButton/__tests__/MenuOptions.test.tsx
+++ b/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/MenuButton/__tests__/MenuOptions.test.tsx
@@ -1,0 +1,132 @@
+// @vitest-environment happy-dom
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+// The root store registers IPC listeners (window.electron.ipcRenderer) and runs
+// init() (window.api.*) at import time. Stub both before the store is imported.
+vi.hoisted(() => {
+  ;(globalThis as { window?: unknown }).window ??= globalThis
+  const w = window as unknown as { electron: unknown; api: unknown }
+  w.electron = {
+    ipcRenderer: { on: () => () => {}, send: () => {}, invoke: async () => undefined }
+  }
+  w.api = new Proxy({}, { get: () => () => Promise.resolve(undefined) })
+})
+
+import { render, screen, fireEvent } from '@testing-library/react'
+import { useRootZustand } from '@renderer/context/root.zustand'
+import MenuRegisterOptions from '../MenuRegisterOptions/MenuRegisterOptions'
+import MenuConnectionOptions from '../MenuConnectionOptions/MenuConnectionOptions'
+
+// The options menu groups register options / connection options / actions,
+// each section carrying its own trailing divider so empty sections never
+// leave a stray separator. These tests guard that null-behaviour and the
+// RTU-over-TCP toggle without needing a real Modbus server.
+
+const seed = (partial: Parameters<typeof useRootZustand.setState>[0]): void => {
+  useRootZustand.setState(partial as never)
+}
+
+beforeEach(() => {
+  window.api = { updateConnectionConfig: vi.fn() } as never
+  useRootZustand.setState({
+    ready: true,
+    clientState: {
+      connectState: 'disconnected',
+      polling: false,
+      scanningUniId: false,
+      scanningRegisters: false
+    }
+  } as never)
+})
+
+describe('MenuRegisterOptions', () => {
+  it('renders advanced/64-bit options with a trailing divider for 16-bit register types', () => {
+    seed({
+      registerConfig: { ...useRootZustand.getState().registerConfig, type: 'holding_registers' }
+    })
+
+    const { container } = render(<MenuRegisterOptions />)
+
+    expect(screen.getByTestId('advanced-mode-checkbox')).toBeInTheDocument()
+    expect(screen.getByTestId('show-64bit-checkbox')).toBeInTheDocument()
+    expect(container.querySelectorAll('hr')).toHaveLength(1)
+  })
+
+  it('renders nothing (no options, no divider) for non-16-bit register types', () => {
+    seed({ registerConfig: { ...useRootZustand.getState().registerConfig, type: 'coils' } })
+
+    const { container } = render(<MenuRegisterOptions />)
+
+    expect(screen.queryByTestId('advanced-mode-checkbox')).not.toBeInTheDocument()
+    expect(container.querySelectorAll('hr')).toHaveLength(0)
+  })
+})
+
+describe('MenuConnectionOptions', () => {
+  it('renders the RTU-over-TCP checkbox with a trailing divider when TCP is selected', () => {
+    seed({
+      connectionConfig: { ...useRootZustand.getState().connectionConfig, protocol: 'ModbusTcp' }
+    })
+
+    const { container } = render(<MenuConnectionOptions />)
+
+    expect(screen.getByRole('checkbox')).not.toBeChecked()
+    expect(container.querySelectorAll('hr')).toHaveLength(1)
+  })
+
+  it('checks the box when the protocol is RTU over TCP', () => {
+    seed({
+      connectionConfig: {
+        ...useRootZustand.getState().connectionConfig,
+        protocol: 'ModbusRtuOverTcp'
+      }
+    })
+
+    render(<MenuConnectionOptions />)
+
+    expect(screen.getByRole('checkbox')).toBeChecked()
+  })
+
+  it('renders nothing (no checkbox, no divider) for serial RTU', () => {
+    seed({
+      connectionConfig: { ...useRootZustand.getState().connectionConfig, protocol: 'ModbusRtu' }
+    })
+
+    const { container } = render(<MenuConnectionOptions />)
+
+    expect(screen.queryByTestId('rtu-over-tcp-checkbox')).not.toBeInTheDocument()
+    expect(container.querySelectorAll('hr')).toHaveLength(0)
+  })
+
+  it('toggles the protocol between TCP and RTU-over-TCP via the checkbox', () => {
+    seed({
+      connectionConfig: { ...useRootZustand.getState().connectionConfig, protocol: 'ModbusTcp' }
+    })
+
+    render(<MenuConnectionOptions />)
+
+    fireEvent.click(screen.getByTestId('rtu-over-tcp-checkbox'))
+    expect(useRootZustand.getState().connectionConfig.protocol).toBe('ModbusRtuOverTcp')
+    expect(window.api.updateConnectionConfig).toHaveBeenCalledWith({ protocol: 'ModbusRtuOverTcp' })
+
+    fireEvent.click(screen.getByTestId('rtu-over-tcp-checkbox'))
+    expect(useRootZustand.getState().connectionConfig.protocol).toBe('ModbusTcp')
+  })
+
+  it('disables the checkbox while not disconnected', () => {
+    seed({
+      connectionConfig: { ...useRootZustand.getState().connectionConfig, protocol: 'ModbusTcp' },
+      clientState: {
+        connectState: 'connected',
+        polling: false,
+        scanningUniId: false,
+        scanningRegisters: false
+      }
+    } as never)
+
+    render(<MenuConnectionOptions />)
+
+    expect(screen.getByRole('checkbox')).toBeDisabled()
+  })
+})

--- a/src/renderer/src/components/client/ConnectionConfig/ConnectionConfig.tsx
+++ b/src/renderer/src/components/client/ConnectionConfig/ConnectionConfig.tsx
@@ -25,6 +25,12 @@ const ProtocolSelect = meme(({ protocol }: { protocol: Protocol }) => {
 
   // RTU over TCP is a TCP-family transport (toggled from the options menu),
   // so the TCP button stays highlighted for it.
+  //
+  // Switching to serial RTU and back lands on plain TCP by design: the mode
+  // lives in the single `protocol` value, and silently restoring the
+  // encapsulated variant would make "TCP doesn't work" hard to diagnose —
+  // the cause would sit hidden in a menu the user never opens. Anyone who
+  // wants it ticks the box again.
   const toggleValue: Protocol = protocol === 'ModbusRtu' ? 'ModbusRtu' : 'ModbusTcp'
 
   return (

--- a/src/renderer/src/components/client/ConnectionConfig/ConnectionConfig.tsx
+++ b/src/renderer/src/components/client/ConnectionConfig/ConnectionConfig.tsx
@@ -23,13 +23,17 @@ const ProtocolSelect = meme(({ protocol }: { protocol: Protocol }) => {
   const disabled = useRootZustand((z) => z.clientState.connectState !== 'disconnected')
   const setProtocol = useRootZustand((z) => z.setProtocol)
 
+  // RTU over TCP is a TCP-family transport (toggled from the options menu),
+  // so the TCP button stays highlighted for it.
+  const toggleValue: Protocol = protocol === 'ModbusRtu' ? 'ModbusRtu' : 'ModbusTcp'
+
   return (
     <ToggleButtonGroup
       disabled={disabled}
       size="small"
       exclusive
       color="primary"
-      value={protocol}
+      value={toggleValue}
       onChange={(_, v) => v !== null && setProtocol(v)}
     >
       <ToggleButton value={'ModbusTcp'} data-testid="protocol-tcp-btn">
@@ -123,7 +127,8 @@ const ConnectionConfig = meme(() => {
   const protocol = useRootZustand((z) => z.connectionConfig.protocol)
   return (
     <>
-      {protocol === 'ModbusTcp' ? <TcpConfig /> : <RtuConfig />}
+      {/* RTU over TCP reuses the TCP host/port inputs; only serial RTU uses the COM form. */}
+      {protocol === 'ModbusRtu' ? <RtuConfig /> : <TcpConfig />}
       <Box sx={{ display: 'flex', gap: 2 }}>
         <ProtocolSelect protocol={protocol} />
         <UnitId />

--- a/src/shared/types/client.ts
+++ b/src/shared/types/client.ts
@@ -71,7 +71,7 @@ export type Transaction = z.infer<typeof TransactionSchema>
 //
 //
 // Connection config
-export const ProtocolSchema = z.enum(['ModbusTcp', 'ModbusRtu'])
+export const ProtocolSchema = z.enum(['ModbusTcp', 'ModbusRtu', 'ModbusRtuOverTcp'])
 export type Protocol = z.infer<typeof ProtocolSchema>
 
 export const ModbusBaudRateSchema = z.enum([


### PR DESCRIPTION

## Summary

- RTU over TCP (encapsulated RTU) client mode for serial-to-Ethernet gateways
- Enabled from the options menu when TCP is selected — reuses the TCP host/port and unit ID inputs
- Options menu grouped into register options / connection options / actions with dividers
- Unit tests for the menu logic and e2e round-trip through an emulated gateway
- Fixes a pre-existing cross-spec state leak that was breaking the full e2e run
- Validated on real hardware (Moxa 5320 + Eastron SDM630) by the requester — closes #17

## What's changed

### Features

**RTU over TCP client mode** — a new protocol option for serial-to-Ethernet gateways in transparent mode, where plain RTU frames (address + PDU + CRC) are tunnelled over a TCP socket. This is distinct from Modbus TCP, which wraps the PDU in an MBAP header. Enabled via a checkbox in the ⚙ options menu, shown only when TCP is selected (serial RTU has no use for it). It reuses the existing TCP host/port inputs and the unit ID field, so no new configuration surface was added — the TCP toggle stays highlighted and the COM form is reserved for serial RTU.

**Options menu grouping** — the ⚙ menu is now split into register options, connection options, and actions, separated by dividers. Each section renders its own trailing divider, so a hidden section (register options on non-16-bit types, RTU over TCP on serial RTU) never leaves a stray separator.

### Implementation notes

**Transport choice** — `modbus-serial` offers three TCP-family connect methods, and only one of them actually sends RTU over the wire:

| Method | On the wire |
|---|---|
| `connectTCP` | Modbus TCP (MBAP) |
| `connectTcpRTUBuffered` | Modbus TCP (MBAP) — strips the CRC and adds an MBAP header, despite the name |
| `connectTelnet` | Raw RTU frame with CRC — real encapsulated RTU |

The client uses `connectTelnet`. An earlier iteration on this branch used `connectTcpRTUBuffered`, which appeared to work only because it was tested against Modbux's own `ServerTCP` — on the wire it was plain Modbus TCP, so it would have failed against an actual gateway. Commit [`a29cc57`](https://github.com/ploxc/modbux/commit/a29cc57) corrects this.

### Tests

- New `MenuOptions.test.tsx` (7 tests) — register and connection option visibility, divider behaviour when a section is hidden, the RTU-over-TCP toggle, and the disabled state while connected
- New `24-client-rtu-over-tcp.spec.ts` e2e suite (13 tests) — full round-trip over an emulated serial-to-Ethernet gateway: a single `socat` instance bridges a TCP listener to a PTY, with the Modbux RTU server on the serial side and the RTU-over-TCP client on the socket side. Skips when socat is unavailable, mirroring `23-server-rtu.spec.ts`
- Extended `modbusClient.test.ts` to assert the RTU-over-TCP path calls `connectTelnet` and neither TCP nor serial connect method

This transport cannot be exercised against Modbux's own server, which speaks MBAP — the socat gateway is what makes a green end-to-end test possible.

### Fixes

**Cross-spec state leak in the e2e suite** — `21-bitmap-settings` enabled `readConfiguration` and never turned it off. The Electron app fixture is worker-scoped, so that state survived into later specs, and `readConfiguration` disables the manual address/length inputs — which made `23-server-rtu` fail while filling a disabled field. With `maxFailures: 1` the run aborted there, so `24-client-rtu-over-tcp` never executed in a full run.

Fixed with a cleanup test (matching the pattern in `19-large-config`), plus explicit assertions of the `readConfiguration` ↔ input-disabled relationship in both directions, so a future break fails in the spec that owns the behaviour rather than an unrelated one further down the run.

This failure pre-dated the branch — it reproduced identically on `main` (498 pass / 1 fail) and matches the "RTU socat: 39/39 in isolation" note in the v2.1.0 test plan.

## Test plan

- [x] `yarn lint` — no errors
- [x] `yarn typecheck` — no errors
- [x] `yarn test` — 450 unit tests pass
- [x] `yarn test:e2e -- e2e/specs/01-main` — 526 pass (was 498 pass / 1 fail / 25 not run before the state-leak fix)
- [x] `yarn test:e2e -- e2e/specs/01-main/24-client-rtu-over-tcp.spec.ts` — 13/13 pass in isolation
- [x] `yarn test:e2e -- e2e/specs/02-standalone` — 8 pass
- [x] `yarn test:e2e -- e2e/specs/03-presentation` — 38 pass, `cog-menu.png` regenerated with the new menu layout
- [x] `yarn test:e2e -- e2e/specs/99-hardware` — 32 pass against the Arduino iEM3000 emulator over USB serial (needs manual COM port selection at the `page.pause()` steps)
- [x] Full e2e — 604 pass across all four suites (602 before, plus the 2 new readConfiguration assertions in spec 21)
- [x] `yarn build:mac` — produces x64 and arm64 DMGs
- [x] Real hardware (gateway) — Moxa 5320 (RS485 port in transparent mode) reading Eastron SDM630 over WiFi, confirmed by @DV-FB in #17
- [x] Windows — full test run passes (the two socat specs skip themselves, as expected)

### Note on Windows

The two socat-based specs (`23-server-rtu`, `24-client-rtu-over-tcp`) skip themselves when socat is absent, which is the case on Windows — they look for it at `/usr/local/bin/socat` and `/usr/bin/socat`. So the Windows e2e run is expected to report fewer tests than the 604 on macOS, with those two suites skipped rather than failed.

The transport itself is platform-independent (a plain TCP socket), but the options-menu UI and the connect path are worth a manual check on Windows.

## Before merging

- [x] Bump `package.json` to `2.2.0` ([`38dde4e`](https://github.com/ploxc/modbux/commit/38dde4e)) — done on the branch so `main` lands on the right version without a follow-up chore commit
- [x] Move the CHANGELOG `[Unreleased]` section to `[2.2.0]` with the release date
- [x] Keep the `v2.2.0-beta.1` prerelease — it stays linked from #17, and it's a nice record of how the feature was validated
- [x] Windows verification (see the test plan)


---
Closes #17

https://claude.ai/code/session_01LJ74fxYgZhmViUJdVxG6mb
