### PR TITLE
stop the register grid from being sortable

### DIFF
--- a/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGrid.tsx
+++ b/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGrid.tsx
@@ -112,9 +112,6 @@ const RegisterGridContent = (): JSX.Element => {
           height: 36,
           overflow: 'hidden'
         },
-        '& .MuiDataGrid-toolbarContainer': {
-          background: theme.palette.background.default
-        },
         '& .register-error-row': {
           backgroundColor: alpha(theme.palette.error.main, 0.08),
           '&:hover': {
@@ -139,6 +136,11 @@ const RegisterGridContent = (): JSX.Element => {
       localeText={{
         noRowsLabel: 'Connect and read to see registers'
       }}
+      // Registers are read in address order and that order carries meaning, so
+      // nothing here is sortable. Set on the grid rather than per column: the
+      // value columns come out of a factory that never carried the flag, so
+      // eight of them were sortable by accident.
+      disableColumnSorting
       slots={{ toolbar: RegisterGridToolbar, footer: Footer, row: BitMapRow }}
       getCellClassName={({ field, row }) =>
         field === 'groupIndex' && row.groupIndex !== undefined

--- a/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/MenuButton/ScanUnitIds/ScanUnitIds.tsx
+++ b/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/MenuButton/ScanUnitIds/ScanUnitIds.tsx
@@ -236,7 +236,12 @@ const ScanResultGrid = meme(() => {
       rowHeight={40}
       columnHeaderHeight={48}
       getRowHeight={() => 'auto'}
-      sx={(theme) => ({
+      // Results are listed per unit ID and that is the order you look them up
+      // in. The type columns keep their column menu on purpose -- filtering to
+      // "only units that answered for holding registers" is useful; reordering
+      // them is not.
+      disableColumnSorting
+      sx={{
         '& .MuiDataGrid-virtualScrollerContent': {
           fontFamily: 'monospace',
           fontSize: '0.95em'
@@ -245,11 +250,8 @@ const ScanResultGrid = meme(() => {
           minHeight: 36,
           height: 36,
           overflow: 'hidden'
-        },
-        '& .MuiDataGrid-toolbarContainer': {
-          background: theme.palette.background.default
         }
-      })}
+      }}
       localeText={{
         noRowsLabel: 'No scan results yet'
       }}

--- a/src/renderer/src/components/client/ClientGrids/RegisterGrid/columns/address.tsx
+++ b/src/renderer/src/components/client/ClientGrids/RegisterGrid/columns/address.tsx
@@ -4,7 +4,6 @@ import { RegisterData } from '@shared'
 
 export const addressColumn = (addressBase: string): GridColDef<RegisterData, number> => ({
   field: 'id',
-  sortable: false,
   hideable: false,
   headerName: 'Addr.',
   width: 60,

--- a/src/renderer/src/components/client/ClientGrids/RegisterGrid/columns/comment.tsx
+++ b/src/renderer/src/components/client/ClientGrids/RegisterGrid/columns/comment.tsx
@@ -3,7 +3,6 @@ import { RegisterData, RegisterMapObject } from '@shared'
 
 export const commentColumn = (registerMap: RegisterMapObject): GridColDef => ({
   field: 'comment',
-  sortable: false,
   headerName: 'Comment',
   minWidth: 120,
   flex: 1,

--- a/src/renderer/src/components/client/ClientGrids/RegisterGrid/columns/convertedValue.tsx
+++ b/src/renderer/src/components/client/ClientGrids/RegisterGrid/columns/convertedValue.tsx
@@ -27,7 +27,6 @@ export const convertedValueColumn = (
   showRaw: boolean
 ): GridColDef<RegisterData> => ({
   field: 'value',
-  sortable: false,
   hideable: false,
   type: 'string',
   headerName: 'Value',

--- a/src/renderer/src/components/client/ClientGrids/RegisterGrid/columns/dataType.tsx
+++ b/src/renderer/src/components/client/ClientGrids/RegisterGrid/columns/dataType.tsx
@@ -3,7 +3,6 @@ import { DataType, DataTypeSchema, RegisterData, RegisterMapObject } from '@shar
 
 export const dataTypeColumn = (registerMap: RegisterMapObject): GridColDef<RegisterData> => ({
   field: 'dataType',
-  sortable: false,
   headerName: 'Data Type',
   width: 80,
   type: 'singleSelect',

--- a/src/renderer/src/components/client/ClientGrids/RegisterGrid/columns/groupEnd.tsx
+++ b/src/renderer/src/components/client/ClientGrids/RegisterGrid/columns/groupEnd.tsx
@@ -6,7 +6,6 @@ export const groupEndColumn = (
   registerMap: RegisterMapObject
 ): GridColDef<RegisterData, boolean> => ({
   field: 'groupEnd',
-  sortable: false,
   headerName: 'End',
   minWidth: 38,
   maxWidth: 38,

--- a/src/renderer/src/components/client/ClientGrids/RegisterGrid/columns/groupIndex.tsx
+++ b/src/renderer/src/components/client/ClientGrids/RegisterGrid/columns/groupIndex.tsx
@@ -3,7 +3,6 @@ import { RegisterData } from '@shared'
 
 export const groupIndexColumn: GridColDef<RegisterData> = {
   field: 'groupIndex',
-  sortable: false,
   hideable: false,
   disableColumnMenu: true,
   headerName: 'G',

--- a/src/renderer/src/components/client/ClientGrids/RegisterGrid/columns/hex.tsx
+++ b/src/renderer/src/components/client/ClientGrids/RegisterGrid/columns/hex.tsx
@@ -4,7 +4,6 @@ import { RegisterData } from '@shared'
 
 export const hexColumn: GridColDef<RegisterData, string> = {
   field: 'hex',
-  sortable: false,
   headerName: 'HEX',
   width: 50,
   renderCell: ({ value }) => (

--- a/src/renderer/src/components/client/ClientGrids/RegisterGrid/columns/interpolation.tsx
+++ b/src/renderer/src/components/client/ClientGrids/RegisterGrid/columns/interpolation.tsx
@@ -218,7 +218,6 @@ const Action = ({ type, address }: ActionProps): JSX.Element => {
 export const interpolationColumn = (type: RegisterType): GridColDef<RegisterData> => ({
   field: 'interpolation',
   type: 'actions',
-  sortable: false,
   headerName: '',
   minWidth: 40,
   maxWidth: 40,

--- a/src/renderer/src/components/client/ClientGrids/RegisterGrid/columns/scalingFactor.tsx
+++ b/src/renderer/src/components/client/ClientGrids/RegisterGrid/columns/scalingFactor.tsx
@@ -8,7 +8,6 @@ export const scalingFactorColumn = (
   type: RegisterType
 ): GridColDef<RegisterData> => ({
   field: 'scalingFactor',
-  sortable: false,
   headerName: 'Scale',
   width: 60,
   type: 'number',

--- a/src/renderer/src/components/client/ClientGrids/RegisterGrid/columns/write.tsx
+++ b/src/renderer/src/components/client/ClientGrids/RegisterGrid/columns/write.tsx
@@ -62,7 +62,6 @@ const Action = ({ address, type }: ActionProps): JSX.Element => {
 export const writeActionColumn = (type: RegisterType): GridActionsColDef<RegisterData> => ({
   field: 'actions',
   type: 'actions',
-  sortable: false,
   headerName: '',
   minWidth: 40,
   maxWidth: 40,

--- a/src/renderer/src/components/client/ClientGrids/TransactionGrid/TransactionGrid.tsx
+++ b/src/renderer/src/components/client/ClientGrids/TransactionGrid/TransactionGrid.tsx
@@ -86,7 +86,7 @@ const TransactionGridContent = meme(() => {
       columnHeaderHeight={48}
       initialState={{ pagination: { paginationModel: { pageSize: 20, page: 0 } } }}
       getRowHeight={() => 'auto'}
-      sx={(theme) => ({
+      sx={{
         '& .MuiDataGrid-virtualScrollerContent': {
           fontFamily: 'monospace',
           fontSize: '0.95em'
@@ -95,11 +95,8 @@ const TransactionGridContent = meme(() => {
           minHeight: 36,
           height: 36,
           overflow: 'hidden'
-        },
-        '& .MuiDataGrid-toolbarContainer': {
-          background: theme.palette.background.default
         }
-      })}
+      }}
       localeText={{
         noRowsLabel: 'No transactions logged yet'
       }}


### PR DESCRIPTION
## Summary

Sorting the register grid tears multi-word values apart. An INT32 read at
address 0 keeps its second half at address 1, an INT64 spans four addresses,
and the grid renders those continuation rows blank in most columns. Reorder the
rows and the halves separate, so every value on screen becomes wrong — not
merely awkward to read.

Found while using the app, not by a test.

## What's changed

### Fixes

- **The register grid is no longer sortable.** Ten columns already said
  `sortable: false`. The eight value columns did not, because they all come out
  of one `valueColumn()` factory that never carried the flag, and neither did
  the bitmap columns — so the columns showing the values you'd be most tempted
  to sort were exactly the ones left open. `disableColumnSorting` on the grid
  replaces all ten flags and closes the gap for good: a column added later
  cannot forget it.
- **Scan results are no longer sortable either**, for a milder reason: they are
  listed per unit ID and that is how you look them up.
- **Three dead style rules dropped.** All three grids styled
  `.MuiDataGrid-toolbarContainer`, which only exists when you use MUI's own
  `GridToolbar`. `GridHeader` renders a custom toolbar slot bare — in v7 as
  well as v9 — so those rules never applied. Two `sx` callbacks kept a `theme`
  parameter for nothing but that rule and are now plain objects.

### Deliberately unchanged

- **Filtering stays.** It hides rows without reordering them, and
  `readConfiguration` drives it programmatically — turning it off would break
  that feature. The scan grid's type columns keep the column menu they
  explicitly opted into, since filtering to "units that answered for holding
  registers" is worth having; only the sort entries go.
- **The transaction log stays sortable by timestamp.** That column says
  `sortable: true` explicitly and the rest say `false` — a deliberate choice,
  and sorting a log by time does not break anything.

## Test plan

- [x] `yarn lint`
- [x] `yarn typecheck` (node + web + e2e)
- [x] `yarn test` — 450/450
- [x] `yarn test:e2e` — 572/572 (01-main, 02-standalone, 03-presentation)
- [ ] `99-hardware` — not run, no devices attached

## Not a release

Same as #20: worth merging, not worth shipping on its own. Version stays at
2.2.0 and this rides along with the next release.
