### PR TITLE
say which transport a connection is using

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,23 @@ All notable changes to Modbux will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.2.1] - 2026-08-07
 
 ### Changed
 
-- **The download is less than half the size** — 225 MB → 108 MB on macOS. The
-  installer was carrying the entire build toolchain plus a second, unused copy
-  of Electron. Nothing about the app itself changes.
+- **The download is less than half the size** — 170 MB → 82 MB on Windows,
+  225 MB → 108 MB on macOS. The installer was carrying the entire build
+  toolchain plus a second, unused copy of Electron.
+
+### Fixed
+
+- **You can see which transport you are connected over.** RTU over TCP reuses
+  the TCP host and port and keeps the TCP button selected, so nothing told the
+  two apart. Now the connect message names it, and the TCP button and the
+  checkbox in the ⚙ menu both turn orange while it is on.
+- **The register grid no longer sorts.** A 32-bit value keeps its second half
+  in the next register, so reordering the rows pulled the halves apart and every
+  value on screen became wrong. Filtering is unaffected.
 
 ## [2.2.0] - 2026-08-06
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,11 +85,21 @@ Don't use `feat` for a bug fix. Don't use `fix` for a refactor. Mean what you sa
 |---------|-------------|
 | `yarn test` | Unit tests (Vitest) |
 | `yarn test:watch` | Unit tests in watch mode |
-| `yarn test:e2e` | Build + full e2e suite (Playwright) |
+| `yarn test:e2e` | Build + the e2e suite (Playwright) |
 | `yarn test:e2e:packaged` | Same specs against the packaged app. Run before releasing. |
 | `yarn test:e2e:hardware` | The `99-hardware` specs. Needs an Arduino and someone at the keyboard. |
-| `yarn presentation` | Screenshot & demo generation |
+| `yarn presentation` | Build + regenerate the documentation screenshots |
 | `yarn checkup` | **Everything.** Lint + typecheck + unit + e2e. Run this before pushing. |
+
+`test:e2e` covers `01-main` and `02-standalone`. Two suites sit outside it and
+are invoked on purpose:
+
+- `99-hardware` waits for an Arduino and for someone to pick the COM port, so an
+  unattended run never finishes.
+- `03-presentation` is a documentation utility, not a check. It clicks through
+  the app and captures what it sees without asserting much, so it costs two
+  minutes to tell you little that `01-main` does not already cover. Run it when
+  the UI changed and the manual needs new screenshots.
 
 `checkup` deliberately leaves out `test:e2e:packaged` — it adds a full packaging
 step and runs far longer, which is too much for every push. Run it before
@@ -124,7 +134,7 @@ you walked away from — that is not a failure, it is a run that never ends. Use
   freshly loaded mapping is on its way, and a snapshot gets no second chance.
 - Use `data-testid` attributes for selectors. Never select by CSS class or DOM structure.
 - Spec files are numbered and ordered. New specs go at the end of their directory.
-- Presentation tests (`03-presentation/`) generate screenshots for the documentation site. If you change UI, update the relevant scenes.
+- Presentation scenes (`03-presentation/`) generate the documentation screenshots and are excluded from the default run. If you change UI, update the relevant scenes and run `yarn presentation`.
 
 ## Pull requests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,7 @@ Don't use `feat` for a bug fix. Don't use `fix` for a refactor. Mean what you sa
 | `yarn test:watch` | Unit tests in watch mode |
 | `yarn test:e2e` | Build + full e2e suite (Playwright) |
 | `yarn test:e2e:packaged` | Same specs against the packaged app. Run before releasing. |
+| `yarn test:e2e:hardware` | The `99-hardware` specs. Needs an Arduino and someone at the keyboard. |
 | `yarn presentation` | Screenshot & demo generation |
 | `yarn checkup` | **Everything.** Lint + typecheck + unit + e2e. Run this before pushing. |
 
@@ -98,6 +99,13 @@ ships. `electron-vite` externalizes whatever sits in `dependencies` and
 that drifts into `devDependencies` passes every normal test and breaks only once
 installed. Packaged runs use a throwaway user-data directory and never touch an
 installed Modbux's config.
+
+`playwright.config.ts` ignores `99-hardware`, so neither `test:e2e` nor
+`test:e2e:packaged` picks those specs up. They are conditional: they need an
+Arduino running `tools/arduino/iem3000.ino` on a serial port, and they stop at a
+`page.pause()` for someone to choose the COM port. In a pipeline — or in any run
+you walked away from — that is not a failure, it is a run that never ends. Use
+`yarn test:e2e:hardware` when the hardware is actually on your desk.
 
 ### Test expectations
 

--- a/README.md
+++ b/README.md
@@ -177,6 +177,17 @@ config of an installed Modbux.
 On macOS and Linux the two socat specs run as well; on Windows they are skipped
 because socat is unavailable, which is why a Windows run reports 36 skipped.
 
+**Run the hardware E2E tests:**
+
+```bash
+yarn test:e2e:hardware
+```
+
+These are left out of the normal runs. They talk to an Arduino running
+`tools/arduino/iem3000.ino` over a serial port and pause partway through so you
+can pick the COM port, so they only make sense with the hardware in front of
+you.
+
 ### Build
 
 **Create a distributable package for your platform:**

--- a/e2e/specs/03-presentation/01-feature-tour.spec.ts
+++ b/e2e/specs/03-presentation/01-feature-tour.spec.ts
@@ -805,8 +805,36 @@ test.describe.serial('Act IV — Interaction', () => {
 let serverPage: Page
 
 test.describe.serial('Act V — Side by Side', () => {
-  test('scene 30 — split view', async ({ electronApp, mainPage }) => {
+  test('scene 29b — RTU over TCP in the cog menu', async ({ mainPage }) => {
+    // Only reachable while disconnected: the transport cannot change mid-session.
+    // The warning colour is the whole point -- it is what turns the TCP button
+    // warning too, and that is the only thing telling the two TCP transports
+    // apart, since RTU over TCP reuses the same host and port.
     await disconnectClient(mainPage)
+    await mainPage.getByTestId('menu-btn').click()
+    await beat(mainPage, 300)
+
+    const popover = mainPage.locator('.MuiPopover-paper')
+    const rtuOverTcp = mainPage.getByTestId('rtu-over-tcp-checkbox')
+    await rtuOverTcp.click()
+    // Park the pointer and the focus away from the checkbox: the hover ripple
+    // it leaves behind otherwise dominates the shot. The popover closes on
+    // click, not on mouse-out, so moving away is safe.
+    await mainPage.mouse.move(5, 5)
+    await mainPage.evaluate(() => (document.activeElement as HTMLElement | null)?.blur())
+    await beat(mainPage, 400)
+    await popover.screenshot({ path: resolve(SHOTS, 'cog-menu-rtu-over-tcp.png') })
+
+    await rtuOverTcp.click()
+    await beat(mainPage, 200)
+    await mainPage.keyboard.press('Escape')
+    await beat(mainPage, 300)
+
+    // The TCP button back on primary, ready for the split view scenes.
+    await snap(mainPage, 'client-rtu-over-tcp-off')
+  })
+
+  test('scene 30 — split view', async ({ mainPage, electronApp }) => {
     await navigateToHome(mainPage)
     await beat(mainPage, 3500)
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "test:e2e": "electron-vite build && playwright test",
     "test:e2e:packaged": "electron-vite build && electron-builder --dir && playwright test --config playwright.packaged.config.ts",
     "test:e2e:hardware": "electron-vite build && playwright test --config playwright.hardware.config.ts",
-    "presentation": "npx playwright test --config playwright.presentation.config.ts",
+    "presentation": "electron-vite build && playwright test --config playwright.presentation.config.ts",
     "checkup": "yarn lint && yarn typecheck && yarn test && yarn test:e2e",
     "socat": "socat -d -d pty,raw,echo=0,link=/tmp/ttyV0 pty,raw,echo=0,link=/tmp/ttyV1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "modbux",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "A Modbus Client/Server tool",
   "main": "./out/main/index.js",
   "author": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "test:watch": "vitest",
     "test:e2e": "electron-vite build && playwright test",
     "test:e2e:packaged": "electron-vite build && electron-builder --dir && playwright test --config playwright.packaged.config.ts",
+    "test:e2e:hardware": "electron-vite build && playwright test --config playwright.hardware.config.ts",
     "presentation": "npx playwright test --config playwright.presentation.config.ts",
     "checkup": "yarn lint && yarn typecheck && yarn test && yarn test:e2e",
     "socat": "socat -d -d pty,raw,echo=0,link=/tmp/ttyV0 pty,raw,echo=0,link=/tmp/ttyV1"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,11 +2,17 @@ import { defineConfig } from '@playwright/test'
 
 export default defineConfig({
   testDir: './e2e/specs',
+  // Two suites stay out of the always-on pipeline.
+  //
   // The hardware specs need an Arduino on a serial port and a human to pick the
-  // COM port at a page.pause(), so an unattended run sits there forever. They
-  // are conditional by nature and stay out of the always-on pipeline; run them
-  // with `yarn test:e2e:hardware`.
-  testIgnore: '**/99-hardware/**',
+  // COM port at a page.pause(), so an unattended run sits there forever. Run
+  // them with `yarn test:e2e:hardware`.
+  //
+  // The presentation tour produces the manual's screenshots. It clicks through
+  // the app and captures what it sees; it barely asserts anything, so it costs
+  // two minutes to tell you little that 01-main does not already check. Run it
+  // when you want fresh screenshots, with `yarn presentation`.
+  testIgnore: ['**/99-hardware/**', '**/03-presentation/**'],
   timeout: 60000,
   retries: 0,
   workers: 1,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,6 +2,11 @@ import { defineConfig } from '@playwright/test'
 
 export default defineConfig({
   testDir: './e2e/specs',
+  // The hardware specs need an Arduino on a serial port and a human to pick the
+  // COM port at a page.pause(), so an unattended run sits there forever. They
+  // are conditional by nature and stay out of the always-on pipeline; run them
+  // with `yarn test:e2e:hardware`.
+  testIgnore: '**/99-hardware/**',
   timeout: 60000,
   retries: 0,
   workers: 1,

--- a/playwright.hardware.config.ts
+++ b/playwright.hardware.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from '@playwright/test'
+import base from './playwright.config'
+
+// The way back into the specs playwright.config.ts leaves out. Requires an
+// Arduino running tools/arduino/iem3000.ino on a serial port, and a person to
+// select the COM port when the run pauses for it.
+export default defineConfig({
+  ...base,
+  testDir: './e2e/specs/99-hardware',
+  testIgnore: []
+})

--- a/playwright.presentation.config.ts
+++ b/playwright.presentation.config.ts
@@ -1,10 +1,14 @@
 import { defineConfig } from '@playwright/test'
+import base from './playwright.config'
 
+// The way back into the presentation tour that playwright.config.ts leaves out.
+// Spreads the base config so workers/retries/maxFailures stay in one place, and
+// overrides only what this suite genuinely needs: a longer timeout for the
+// deliberate pauses between scenes, and its own output directory.
 export default defineConfig({
+  ...base,
   testDir: './e2e/specs/03-presentation',
+  testIgnore: [],
   timeout: 120000,
-  retries: 0,
-  workers: 1,
-  maxFailures: 1,
   outputDir: './e2e/presentation-output/test-results'
 })

--- a/src/main/modules/__tests__/modbusClient.test.ts
+++ b/src/main/modules/__tests__/modbusClient.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import type { Windows } from '@shared'
+import type { Protocol, Windows } from '@shared'
 import { AppState } from '../../state'
 
 // Track event handlers registered on the mock ModbusRTU client
@@ -200,7 +200,7 @@ describe('ModbusClient', () => {
       expect(messages.some((m) => m[1].message.includes('not found or not available'))).toBe(true)
     })
 
-    it('emits "Reconnected" message on successful reconnect', async () => {
+    it('emits "Reconnected" message naming the transport', async () => {
       await connectClient()
       // Simulate connection loss — isOpen goes false
       mockModbusRTU.isOpen = false
@@ -211,7 +211,20 @@ describe('ModbusClient', () => {
       await vi.advanceTimersByTimeAsync(3500)
 
       const messages = getWindowCalls('backend_message')
-      expect(messages.some((m) => m[1].message === 'Reconnected to server')).toBe(true)
+      expect(messages.some((m) => m[1].message === 'Reconnected over Modbus TCP')).toBe(true)
+    })
+
+    it.each([
+      ['ModbusTcp', 'Connected over Modbus TCP'],
+      ['ModbusRtuOverTcp', 'Connected over RTU over TCP'],
+      ['ModbusRtu', 'Connected over Modbus RTU']
+    ])('names the transport in the connect message for %s', async (protocol, expected) => {
+      appState.updateConnectionConfig({ protocol: protocol as Protocol })
+
+      await client.connect()
+
+      const messages = getWindowCalls('backend_message')
+      expect(messages.some((m) => m[1].message === expected)).toBe(true)
     })
 
     it('resets consecutive reconnects after 10s stability', async () => {

--- a/src/main/modules/modbusClient.ts
+++ b/src/main/modules/modbusClient.ts
@@ -10,6 +10,7 @@ import {
   createRegisters,
   groupAddressInfos,
   humanizeSerialError,
+  PROTOCOL_LABELS,
   RawTransaction,
   RegisterData,
   RegisterType,
@@ -235,7 +236,7 @@ export class ModbusClient {
       }
       if (this._reconnectTriggered) {
         this._emitMessage({
-          message: `Reconnected to server`,
+          message: `Reconnected over ${PROTOCOL_LABELS[protocol]}`,
           variant: 'success',
           error: null
         })
@@ -247,7 +248,7 @@ export class ModbusClient {
         }, 1000)
       } else {
         this._emitMessage({
-          message: 'Connected to server',
+          message: `Connected over ${PROTOCOL_LABELS[protocol]}`,
           variant: 'success',
           error: null
         })

--- a/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/MenuButton/MenuConnectionOptions/MenuConnectionOptions.tsx
+++ b/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/MenuButton/MenuConnectionOptions/MenuConnectionOptions.tsx
@@ -21,6 +21,10 @@ const MenuConnectionOptions = (): JSX.Element | null => {
         control={
           <Checkbox
             size="small"
+            // Warning colour here and on the TCP button, so ticking the box
+            // shows you straight away which control out on the toolbar is
+            // going to change.
+            color="warning"
             checked={rtuOverTcp}
             onChange={(e) =>
               useRootZustand

--- a/src/renderer/src/components/client/ConnectionConfig/ConnectionConfig.tsx
+++ b/src/renderer/src/components/client/ConnectionConfig/ConnectionConfig.tsx
@@ -6,7 +6,8 @@ import {
   InputBaseComponentProps,
   TextField,
   ToggleButton,
-  ToggleButtonGroup
+  ToggleButtonGroup,
+  Tooltip
 } from '@mui/material'
 import RtuConfig from './RtuConfig/RtuConfig'
 import TcpConfig from './TcpConfig/TcpConfig'
@@ -24,14 +25,26 @@ const ProtocolSelect = meme(({ protocol }: { protocol: Protocol }) => {
   const setProtocol = useRootZustand((z) => z.setProtocol)
 
   // RTU over TCP is a TCP-family transport (toggled from the options menu),
-  // so the TCP button stays highlighted for it.
+  // so the TCP button stays highlighted for it -- but in warning colour, since
+  // it reuses the same host and port and would otherwise be indistinguishable
+  // from plain TCP.
   //
   // Switching to serial RTU and back lands on plain TCP by design: the mode
   // lives in the single `protocol` value, and silently restoring the
-  // encapsulated variant would make "TCP doesn't work" hard to diagnose —
-  // the cause would sit hidden in a menu the user never opens. Anyone who
-  // wants it ticks the box again.
+  // encapsulated variant would make "TCP doesn't work" hard to diagnose.
+  // Anyone who wants it ticks the box again.
+  const rtuOverTcp = protocol === 'ModbusRtuOverTcp'
   const toggleValue: Protocol = protocol === 'ModbusRtu' ? 'ModbusRtu' : 'ModbusTcp'
+
+  const tcpButton = (
+    <ToggleButton
+      value={'ModbusTcp'}
+      data-testid="protocol-tcp-btn"
+      color={rtuOverTcp ? 'warning' : 'primary'}
+    >
+      TCP
+    </ToggleButton>
+  )
 
   return (
     <ToggleButtonGroup
@@ -42,9 +55,13 @@ const ProtocolSelect = meme(({ protocol }: { protocol: Protocol }) => {
       value={toggleValue}
       onChange={(_, v) => v !== null && setProtocol(v)}
     >
-      <ToggleButton value={'ModbusTcp'} data-testid="protocol-tcp-btn">
-        TCP
-      </ToggleButton>
+      {rtuOverTcp ? (
+        <Tooltip title="RTU over TCP is on: raw RTU frames over the socket, not Modbus TCP. Turn it off in the cog menu.">
+          {tcpButton}
+        </Tooltip>
+      ) : (
+        tcpButton
+      )}
       <ToggleButton value={'ModbusRtu'} data-testid="protocol-rtu-btn">
         RTU
       </ToggleButton>

--- a/src/shared/types/client.ts
+++ b/src/shared/types/client.ts
@@ -74,6 +74,17 @@ export type Transaction = z.infer<typeof TransactionSchema>
 export const ProtocolSchema = z.enum(['ModbusTcp', 'ModbusRtu', 'ModbusRtuOverTcp'])
 export type Protocol = z.infer<typeof ProtocolSchema>
 
+/**
+ * How each transport is named to the user. RTU over TCP is the one worth
+ * spelling out: it reuses the TCP host and port and keeps the TCP button
+ * selected, so nothing on screen distinguishes it from plain TCP.
+ */
+export const PROTOCOL_LABELS: Record<Protocol, string> = {
+  ModbusTcp: 'Modbus TCP',
+  ModbusRtu: 'Modbus RTU',
+  ModbusRtuOverTcp: 'RTU over TCP'
+}
+
 export const ModbusBaudRateSchema = z.enum([
   '1200',
   '2400',

--- a/tsconfig.e2e.json
+++ b/tsconfig.e2e.json
@@ -7,7 +7,8 @@
     "src/preload/*.d.ts",
     "playwright.config.ts",
     "playwright.packaged.config.ts",
-    "playwright.presentation.config.ts"
+    "playwright.presentation.config.ts",
+    "playwright.hardware.config.ts"
   ],
   "compilerOptions": {
     "strict": true,


### PR DESCRIPTION
## Summary

RTU over TCP reuses the TCP host, port and unit ID, and keeps the TCP button
selected, so nothing on screen told the two apart. Leave the box ticked, come
back later, and "TCP doesn't work" has its cause sitting in a menu you never
open.

That is not hypothetical — it is how it went wrong in practice, and it is the
case [#19](https://github.com/ploxc/modbux/pull/19) predicted in a comment while
deciding it was niche enough to leave alone. It isn't.

## What's changed

### Fixes

Nothing new becomes possible here — the app already spoke all three transports.
It just never said which one, and that is what made it hard to diagnose.

- **The connect message names the transport** — `Connected over Modbus TCP`,
  `over RTU over TCP`, `over Modbus RTU`. The same for a reconnect, where you
  did not choose to connect at all. Nothing about port or baud rate: those are
  already on screen in the topbar.
- **The TCP button turns warning** while RTU over TCP is on, with a tooltip
  saying what it does and where to switch it off.
- **The cog-menu checkbox is warning too**, so ticking it shows you straight
  away which control out on the toolbar is about to change colour.

Three signals at the three moments that matter: when you set it, for as long as
it is on, and when you connect.

### Implementation notes

`PROTOCOL_LABELS` lives in `src/shared/types/client.ts` as a
`Record<Protocol, string>` — main needs it for the message, the renderer for the
tooltip, and a fourth transport cannot be added without naming it.

The comment in `ConnectionConfig` said we deliberately show nothing here, and
that switching to serial RTU and back drops the encapsulated variant on purpose.
The second half still holds; the first no longer does, and the comment now says
so.

### Tests

- Three new unit cases pin the label per transport rather than leaving one of
  them to ride along with an existing assertion. The old test asserted the
  literal string `Reconnected to server`, so it had to move regardless.
- A presentation scene captures the ticked checkbox. It only exists while
  disconnected — the transport cannot change mid-session — so it sits at the top
  of Act V rather than beside the other cog-menu shot in Act III.

## Test plan

- [x] `yarn lint`
- [x] `yarn typecheck` (node + web + e2e)
- [x] `yarn test` — 453/453
- [x] `yarn test:e2e` — 573/573 (01-main, 02-standalone, 03-presentation)
- [ ] `99-hardware` — not run, no devices attached

## Worth releasing, as a patch

#20 and #21 were each merged without a release: a smaller installer and a
sorting fix are both real, but neither gives an existing install a reason to
update, and a banner that delivers nothing you can see teaches people to ignore
banners.

This is visible, so there is now a reason — and the other two ship with it:

- the download is less than half the size (170.4 → 81.5 MB on Windows,
  225 → 108 MB on macOS)
- sorting no longer tears multi-word values apart
- you can see which transport you are connected over

All three are patch-shaped. Nothing here is new functionality: the transports
already worked, the registers already read, the installer already installed.
So **2.2.1**, with the CHANGELOG's `Unreleased` section renamed and these
folded in.
