### PR TITLE
Let the bit list scroll inside its own panel

### DIFF
--- a/e2e/specs/01-main/26-server-layout.spec.ts
+++ b/e2e/specs/01-main/26-server-layout.spec.ts
@@ -29,9 +29,12 @@ test.describe.serial('Server layout — panels stay inside the view', () => {
     [820, 800]
   ] as [number, number][]) {
     test(`no overflow at ${width}x${height}`, async ({ mainPage, electronApp }) => {
-      await electronApp.evaluate(({ BrowserWindow }, size) => {
-        BrowserWindow.getAllWindows()[0].setSize(size[0], size[1])
-      }, [width, height])
+      await electronApp.evaluate(
+        ({ BrowserWindow }, size) => {
+          BrowserWindow.getAllWindows()[0].setSize(size[0], size[1])
+        },
+        [width, height]
+      )
       await mainPage.waitForTimeout(500)
 
       const overflow = await mainPage

--- a/e2e/specs/01-main/26-server-layout.spec.ts
+++ b/e2e/specs/01-main/26-server-layout.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from '../../fixtures/electron-app'
+import { navigateToServer, addBool } from '../../fixtures/helpers'
+
+/**
+ * The server view lays its four panels out in a wrapping flex row. Nothing
+ * bounds their height, so a panel grows with its contents and the overflow it
+ * carries lands on the container instead of on the list inside the panel.
+ *
+ * It only shows once there is enough in a panel to outgrow the space, which is
+ * why filling the bit lists comes first. The window is a fixed size and a
+ * smaller screen clamps it, so how visible this is depends on the machine.
+ */
+const DEFAULT_SIZE: [number, number] = [1480, 1000]
+const BITS = 14
+
+test.describe.serial('Server layout — panels stay inside the view', () => {
+  test('fill both bit lists', async ({ mainPage }) => {
+    await navigateToServer(mainPage)
+    for (let i = 0; i < BITS; i++) {
+      await addBool(mainPage, 'coils', i, true)
+      await addBool(mainPage, 'discrete_inputs', i, true)
+    }
+    await expect(mainPage.getByTestId(`server-bool-row-coils-${BITS - 1}`)).toBeVisible()
+  })
+
+  for (const [width, height] of [
+    [1200, 900],
+    [1024, 768],
+    [820, 800]
+  ] as [number, number][]) {
+    test(`no overflow at ${width}x${height}`, async ({ mainPage, electronApp }) => {
+      await electronApp.evaluate(({ BrowserWindow }, size) => {
+        BrowserWindow.getAllWindows()[0].setSize(size[0], size[1])
+      }, [width, height])
+      await mainPage.waitForTimeout(500)
+
+      const overflow = await mainPage
+        .getByTestId('server-grid')
+        .evaluate((el: HTMLElement) => el.scrollHeight - el.clientHeight)
+
+      expect(overflow).toBeLessThanOrEqual(1)
+    })
+  }
+
+  test('restore the window', async ({ electronApp }) => {
+    await electronApp.evaluate(({ BrowserWindow }, size) => {
+      BrowserWindow.getAllWindows()[0].setSize(size[0], size[1])
+    }, DEFAULT_SIZE)
+  })
+})

--- a/src/renderer/src/components/server/ServerGrid/ServerBooleans/ServerBooleans.tsx
+++ b/src/renderer/src/components/server/ServerGrid/ServerBooleans/ServerBooleans.tsx
@@ -219,18 +219,30 @@ const ServerBooleans = meme(({ name, type }: ServerBooleanProps) => {
       <Paper
         variant="outlined"
         sx={{
+          flex: 1,
           width: '100%',
           height: '100%',
           backgroundColor: '#2A2A2A',
           fontSize: '0.95em',
-          display: 'flex',
-          flexDirection: 'column'
+          position: 'relative'
         }}
       >
         <ServerPartTitle name={name} registerType={type} />
+        {/*
+          Positioned rather than flexed, the way ServerRegisters does it. A
+          flex child takes its share of a parent that has a height, and this
+          one does not: the Paper asks for 100% of a box that only carries a
+          minHeight. So the list grew instead, and the overflow landed on the
+          view rather than here. Anchored top to bottom, the height comes from
+          the Paper and the scrollbar appears where it belongs.
+        */}
         <Box
           sx={{
-            flex: 1,
+            position: 'absolute',
+            top: 38,
+            left: 0,
+            right: 0,
+            bottom: 0,
             overflow: 'auto',
             display: 'flex',
             gap: 0,

--- a/src/renderer/src/components/server/ServerGrid/ServerGrid.tsx
+++ b/src/renderer/src/components/server/ServerGrid/ServerGrid.tsx
@@ -5,7 +5,10 @@ import Box from '@mui/material/Box'
 
 const ServerGrid = (): JSX.Element => {
   return (
-    <Box sx={{ height: '100%', minHeight: 0, display: 'flex', gap: 2, flexWrap: 'wrap' }}>
+    <Box
+      data-testid="server-grid"
+      sx={{ height: '100%', minHeight: 0, display: 'flex', gap: 2, flexWrap: 'wrap' }}
+    >
       <ServerBooleans name="Coils" type={'coils'} />
       <ServerBooleans name="Discrete Inputs" type={'discrete_inputs'} />
       <ServerRegisters name="Input Registers" type={'input_registers'} />


### PR DESCRIPTION
On a laptop screen the coils and discrete inputs panels grew past the server view and the whole thing scrolled underneath them. Which is the wrong half moving: the panel already carries a scroll area for exactly this.

That area never came into play. A flex child takes its share of a parent that has a height, and this one has none — the Paper asks for 100% of a box that only carries a `minHeight`, and 100% of auto is auto. So the list grew instead, and the overflow landed on the view.

`ServerRegisters` never had the problem. It anchors its content top to bottom rather than flexing it, so the height comes from the Paper and cannot follow the contents. `ServerBooleans` now does the same.

The percentages still size the panels and collapsing still works.

## Why now

The layout is not what changed. `git diff v1.4.2 -- ServerGrid.tsx` leaves that flex container’s `sx` untouched — only a removed import, and the `data-testid` this PR adds for the spec.

What changed is the content. A bit used to be a button in a wrapping row and is now a row of its own, so the same count of bits fills far more height and reaches a limit that was always missing.

## Tests

`26-server-layout.spec.ts` fills both bit lists and resizes the window, because neither a full list nor a small window shows this alone. It covers 1200x900, 1024x768, and 820x800 — the last being the app’s own `minWidth`/`minHeight`— and restores the window afterwards so later specs do not inherit a small one.

Written before the fix, and red on the unfixed code:

```
✘ no overflow at 1200x900
  Expected: <= 1
  Received: 18
```

Lint, typecheck, unit and the full e2e suite are green locally in both modes, and on all five runners.

Draft because the fix is visual: a green suite proves the overflow is gone, not that it looks right.
