### PR TITLE
Move glob off the version an advisory names

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4961,8 +4961,8 @@ __metadata:
   linkType: hard
 
 "glob@npm:^10.2.2":
-  version: 10.4.5
-  resolution: "glob@npm:10.4.5"
+  version: 10.5.0
+  resolution: "glob@npm:10.5.0"
   dependencies:
     foreground-child: "npm:^3.1.0"
     jackspeak: "npm:^3.1.2"
@@ -4972,7 +4972,7 @@ __metadata:
     path-scurry: "npm:^1.11.1"
   bin:
     glob: dist/esm/bin.mjs
-  checksum: 10c0/19a9759ea77b8e3ca0a43c2f07ecddc2ad46216b786bb8f993c445aee80d345925a21e5280c7b7c6c59e860a0154b84e4b2b60321fea92cd3c56b4a7489f160e
+  checksum: 10c0/100705eddbde6323e7b35e1d1ac28bcb58322095bd8e63a7d0bef1a2cdafe0d0f7922a981b2b48369a4f8c1b077be5c171804534c3509dfe950dde15fbe6d828
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes the reporting half of #25, and nothing else. Read the next section before assuming otherwise.

`cacache` asks for `glob@^10.2.2` and the lockfile sat on 10.4.5. 10.5.0 satisfies the same range, so `yarn up -R glob` moves it and leaves everything else where it was.

## What this does not do

It buys no safety. The advisory is about glob’s CLI flag `-c/--cmd`, which nothing here invokes, and `glob` is not in `dependencies`, so it never reaches the asar. It clears a line from the alert list. That is the whole of it.

The patch #25 proposes should not be applied either way: its "safe" example passes `argv0` to `execSync`, which sets the process name rather than an argument, so it does not do what the text says it does.

## What it leaves

`yarn why glob` gives three chains. Only the first is on the version the advisory names:

```
glob 10.5.0 ← cacache ← make-fetch-happen ← node-gyp ← @serialport/bindings-cpp
                                                     ← @electron/rebuild
                                                     ← fsevents
glob  7.2.3 ← @electron/asar ← app-builder-lib ← electron-builder
glob  7.2.3 ← rimraf ← flat-cache ← file-entry-cache ← eslint
```

No direct dependency sits on any of them, so upgrading something we own moves none of it. Neither does #27: `yarn why glob` on that branch reports the same resolution as here.

Lint, typecheck, the unit tests and the full e2e suite are green locally in both modes, and on all five runners. Windows failed once on the first attempt, with the Electron process gone by the second spec, and passed on the re-run.
