### PR TITLE
Filter the columns worth filtering, and clear them from the toolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   You see the command before it runs, and the elevation goes through PolicyKit,
   so you approve it yourself and Modbux never sees your password. Inside
   Flatpak or Snap it hands you the command instead.
+- **A button that clears the filters you set.** It sits next to RAW in the
+  client toolbar and shows up only while a filter is on, so a filter left behind
+  no longer reads as missing data.
+
+### Changed
+
+- **Only the columns worth filtering still offer a filter.** Addr., Bit and BIN
+  lost theirs: a filter over an address or a row of LEDs answers nothing anyone
+  asks. HEX and the value columns keep theirs, because a status word or a fault
+  code from the manual is often exactly what you are hunting for.
+- **Reading a configuration turns filtering off.** That mode already hides the
+  rows without a data type, and a filter of your own could fight it or take it
+  away from the column menu, leaving the list full of empty rows.
 
 ### Fixed
 

--- a/e2e/fixtures/helpers.ts
+++ b/e2e/fixtures/helpers.ts
@@ -656,3 +656,20 @@ export async function getServer2Port(p: Page): Promise<string> {
   await navigateToClient(p)
   return port
 }
+
+/** Open the column menu of one grid column. The trigger only renders on hover. */
+export async function openColumnMenu(p: Page, field: string): Promise<void> {
+  await test.step(`open column menu of ${field}`, async () => {
+    // A menu closed a moment ago is still mounted while it fades, so wait it
+    // out before opening the next one -- two menu lists at once make every
+    // locator below ambiguous.
+    const menu = p.locator('.MuiDataGrid-menuList')
+    await expect(menu).toHaveCount(0)
+
+    const header = p.locator(`.MuiDataGrid-columnHeader[data-field="${field}"]`)
+    await header.hover()
+    await header.locator('.MuiDataGrid-menuIconButton').click()
+    // Not getByRole('menu'): the action cells carry that role too.
+    await expect(menu).toBeVisible()
+  })
+}

--- a/e2e/specs/01-main/15-client-toolbar.spec.ts
+++ b/e2e/specs/01-main/15-client-toolbar.spec.ts
@@ -11,7 +11,8 @@ import {
   disableReadConfiguration,
   cleanServerState,
   loadServerConfig,
-  expectCell
+  expectCell,
+  openColumnMenu
 } from '../../fixtures/helpers'
 import { resolve } from 'path'
 
@@ -405,6 +406,91 @@ test.describe.serial('Client toolbar — display options and utilities', () => {
     // Verify grid has data
     const rowCount = await mainPage.locator('.MuiDataGrid-row').count()
     expect(rowCount).toBeGreaterThan(0)
+  })
+
+  // ─── Column filters ─────────────────────────────────────────────────
+
+  test('clear filters button is hidden while nothing is filtered', async ({ mainPage }) => {
+    await expect(mainPage.getByTestId('clear-filters-btn')).not.toBeVisible()
+  })
+
+  test('filtering on hex reveals the clear filters button', async ({ mainPage }) => {
+    const rowsBefore = await mainPage.locator('.MuiDataGrid-row').count()
+    expect(rowsBefore).toBeGreaterThan(1)
+
+    await openColumnMenu(mainPage, 'hex')
+    await mainPage
+      .locator('.MuiDataGrid-menuList')
+      .getByRole('menuitem', { name: 'Filter' })
+      .click()
+
+    const valueInput = mainPage.locator('.MuiDataGrid-filterFormValueInput input')
+    await expect(valueInput).toBeVisible()
+
+    // An empty filter form is not a filter yet.
+    await expect(mainPage.getByTestId('clear-filters-btn')).not.toBeVisible()
+
+    // Dummy data reads 0000 across the board, so this matches nothing and the
+    // grid empties -- proof the filter reached the rows, not only the toolbar.
+    await valueInput.fill('ffff')
+    await expect(mainPage.getByTestId('clear-filters-btn')).toBeVisible()
+
+    await mainPage.keyboard.press('Escape')
+    await expect(mainPage.locator('.MuiDataGrid-row')).toHaveCount(0)
+  })
+
+  test('clearing filters restores every row', async ({ mainPage }) => {
+    await mainPage.getByTestId('clear-filters-btn').click()
+
+    await expect(mainPage.getByTestId('clear-filters-btn')).not.toBeVisible()
+    expect(await mainPage.locator('.MuiDataGrid-row').count()).toBeGreaterThan(1)
+  })
+
+  test('address and binary columns offer no filter', async ({ mainPage }) => {
+    await openColumnMenu(mainPage, 'id')
+    await expect(
+      mainPage.locator('.MuiDataGrid-menuList').getByRole('menuitem', { name: 'Filter' })
+    ).toHaveCount(0)
+    await mainPage.keyboard.press('Escape')
+
+    // BIN has no column menu at all.
+    const binHeader = mainPage.locator('.MuiDataGrid-columnHeader[data-field="bin"]')
+    await binHeader.hover()
+    await expect(binHeader.locator('.MuiDataGrid-menuIconButton')).toHaveCount(0)
+  })
+
+  test('read configuration takes filtering away entirely', async ({ mainPage }) => {
+    // Read configuration hides rows without a data type, so give one row a type
+    // and keep the count as the yardstick.
+    const firstRow = mainPage.locator('.MuiDataGrid-row').first()
+    await firstRow.locator('[data-field="dataType"]').dblclick()
+    await mainPage.waitForTimeout(300)
+    await mainPage.getByRole('option', { name: 'INT16', exact: true }).click()
+    await mainPage.keyboard.press('Enter')
+
+    const rowsBefore = await mainPage.locator('.MuiDataGrid-row').count()
+    await enableReadConfiguration(mainPage)
+
+    const configuredRows = await mainPage.locator('.MuiDataGrid-row').count()
+    expect(configuredRows).toBeGreaterThan(0)
+    expect(configuredRows).toBeLessThan(rowsBefore)
+
+    // No column offers a filter, the data type column least of all: its filter
+    // is what hides the rows above, and editing it from the menu would bring
+    // them back.
+    for (const field of ['hex', 'dataType']) {
+      await openColumnMenu(mainPage, field)
+      await expect(
+        mainPage.locator('.MuiDataGrid-menuList').getByRole('menuitem', { name: 'Filter' })
+      ).toHaveCount(0)
+      await mainPage.keyboard.press('Escape')
+    }
+
+    // And with no filter of the user's to clear, no button either.
+    await expect(mainPage.getByTestId('clear-filters-btn')).not.toBeVisible()
+    await expect(mainPage.locator('.MuiDataGrid-row')).toHaveCount(configuredRows)
+
+    await disableReadConfiguration(mainPage)
   })
 
   // ─── Time settings ──────────────────────────────────────────────────

--- a/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGrid.tsx
+++ b/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGrid.tsx
@@ -80,6 +80,12 @@ const RegisterGridContent = (): JSX.Element => {
       // Off under e2e only, so a spec asserts on the column it named rather
       // than on whether that column happened to be in the rendered band.
       disableVirtualization={window.api.isE2e}
+      // Read configuration owns the filter model while it is on. Leaving the
+      // column menus open would let a filter of the user's fight it, and the
+      // data type filter below could be edited or deleted from the menu, which
+      // fills the list with the empty rows it exists to hide. Only the menu
+      // entries go: a model set here still filters.
+      disableColumnFilter={readConfiguration}
       autoHeight={false}
       density="compact"
       rowHeight={40}

--- a/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/ClearFiltersButton/ClearFiltersButton.tsx
+++ b/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/ClearFiltersButton/ClearFiltersButton.tsx
@@ -1,0 +1,49 @@
+import { FilterAltOff } from '@mui/icons-material'
+import IconButton from '@mui/material/IconButton'
+import {
+  gridFilterActiveItemsSelector,
+  gridFilterModelSelector,
+  useGridApiContext,
+  useGridSelector
+} from '@mui/x-data-grid'
+import { useCallback } from 'react'
+
+// The grid sets a filter of its own while read configuration is on, to keep
+// rows without a data type out of the way. It carries this id so it can be told
+// apart from what the user filtered on: it never lights the button up, and it
+// survives a clear. Dropping it would fill the list with empty rows.
+const INTERNAL_FILTER_ID = 1
+
+const ClearFiltersButton = (): JSX.Element | null => {
+  const apiRef = useGridApiContext()
+  // Active items rather than the model: opening the filter panel already puts
+  // an empty item in the model, and a form nobody has typed in yet is not a
+  // filter the user would want a button to clear.
+  const activeItems = useGridSelector(apiRef, gridFilterActiveItemsSelector)
+
+  const handleClear = useCallback(() => {
+    const filterModel = gridFilterModelSelector(apiRef)
+    apiRef.current?.setFilterModel({
+      ...filterModel,
+      items: filterModel.items.filter((item) => item.id === INTERNAL_FILTER_ID)
+    })
+  }, [apiRef])
+
+  const userFilters = activeItems.filter((item) => item.id !== INTERNAL_FILTER_ID)
+  if (userFilters.length === 0) return null
+
+  return (
+    <IconButton
+      data-testid="clear-filters-btn"
+      aria-label="Clear filters"
+      title="Clear filters"
+      size="small"
+      color="warning"
+      onClick={handleClear}
+    >
+      <FilterAltOff />
+    </IconButton>
+  )
+}
+
+export default ClearFiltersButton

--- a/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/RegisterGridToolbar.tsx
+++ b/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/RegisterGridToolbar.tsx
@@ -11,6 +11,7 @@ import ClearButton from './ClearButton/ClearButton'
 import ShowLogButton from './ShowLogButton/ShowLogButton'
 import MenuButton from './MenuButton/MenuButton'
 import RawButton from './RawButton/RawButton'
+import ClearFiltersButton from './ClearFiltersButton/ClearFiltersButton'
 import { useRootZustand } from '@renderer/context/root.zustand'
 import TextField from '@mui/material/TextField'
 
@@ -58,6 +59,7 @@ const RegisterGridToolbar = meme(() => {
         <ToggleEndianButton />
         <TimeSettings />
         <RawButton />
+        <ClearFiltersButton />
       </Box>
       <Box sx={{ display: 'flex', gap: 1, alignItems: 'center', flex: 1 }}>
         <Box sx={{ flex: '1 1 0' }}></Box>

--- a/src/renderer/src/components/client/ClientGrids/RegisterGrid/columns/address.tsx
+++ b/src/renderer/src/components/client/ClientGrids/RegisterGrid/columns/address.tsx
@@ -4,6 +4,7 @@ import { RegisterData } from '@shared'
 
 export const addressColumn = (addressBase: string): GridColDef<RegisterData, number> => ({
   field: 'id',
+  filterable: false,
   hideable: false,
   headerName: 'Addr.',
   width: 60,

--- a/src/renderer/src/components/client/ClientGrids/RegisterGrid/columns/binary.tsx
+++ b/src/renderer/src/components/client/ClientGrids/RegisterGrid/columns/binary.tsx
@@ -56,6 +56,8 @@ const WordLedDisplay = meme(({ value = 0 }: Props): JSX.Element => {
 
 export const binaryColumn: GridColDef<RegisterData, string> = {
   field: 'bin',
+  // A filter over a bit string answers nothing anyone asks.
+  disableColumnMenu: true,
   headerName: 'BIN',
   width: 80,
   renderCell: ({ row }) => <WordLedDisplay value={row.words?.['uint16']} />

--- a/src/renderer/src/components/client/ClientGrids/RegisterGrid/columns/bit.tsx
+++ b/src/renderer/src/components/client/ClientGrids/RegisterGrid/columns/bit.tsx
@@ -4,6 +4,7 @@ import { RegisterData } from '@shared'
 
 export const bitColumn: GridColDef<RegisterData, boolean, boolean> = {
   field: 'bit',
+  filterable: false,
   type: 'boolean',
   headerName: 'Bit',
   width: 80,


### PR DESCRIPTION
No column in the register grid declared `filterable`, so every one of them offered a filter because MUI defaults to one, not because anyone chose it:

```console
$ git grep -n 'filterable\|sortable\|disableColumnMenu' spike/mui-latest -- 'src/renderer/src/components/client/ClientGrids/RegisterGrid/columns'
spike/mui-latest:src/renderer/src/components/client/ClientGrids/RegisterGrid/columns/groupIndex.tsx:7:  disableColumnMenu: true,
```

The rule applied here is not whether filtering works but whether the question it answers gets asked. Addr. and Bit lose theirs, since finding an address is what the scan is for, and BIN loses its column menu outright. HEX keeps its filter, because a status word or a fault code from the manual is often exactly what you are hunting for, and that is filtering on the value rather than on its presentation. The value columns keep theirs.

## Clearing a filter

A grid that hides rows looks like a grid that lost them, so `ClearFiltersButton` sits beside RAW and shows only while a filter is on.

It reads the grid's active items rather than its filter model. Opening the filter panel already puts an empty item in the model, and a form nobody has typed in yet is not something to offer a button for.

## Read configuration

`RegisterGrid.tsx` sets a filter model of its own in that mode, to keep the rows without a data type out of the way. That left a hole: the item could be edited or deleted from the data type column menu, which fills the list with the rows the mode exists to hide.

Filtering is off there now. `disableColumnFilter` takes away the menu entries and nothing else, so the model set from code still filters.

## Tests

`15-client-toolbar.spec.ts` covers the button appearing only for a filter that is set, clearing restoring the rows, the columns that offer no filter, and read configuration taking filtering away while keeping its own rows hidden.

Draft because the base is the MUI spike in #28.
