### PR TITLE
Let the splash window fit whatever window it gets

### DIFF
--- a/resources/splash.html
+++ b/resources/splash.html
@@ -8,14 +8,18 @@
     <meta name="msapplication-TileColor" content="#181818" />
     <style>
         html,
-        .body {
+        body {
             margin: 0;
             background: #181818;
             display: flex;
             align-items: center;
             justify-content: center;
-            width: 400px;
-            height: 300px;
+            /* Not the window size in pixels: on Windows the content area comes
+               out smaller than the size the BrowserWindow was asked for, and a
+               page fixed at that size no longer fits inside it. */
+            width: 100%;
+            height: 100%;
+            overflow: hidden;
             font-size: 14px;
         }
 


### PR DESCRIPTION
Windows drew scrollbars across the logo in the splash window.

Two things were wrong in `resources/splash.html`. The stylesheet sized `html, .body`, and nothing in the document carries that class, so the margin reset never applied to the body at all. And the page was pinned at the pixel size the `BrowserWindow` was asked for:

```css
width: 400px;
height: 300px;
```

On Windows the content area comes out smaller than the size passed to the constructor, so a page fixed at that size no longer fits inside it and overflows. Percentages make the page follow the window instead, and `overflow: hidden` says what a splash screen means either way.

## Where it shows

Windows only. Jens saw it there and not on Linux, which opens the same splash. macOS opens none: `src/main/index.ts` creates the window only when the platform is not darwin, which is why this stood for as long as it did.

## What is not measured here

Why the Windows content area is short. `useContentSize` would settle it, but the fix above holds whatever the answer is, so it stays out of this change.

Draft until someone confirms it on Windows. There is no test for this: the splash closes as soon as the main window is ready, and the suite never looks at it.