### PR TITLE
Keep what the app writes on its way out

### DIFF
--- a/e2e/fixtures/electron-app.ts
+++ b/e2e/fixtures/electron-app.ts
@@ -5,6 +5,35 @@ import {
   type Page
 } from '@playwright/test'
 import { launchOptions } from './launch'
+import { createWriteStream, mkdirSync } from 'fs'
+import { join } from 'path'
+
+/**
+ * Everything the app writes, kept next to the traces.
+ *
+ * Playwright owns the child process and nothing reads its stdio, so a run that
+ * ends with "Target page, context or browser has been closed" says only that
+ * the app is gone. The exit line below is the point of this: a code means the
+ * app came down on its own, a signal means something else took it.
+ *
+ * The workflow uploads test-results/ when a run fails, so the file travels with
+ * the trace it belongs to.
+ */
+function keepOutput(app: ElectronApplication): void {
+  const dir = join(process.cwd(), 'test-results')
+  mkdirSync(dir, { recursive: true })
+
+  const worker = process.env.TEST_WORKER_INDEX ?? '0'
+  const log = createWriteStream(join(dir, `electron-main-${worker}.log`), { flags: 'a' })
+  const stamp = (): string => new Date().toISOString()
+
+  const proc = app.process()
+  proc.stdout?.on('data', (c: Buffer) => log.write(`[${stamp()}] out ${c.toString()}`))
+  proc.stderr?.on('data', (c: Buffer) => log.write(`[${stamp()}] err ${c.toString()}`))
+  proc.on('exit', (code, signal) => {
+    log.write(`[${stamp()}] exit code=${code} signal=${signal}\n`)
+  })
+}
 
 export type ElectronFixtures = {
   electronApp: ElectronApplication
@@ -17,6 +46,7 @@ export const test = base.extend<{}, ElectronFixtures>({
     // eslint-disable-next-line no-empty-pattern
     async ({}, use): Promise<void> => {
       const app = await electron.launch(launchOptions())
+      keepOutput(app)
 
       await app.evaluate((ctx) =>
         ctx.session.defaultSession.clearStorageData({ storages: ['localstorage'] })

--- a/e2e/fixtures/launch.ts
+++ b/e2e/fixtures/launch.ts
@@ -103,9 +103,11 @@ export function launchOptions(): LaunchOptions {
   const isolate = isPackaged || process.env.E2E_ISOLATED_PROFILE === '1'
   const args = isolate ? [`--user-data-dir=${isolatedUserDataDir()}`] : []
 
-  // Turns off DataGrid virtualisation, so a locator finds the column or row it
-  // names instead of only the ones the current window happens to render.
-  const env = { ...process.env, MODBUX_E2E: '1' }
+  // MODBUX_E2E turns off DataGrid virtualisation, so a locator finds the column
+  // or row it names instead of only the ones the current window happens to
+  // render. ELECTRON_ENABLE_LOGGING sends Chromium's own logging to stderr,
+  // which the fixture keeps: without it the app says nothing on its way out.
+  const env = { ...process.env, MODBUX_E2E: '1', ELECTRON_ENABLE_LOGGING: '1' }
 
   if (!isPackaged) return { args: [join(ROOT, 'out/main/index.js'), ...args], env }
 


### PR DESCRIPTION
Windows has now dropped its Electron process three times, always in the first specs, always as `Target page, context or browser has been closed`. Green on a re-run each time.

The third one ran with `--trace retain-on-failure` and kept a trace. All it says:

```
Evaluate  BrowserWindow ... getTitle() === 'Modbux'   ok
Wait for load state "domcontentloaded"                ok
Wait for timeout 500                                  failed
```

The window existed and its DOM had loaded. The process went away a quarter of a second later, during a plain wait, with nothing touching it. The trace holds no main-process output, because Playwright owns the child process and nobody was reading its stdio.

## What this adds

`electron-app.ts` keeps stdout and stderr in `test-results/electron-main-<worker>.log`, and writes one line when the process exits. `launch.ts` sets `ELECTRON_ENABLE_LOGGING`, without which Chromium says nothing on the way out.

The exit line is the point:

```
[2026-08-28T07:38:54.244Z] exit code=0 signal=null
```

A code means the app came down by itself. A signal means something else took it. Today that question has no answer at all.

`e2e.yml` needs no change: it already uploads `test-results/` when a run fails, so the log travels with the trace.

## What it does not do

It does not fix the flake, and it cannot be verified by a green run. It pays off the next time Windows drops the process, which is why the run against this branch is Windows only, in dev mode, repeated until it happens.

Verified locally only in the sense that the file fills and the exit line lands.