### PR TITLE
Say which path takes the app down

### DIFF
--- a/e2e/fixtures/electron-app.ts
+++ b/e2e/fixtures/electron-app.ts
@@ -19,7 +19,7 @@ import { join } from 'path'
  * The workflow uploads test-results/ when a run fails, so the file travels with
  * the trace it belongs to.
  */
-function keepOutput(app: ElectronApplication): void {
+export function keepOutput(app: ElectronApplication): void {
   const dir = join(process.cwd(), 'test-results')
   mkdirSync(dir, { recursive: true })
 
@@ -27,11 +27,14 @@ function keepOutput(app: ElectronApplication): void {
   const log = createWriteStream(join(dir, `electron-main-${worker}.log`), { flags: 'a' })
   const stamp = (): string => new Date().toISOString()
 
+  // The persistence spec launches its own app beside the worker's, and both
+  // write here, so every line says which process it came from.
   const proc = app.process()
-  proc.stdout?.on('data', (c: Buffer) => log.write(`[${stamp()}] out ${c.toString()}`))
-  proc.stderr?.on('data', (c: Buffer) => log.write(`[${stamp()}] err ${c.toString()}`))
+  const pid = proc.pid
+  proc.stdout?.on('data', (c: Buffer) => log.write(`[${stamp()}] ${pid} out ${c.toString()}`))
+  proc.stderr?.on('data', (c: Buffer) => log.write(`[${stamp()}] ${pid} err ${c.toString()}`))
   proc.on('exit', (code, signal) => {
-    log.write(`[${stamp()}] exit code=${code} signal=${signal}\n`)
+    log.write(`[${stamp()}] ${pid} exit code=${code} signal=${signal}\n`)
   })
 }
 

--- a/e2e/specs/02-standalone/01-persistence.spec.ts
+++ b/e2e/specs/02-standalone/01-persistence.spec.ts
@@ -8,6 +8,7 @@ import {
 import { resolve } from 'path'
 import { loadServerConfig, selectUnitId } from '../../fixtures/helpers'
 import { launchOptions } from '../../fixtures/launch'
+import { keepOutput } from '../../fixtures/electron-app'
 
 const CONFIG_DIR = resolve(__dirname, '../../fixtures/config-files')
 const SERVER_CONFIG = resolve(CONFIG_DIR, 'server-integration.json')
@@ -18,6 +19,10 @@ let page: Page
 
 async function launchApp(clearStorage = true): Promise<void> {
   app = await electron.launch(launchOptions())
+  // This spec launches its own app, so it needs the same output kept as the
+  // shared fixture keeps. Its launches race the worker's app for the single
+  // instance lock, which is where the log has to be able to speak.
+  keepOutput(app)
   if (clearStorage) {
     await app.evaluate((ctx) =>
       ctx.session.defaultSession.clearStorageData({ storages: ['localstorage'] })

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -178,6 +178,18 @@ app.whenReady().then(() => {
     const id = window.id
     lifecycle(`window ${id} created`)
     window.on('closed', () => lifecycle(`window ${id} closed`))
+
+    // A window that goes away on its own takes its reason with it. These three
+    // are the ways that happens without anyone calling close(): the renderer
+    // dies, the page never loads, or it stops answering.
+    window.webContents.on('render-process-gone', (_e, details) =>
+      lifecycle(`window ${id} renderer gone: reason=${details.reason} exit=${details.exitCode}`)
+    )
+    window.webContents.on('did-fail-load', (_e, code, description, url) =>
+      lifecycle(`window ${id} failed to load ${url}: ${code} ${description}`)
+    )
+    window.on('unresponsive', () => lifecycle(`window ${id} unresponsive`))
+
     optimizer.watchWindowShortcuts(window)
   })
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -28,10 +28,21 @@ const server = new ModbusServer({ windows })
 // IPC
 initIpc(app, appState, client, server)
 
+/**
+ * Say which path took the app down.
+ *
+ * A process that quits leaves nothing behind that names the reason, and the
+ * two callers of app.quit() below look identical from the outside: an exit
+ * with code 0. On CI these lines land in the log the e2e fixture keeps beside
+ * the traces, and in dev they land in the terminal.
+ */
+const lifecycle = (message: string): void => console.error(`[lifecycle] ${message}`)
+
 // Single instance
 const gotTheLock = app.requestSingleInstanceLock()
 
 if (!gotTheLock) {
+  lifecycle('another instance holds the single instance lock, quitting')
   app.quit()
 } else {
   app.on('second-instance', () => {
@@ -164,6 +175,9 @@ app.whenReady().then(() => {
   // and ignore CommandOrControl + R in production.
   // see https://github.com/alex8088/electron-toolkit/tree/master/packages/utils
   app.on('browser-window-created', (_, window) => {
+    const id = window.id
+    lifecycle(`window ${id} created`)
+    window.on('closed', () => lifecycle(`window ${id} closed`))
     optimizer.watchWindowShortcuts(window)
   })
 
@@ -185,8 +199,10 @@ app.whenReady().then(() => {
 // for applications and their menu bar to stay active until the user quits
 // explicitly with Cmd + Q.
 app.on('window-all-closed', () => {
+  lifecycle('every window is closed')
   windows.server = null
   if (process.platform !== 'darwin') {
+    lifecycle('quitting because no window is left')
     app.quit()
   }
 })


### PR DESCRIPTION
Two Windows failures have now been captured, both ending the same way:

```
[2026-08-28T08:29:08.334Z] exit code=0 signal=null
[2026-08-28T09:08:13.910Z] exit code=0 signal=null
```

Code 0 means the app quit itself. Two places do that, and they are indistinguishable from outside the process: the single instance lock in `index.ts`, and `window-all-closed`. Each says so now, and every window reports when it is created and when it closes.

The first capture also carried `ERR_FAILED` loading the splash, from a load that was stopped rather than a file that was missing. That looked like the cause until the second capture arrived without it and ended identically. It stays out of this change.

## Why the lines are not gated on the e2e run

The same question comes back as "the app closed by itself" from a user, and the answer is as unavailable there as it was here. In dev the lines land in the terminal, in a packaged app they go where a packaged app's stdio goes, and on CI the fixture keeps them.

Draft until a Windows run drops the process again and the log names the path.