### PR TITLE
Hold tar at one version, past the advisories

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,8 @@
   },
   "resolutions": {
     "ip-address": "^10.3.1",
-    "node-abi": "^4.33.0"
+    "node-abi": "^4.33.0",
+    "tar": "^7.5.22"
   },
   "packageManager": "yarn@4.10.3+sha512.c38cafb5c7bb273f3926d04e55e1d8c9dfa7d9c3ea1f36a4868fa028b9e5f72298f0b7f401ad5eb921749eb012eb1c3bb74bf7503df3ee43fd600d14a018266f"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8023,20 +8023,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:^7.4.3":
-  version: 7.5.1
-  resolution: "tar@npm:7.5.1"
-  dependencies:
-    "@isaacs/fs-minipass": "npm:^4.0.0"
-    chownr: "npm:^3.0.0"
-    minipass: "npm:^7.1.2"
-    minizlib: "npm:^3.1.0"
-    yallist: "npm:^5.0.0"
-  checksum: 10c0/0dad0596a61586180981133b20c32cfd93c5863c5b7140d646714e6ea8ec84583b879e5dc3928a4d683be6e6109ad7ea3de1cf71986d5194f81b3a016c8858c9
-  languageName: node
-  linkType: hard
-
-"tar@npm:^7.5.4":
+"tar@npm:^7.5.22":
   version: 7.5.22
   resolution: "tar@npm:7.5.22"
   dependencies:
@@ -8046,19 +8033,6 @@ __metadata:
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
   checksum: 10c0/1311f6be85a8157ac4c9147bae43e13923d2a1aae15e4aa1bd5239e4e03d2cf53cfe103dde7f35832fbb4c938b042856bc8e9a0afd29abd05e2d1608788c4fea
-  languageName: node
-  linkType: hard
-
-"tar@npm:^7.5.7":
-  version: 7.5.9
-  resolution: "tar@npm:7.5.9"
-  dependencies:
-    "@isaacs/fs-minipass": "npm:^4.0.0"
-    chownr: "npm:^3.0.0"
-    minipass: "npm:^7.1.2"
-    minizlib: "npm:^3.1.0"
-    yallist: "npm:^5.0.0"
-  checksum: 10c0/e870beb1b2477135ca2abe86b2d18f7b35d0a4e3a37bbc523d3b8f7adca268dfab543f26528a431d569897f8c53a7cac745cdfbc4411c2f89aeeacc652b81b0a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Thirteen of the open alerts are on `tar`, including the one marked critical, and all of them arrive through the node-gyp subtree that the packaged app carries.

The tree held three copies:

```console
$ yarn why tar | grep -oE "tar@npm:[0-9.]+" | sort -u
tar@npm:7.5.1
tar@npm:7.5.22
tar@npm:7.5.9
```

The highest fix version the open alerts ask for is 7.5.21, and 7.5.22 is current, so one resolution covers all three. After it:

```console
$ grep -E '^"?tar@npm:' yarn.lock | sort -u
"tar@npm:^7.5.22":

$ yarn why tar | grep -oE "tar@npm:[0-9.]+" | sort -u
tar@npm:7.5.22
```

`package.json` already resolves `ip-address` and `node-abi` this way.

## What this does not do

It does not make the package smaller, and it does not stop the app shipping code it never runs. Dependabot reads the lockfile, so this changes what the list says; `files` in `electron-builder.yml` is what changes what a user gets. Those are separate, and this is the first of the two.

## What was run

Lint, typecheck, the unit tests, and a packaged run of the navigation spec, since `tar` sits in the path electron-builder and node-gyp both use. The full matrix runs on this branch.