### PR TITLE
Run the packaged suite even when the dev one fails

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -154,15 +154,18 @@ jobs:
         shell: bash
         run: ${{ runner.os == 'Linux' && 'xvfb-run -a' || '' }} yarn playwright test --trace retain-on-failure
 
+      # not cancelled(), rather than success(): a failure in the dev run says
+      # nothing about the packaged app, and the packaged app is what ships. The
+      # job still ends red, and now it ends red with both answers in it.
       - name: Package
-        if: inputs.mode != 'dev'
+        if: '!cancelled() && inputs.mode != ''dev'''
         shell: bash
         run: |
           yarn electron-builder --dir --publish never ||
             { sleep 15; yarn electron-builder --dir --publish never; }
 
       - name: E2E against dist/
-        if: inputs.mode != 'dev'
+        if: '!cancelled() && inputs.mode != ''dev'''
         shell: bash
         run: ${{ runner.os == 'Linux' && 'xvfb-run -a' || '' }} yarn playwright test --config playwright.packaged.config.ts --trace retain-on-failure
 


### PR DESCRIPTION
A failing step skips what comes after it, so this:

```yaml
- name: E2E against out/     # fails
- name: Package              # skipped
- name: E2E against dist/    # skipped
```

leaves the question that matters unanswered. What ships is the packaged app, and every Windows failure anyone has been able to point at is in the dev step: the window that goes away, and now a spec that cannot reopen a file it just wrote.

`!cancelled()` rather than `always()`, so a cancelled run still stops.

The job still ends red when the dev half fails. It now ends red with both halves in it, which is the difference between "Windows is unhappy" and "Windows is unhappy about the half nobody installs".