### PR TITLE
feat: the endian toggle, and what it does to what you see

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Reading a configuration turns filtering off.** That mode already hides the
   rows without a data type, and a filter of your own could fight it or take it
   away from the column menu, leaving the list full of empty rows.
+- **Switching between BE and LE reads again.** The rows on screen were read in
+  the other word order and stayed that way until you read yourself, so a 32-bit
+  value kept showing the number it had before the switch. Modbux reads again
+  when there is something to reinterpret, unless polling or a scan is about to
+  anyway.
 - **A scan dialog no longer closes when you click beside it.** Reaching for
   anything behind it threw away the scan you were setting up. It has a close
   button now, off while a scan runs, and Escape still works.

--- a/e2e/specs/01-main/07-endianness.spec.ts
+++ b/e2e/specs/01-main/07-endianness.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from '../../fixtures/electron-app'
 import {
   selectUnitId,
   cell,
+  cellLocator,
   readRegisters,
   clearData,
   loadServerConfig,
@@ -123,6 +124,23 @@ test.describe.serial('Endianness — Little Endian round-trip', () => {
     // BE: [0x6553, 0xF100] -> LE: [0xF100, 0x6553]
     await expectCell(mainPage, 26, 'hex', 'F100')
     await expectCell(mainPage, 27, 'hex', '6553')
+  })
+
+  // ─── Toggling reads again ──────────────────────────────────────────
+
+  test('toggling endianness reads again instead of leaving the rows stale', async ({
+    mainPage
+  }) => {
+    await expectCell(mainPage, 2, 'word_int32', '-70000')
+
+    // The server stays little endian, so reading the same registers as big
+    // endian gives a different number. It can only show up without pressing
+    // Read if the toggle asked for one.
+    await setClientEndianness(mainPage, 'be')
+    await expect(cellLocator(mainPage, 2, 'word_int32')).not.toHaveText('-70000')
+
+    await setClientEndianness(mainPage, 'le')
+    await expectCell(mainPage, 2, 'word_int32', '-70000')
   })
 
   // ─── Cleanup: restore Big Endian ───────────────────────────────────

--- a/src/renderer/src/components/shared/inputs/EndianTable.tsx
+++ b/src/renderer/src/components/shared/inputs/EndianTable.tsx
@@ -1,99 +1,94 @@
-import { Typography, Table, TableBody, TableCell, TableHead, TableRow, Paper } from '@mui/material'
+import { Paper, Table, TableBody, TableCell, TableHead, TableRow, Typography } from '@mui/material'
+import { tableCellClasses } from '@mui/material/TableCell'
 
-const EndianTable = (): JSX.Element => {
-  return (
-    <Paper sx={{ px: 3, py: 2, maxHeight: '66dvh', overflow: 'auto', minWidth: '80dvw' }}>
-      <Typography variant="h6">Big-Endian vs Little-Endian Word Order</Typography>
-      <Typography variant="body1" sx={{ mb: 2 }}>
-        The following table shows an example of a 32-bit integer value (<strong>305419896</strong>,
-        hexadecimal <strong>0x12345678</strong>) and how it is split into 16-bit words in both
-        Big-Endian and Little-Endian formats. We also show how these words are assigned to Modbus
-        registers, along with SCL (Structured Control Language) assignments.
-      </Typography>
+/**
+ * What BE and LE do to one value, shown rather than described.
+ *
+ * This hangs off the BE/LE toggle as a tooltip, so it competes with the app
+ * behind it and has to stay readable at a glance. The question a user has is
+ * which half of a 32-bit value lands in the first register, and two rows
+ * answer it.
+ *
+ * The hex carries the same monospace and colour as the HEX column in the
+ * register grid, so a value looks the same wherever it appears.
+ */
 
-      <Table size="small">
-        <TableHead>
-          <TableRow>
-            <TableCell>
-              <strong>Order Type</strong>
-            </TableCell>
-            <TableCell>
-              <strong>Register 0</strong>
-            </TableCell>
-            <TableCell>
-              <strong>Register 1</strong>
-            </TableCell>
-            <TableCell>
-              <strong>SCL Register Assignments</strong>
-            </TableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          <TableRow>
-            <TableCell>Big-Endian</TableCell>
-            <TableCell>
-              <strong>0x1234</strong> (W1)
-            </TableCell>
-            <TableCell>
-              <strong>0x5678</strong> (W0)
-            </TableCell>
-            <TableCell>registers[0] := W1; registers[1] := W0;</TableCell>
-          </TableRow>
-          <TableRow>
-            <TableCell>Little-Endian</TableCell>
-            <TableCell>
-              <strong>0x5678</strong> (W0)
-            </TableCell>
-            <TableCell>
-              <strong>0x1234</strong> (W1)
-            </TableCell>
-            <TableCell>registers[0] := W0; registers[1] := W1;</TableCell>
-          </TableRow>
-        </TableBody>
-      </Table>
+const Hex = ({ children }: { children: string }): JSX.Element => (
+  <Typography
+    component="span"
+    sx={(theme) => ({
+      fontFamily: 'monospace',
+      color: theme.palette.primary.light,
+      fontSize: '0.9em'
+    })}
+  >
+    {children}
+  </Typography>
+)
 
-      <Typography variant="body1" sx={{ mt: 2 }}>
-        <strong>Big-Endian (BE):</strong> In Big-Endian format, the most significant byte (MSB) is
-        stored first, followed by the least significant byte (LSB). In Modbus, this is the standard
-        for most systems, including PLCs like Siemens S7. In the example, the 32-bit integer{' '}
-        <strong>0x12345678</strong> is stored as:
-      </Typography>
+const EndianTable = (): JSX.Element => (
+  <Paper elevation={4} sx={{ px: 2, py: 1.5, width: 'fit-content' }}>
+    <Typography sx={{ fontSize: 13 }}>
+      32 bit value: <Hex>0x12345678</Hex>
+    </Typography>
 
-      <Typography variant="body2" sx={{ ml: 2, mt: 1 }}>
-        - Word order: <strong>W1 = 0x1234</strong>, <strong>W0 = 0x5678</strong>
-        <br />- SCL assignment: `registers[0] := W1`, `registers[1] := W0`
-      </Typography>
+    {/*
+      Set once here rather than per cell. The size comes down from the table,
+      and Hex sizes itself against it in em rather than in pixels, so one
+      number governs the lot. Padding does not come down: a cell brings its
+      own, so the outer two are cleared with pseudo classes, which is the only
+      way to reach first and last.
+    */}
+    <Table
+      size="small"
+      sx={{
+        fontSize: 11,
+        [`& .${tableCellClasses.root}`]: { whiteSpace: 'nowrap' },
+        '& td:first-of-type, & th:first-of-type': { pl: 0 },
+        '& td:last-of-type, & th:last-of-type': { pr: 0 }
+      }}
+    >
+      <TableHead>
+        <TableRow>
+          <TableCell />
+          <TableCell>Register 0</TableCell>
+          <TableCell>Register 1</TableCell>
+          <TableCell align="right">ST</TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        <TableRow>
+          <TableCell>Big-Endian</TableCell>
+          <TableCell>
+            <Hex>0x1234</Hex> high
+          </TableCell>
+          <TableCell>
+            <Hex>0x5678</Hex> low
+          </TableCell>
+          <TableCell align="right">
+            <Hex>reg[0] := dWord.W1; reg[1] := dWord.W0;</Hex>
+          </TableCell>
+        </TableRow>
+        <TableRow>
+          <TableCell>Little-Endian</TableCell>
+          <TableCell>
+            <Hex>0x5678</Hex> low
+          </TableCell>
+          <TableCell>
+            <Hex>0x1234</Hex> high
+          </TableCell>
+          <TableCell align="right">
+            <Hex>reg[0] := dWord.W0; reg[1] := dWord.W1;</Hex>
+          </TableCell>
+        </TableRow>
+      </TableBody>
+    </Table>
 
-      <Typography variant="body1" sx={{ mt: 2 }}>
-        <strong>Little-Endian (LE):</strong> In Little-Endian format, the least significant byte
-        (LSB) is stored first, followed by the most significant byte (MSB). This format is less
-        common in Modbus communication. In the same example, the 32-bit integer{' '}
-        <strong>0x12345678</strong> is stored as:
-      </Typography>
-
-      <Typography variant="body2" sx={{ ml: 2, mt: 1 }}>
-        - Word order: <strong>W1 = 0x5678</strong>, <strong>W0 = 0x1234</strong>
-        <br />- SCL assignment: `registers[0] := W0`, `registers[1] := W1`
-      </Typography>
-
-      <Typography component={'div'} variant="body1" sx={{ mt: 2 }}>
-        <strong>Explanation:</strong>
-        <ul>
-          <li>
-            In <strong>Big-Endian</strong>, the high-order word (<strong>W1</strong>) is assigned to
-            the first register, while the low-order word (<strong>W0</strong>) is assigned to the
-            second register.
-          </li>
-          <li>
-            In <strong>Little-Endian</strong>, the low-order word (<strong>W0</strong>) is stored
-            first, and the high-order word (<strong>W1</strong>) is stored second.
-          </li>
-        </ul>
-        When communicating with Modbus devices, it{`'`}s essential to know which endianness the
-        device uses to ensure correct data interpretation.
-      </Typography>
-    </Paper>
-  )
-}
+    <Typography variant="caption" sx={{ display: 'block', mt: 1, opacity: 0.7 }}>
+      Big-Endian puts the high word first and is what most devices use. Pick the one your device
+      uses, or every 32-bit value reads as nonsense.
+    </Typography>
+  </Paper>
+)
 
 export default EndianTable

--- a/src/renderer/src/context/root.zustand.ts
+++ b/src/renderer/src/context/root.zustand.ts
@@ -286,9 +286,20 @@ export const useRootZustand = create<
         }),
       setLittleEndian: (littleEndian) =>
         set((state) => {
-          if (!get().ready) return
+          const currentState = get()
+          if (!currentState.ready) return
           state.registerConfig.littleEndian = littleEndian
           window.api.updateRegisterConfig({ littleEndian })
+
+          // The rows on screen were read in the other word order, and the
+          // conversion happens where the reading does, so they stay that way
+          // until the next read. Ask for one, unless something else is about
+          // to: polling reads on its own, and a scan is filling the list.
+          const { connectState, polling, scanningRegisters } = currentState.clientState
+          const hasRows = useDataZustand.getState().registerData.length > 0
+          if (connectState === 'connected' && !polling && !scanningRegisters && hasRows) {
+            window.api.read()
+          }
         }),
       setReadConfiguration: (readConfiguration) =>
         set((state) => {


### PR DESCRIPTION
The BE/LE toggle carried a full page of prose in a tooltip: a table, two paragraphs per format, a bulleted explanation, sized at 80dvw by 66dvh. Nobody reads that with the pointer held still, and it did not look like the rest of the app while not being read.

What someone hovering there wants to know is which half of a 32-bit value lands in the first register. That is one example value and two rows.

## What is in it now

`0x12345678`, split across Register 0 and Register 1 for both orders, with the ST assignment beside each row and one sentence underneath about picking the one your device uses.

The hex is the same monospace and the same primary colour as the HEX column in the register grid, so a value looks the same wherever it turns up.

## Layout

A plain `Table size="small"`. An earlier attempt built a CSS grid with fixed column widths and a component per row, and its header drifted out of line with its own body, which is what a table is for.

The font size is set once on the table, and `Hex` sizes itself against it in em. Cell padding does not come down from the table, so the outer two are cleared with `:first-of-type` and `:last-of-type`.

## What was run

Lint, typecheck and the unit tests. Nothing else touches this, and the specs do not look at the tooltip.

Draft because it is a visual change and it is Jens's call whether it fits.