### PR TITLE
chore: move uuid to 11

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "lodash": "^4.18.1",
     "luxon": "^3.7.2",
     "modbus-serial": "^8.0.25",
-    "uuid": "^10.0.0",
+    "uuid": "^11.1.1",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6344,7 +6344,7 @@ __metadata:
     react-dom: "npm:^18.3.1"
     react-imask: "npm:^7.6.1"
     typescript: "npm:^5.9.3"
-    uuid: "npm:^10.0.0"
+    uuid: "npm:^11.1.1"
     vite: "npm:^7"
     vitest: "npm:^4.1"
     zod: "npm:^3.25.76"
@@ -8389,12 +8389,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:^10.0.0":
-  version: 10.0.0
-  resolution: "uuid@npm:10.0.0"
+"uuid@npm:^11.1.1":
+  version: 11.1.1
+  resolution: "uuid@npm:11.1.1"
   bin:
-    uuid: dist/bin/uuid
-  checksum: 10c0/eab18c27fe4ab9fb9709a5d5f40119b45f2ec8314f8d4cf12ce27e4c6f4ffa4a6321dc7db6c515068fa373c075b49691ba969f0010bf37f44c37ca40cd6bf7fe
+    uuid: dist/esm/bin/uuid
+  checksum: 10c0/9e3af58eba872ece5a5e76f4773a94fc78a0ef2c2444c38dbe6b42f41dadf76c01850fd783604f27986f6195e6286aef064d45987d401b2a33127b98ddf7c0c5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The last open Dependabot alert. GHSA-w5hq-g745-h8pq is about `v3()`, `v5()` and `v6()` when the caller hands in its own buffer: they write past the end without throwing, where `v4()` already raises a `RangeError`. Modbux calls `v4()` twice, in `SelectServer.tsx` and `modbusClient.ts`, without a buffer, so the advisory never reached the app. The bump closes the alert rather than fixing anything.

Named imports carry over from 10 to 11 unchanged, so no source file moves.

Local: typecheck, lint, 508 tests, and a build to confirm it bundles.

No changelog entry: nothing changes for anyone using Modbux.