### PR TITLE
feat: hand the client view over to a running scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   written in batches, so the grid costs nothing: the same scan took eight times
   longer with the grid up before this, and the window stopped answering while
   it ran. You can scroll and page through it while it fills, but not edit it:
-  the rows are still arriving. The eye beside the scan button puts it back the
+  the rows are still arriving, and the toolbar and the transaction log step
+  aside for the same reason. Starting a scan turns advanced mode on, since a
+  scan walks raw addresses. The eye beside the scan button puts it all back the
   old way.
 - **A scan says how many it found.** The grid shows the first rows, not the
   total, so the count sits beside the scan button. The unit ID scan counts the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **A button that clears the filters you set.** It sits next to RAW in the
   client toolbar and shows up only while a filter is on, so a filter left behind
   no longer reads as missing data.
+- **A scan says how many registers it found.** A scan over thousands of
+  addresses showed a progress bar and nothing else, so a run that turned up
+  nothing looked like a run still warming up. The count sits beside the scan
+  button. The unit ID scan counts the units that answered, not the rows.
 
 ### Changed
 
@@ -46,6 +50,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **The coils and discrete inputs lists scroll inside their own panel.** A long
   list used to grow past the server view, and the whole view scrolled
   underneath it instead.
+- **The scan timeout keeps what you type.** Clearing the field and typing 500
+  left 10000 behind. A value outside 100 to 10000 is corrected when you leave
+  the field instead of while you are still typing.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   it ran. You can scroll and page through it while it fills, but not edit it:
   the rows are still arriving, and the toolbar and the transaction log step
   aside for the same reason. Starting a scan turns advanced mode on, since a
-  scan walks raw addresses. The eye beside the scan button puts it all back the
-  old way.
+  scan walks raw addresses, and the dialog stays open when the scan ends rather
+  than closing to reveal what you were already watching. The eye beside the
+  scan button puts it all back the old way.
 - **A scan says how many it found.** The grid shows the first rows, not the
   total, so the count sits beside the scan button. The unit ID scan counts the
   units that answered, since its results list every unit it asked.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **A button that clears the filters you set.** It sits next to RAW in the
   client toolbar and shows up only while a filter is on, so a filter left behind
   no longer reads as missing data.
-- **A scan says how many registers it found.** A scan over thousands of
-  addresses showed a progress bar and nothing else, so a run that turned up
-  nothing looked like a run still warming up. The count sits beside the scan
-  button. The unit ID scan counts the units that answered, not the rows.
+- **The grid fills while a register scan runs.** It used to disappear for the
+  length of the scan, leaving a progress bar and no sign of what was coming in.
+  It stays up now and the rows arrive as the scan walks the range. They are
+  written in batches, so the grid costs nothing: the same scan took eight times
+  longer with the grid up before this, and the window stopped answering while
+  it ran. You can scroll and page through it while it fills, but not edit it:
+  the rows are still arriving. The eye beside the scan button puts it back the
+  old way.
+- **A scan says how many it found.** The grid shows the first rows, not the
+  total, so the count sits beside the scan button. The unit ID scan counts the
+  units that answered, since its results list every unit it asked.
 
 ### Changed
 
@@ -34,6 +41,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Reading a configuration turns filtering off.** That mode already hides the
   rows without a data type, and a filter of your own could fight it or take it
   away from the column menu, leaving the list full of empty rows.
+- **A scan dialog no longer closes when you click beside it.** Reaching for
+  anything behind it threw away the scan you were setting up. It has a close
+  button now, off while a scan runs, and Escape still works.
 
 ### Fixed
 

--- a/e2e/fixtures/config-files/server-scan-perf.json
+++ b/e2e/fixtures/config-files/server-scan-perf.json
@@ -1,0 +1,20015 @@
+{
+  "version": 2,
+  "modbuxVersion": "2.0.0",
+  "name": "Scan grid performance",
+  "littleEndian": false,
+  "serverRegistersPerUnit": {
+    "0": {
+      "coils": {},
+      "discrete_inputs": {},
+      "holding_registers": {
+        "0": {
+          "value": 1000,
+          "params": {
+            "address": 0,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 0",
+            "value": 1000
+          }
+        },
+        "1": {
+          "value": 1001,
+          "params": {
+            "address": 1,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1",
+            "value": 1001
+          }
+        },
+        "2": {
+          "value": 1002,
+          "params": {
+            "address": 2,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 2",
+            "value": 1002
+          }
+        },
+        "3": {
+          "value": 1003,
+          "params": {
+            "address": 3,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 3",
+            "value": 1003
+          }
+        },
+        "4": {
+          "value": 1004,
+          "params": {
+            "address": 4,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 4",
+            "value": 1004
+          }
+        },
+        "5": {
+          "value": 1005,
+          "params": {
+            "address": 5,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 5",
+            "value": 1005
+          }
+        },
+        "6": {
+          "value": 1006,
+          "params": {
+            "address": 6,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 6",
+            "value": 1006
+          }
+        },
+        "7": {
+          "value": 1007,
+          "params": {
+            "address": 7,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 7",
+            "value": 1007
+          }
+        },
+        "8": {
+          "value": 1008,
+          "params": {
+            "address": 8,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 8",
+            "value": 1008
+          }
+        },
+        "9": {
+          "value": 1009,
+          "params": {
+            "address": 9,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 9",
+            "value": 1009
+          }
+        },
+        "10": {
+          "value": 1010,
+          "params": {
+            "address": 10,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 10",
+            "value": 1010
+          }
+        },
+        "11": {
+          "value": 1011,
+          "params": {
+            "address": 11,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 11",
+            "value": 1011
+          }
+        },
+        "12": {
+          "value": 1012,
+          "params": {
+            "address": 12,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 12",
+            "value": 1012
+          }
+        },
+        "13": {
+          "value": 1013,
+          "params": {
+            "address": 13,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 13",
+            "value": 1013
+          }
+        },
+        "14": {
+          "value": 1014,
+          "params": {
+            "address": 14,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 14",
+            "value": 1014
+          }
+        },
+        "15": {
+          "value": 1015,
+          "params": {
+            "address": 15,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 15",
+            "value": 1015
+          }
+        },
+        "16": {
+          "value": 1016,
+          "params": {
+            "address": 16,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 16",
+            "value": 1016
+          }
+        },
+        "17": {
+          "value": 1017,
+          "params": {
+            "address": 17,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 17",
+            "value": 1017
+          }
+        },
+        "18": {
+          "value": 1018,
+          "params": {
+            "address": 18,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 18",
+            "value": 1018
+          }
+        },
+        "19": {
+          "value": 1019,
+          "params": {
+            "address": 19,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 19",
+            "value": 1019
+          }
+        },
+        "20": {
+          "value": 1020,
+          "params": {
+            "address": 20,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 20",
+            "value": 1020
+          }
+        },
+        "21": {
+          "value": 1021,
+          "params": {
+            "address": 21,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 21",
+            "value": 1021
+          }
+        },
+        "22": {
+          "value": 1022,
+          "params": {
+            "address": 22,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 22",
+            "value": 1022
+          }
+        },
+        "23": {
+          "value": 1023,
+          "params": {
+            "address": 23,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 23",
+            "value": 1023
+          }
+        },
+        "24": {
+          "value": 1024,
+          "params": {
+            "address": 24,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 24",
+            "value": 1024
+          }
+        },
+        "25": {
+          "value": 1025,
+          "params": {
+            "address": 25,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 25",
+            "value": 1025
+          }
+        },
+        "26": {
+          "value": 1026,
+          "params": {
+            "address": 26,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 26",
+            "value": 1026
+          }
+        },
+        "27": {
+          "value": 1027,
+          "params": {
+            "address": 27,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 27",
+            "value": 1027
+          }
+        },
+        "28": {
+          "value": 1028,
+          "params": {
+            "address": 28,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 28",
+            "value": 1028
+          }
+        },
+        "29": {
+          "value": 1029,
+          "params": {
+            "address": 29,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 29",
+            "value": 1029
+          }
+        },
+        "30": {
+          "value": 1030,
+          "params": {
+            "address": 30,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 30",
+            "value": 1030
+          }
+        },
+        "31": {
+          "value": 1031,
+          "params": {
+            "address": 31,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 31",
+            "value": 1031
+          }
+        },
+        "32": {
+          "value": 1032,
+          "params": {
+            "address": 32,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 32",
+            "value": 1032
+          }
+        },
+        "33": {
+          "value": 1033,
+          "params": {
+            "address": 33,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 33",
+            "value": 1033
+          }
+        },
+        "34": {
+          "value": 1034,
+          "params": {
+            "address": 34,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 34",
+            "value": 1034
+          }
+        },
+        "35": {
+          "value": 1035,
+          "params": {
+            "address": 35,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 35",
+            "value": 1035
+          }
+        },
+        "36": {
+          "value": 1036,
+          "params": {
+            "address": 36,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 36",
+            "value": 1036
+          }
+        },
+        "37": {
+          "value": 1037,
+          "params": {
+            "address": 37,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 37",
+            "value": 1037
+          }
+        },
+        "38": {
+          "value": 1038,
+          "params": {
+            "address": 38,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 38",
+            "value": 1038
+          }
+        },
+        "39": {
+          "value": 1039,
+          "params": {
+            "address": 39,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 39",
+            "value": 1039
+          }
+        },
+        "40": {
+          "value": 1040,
+          "params": {
+            "address": 40,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 40",
+            "value": 1040
+          }
+        },
+        "41": {
+          "value": 1041,
+          "params": {
+            "address": 41,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 41",
+            "value": 1041
+          }
+        },
+        "42": {
+          "value": 1042,
+          "params": {
+            "address": 42,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 42",
+            "value": 1042
+          }
+        },
+        "43": {
+          "value": 1043,
+          "params": {
+            "address": 43,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 43",
+            "value": 1043
+          }
+        },
+        "44": {
+          "value": 1044,
+          "params": {
+            "address": 44,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 44",
+            "value": 1044
+          }
+        },
+        "45": {
+          "value": 1045,
+          "params": {
+            "address": 45,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 45",
+            "value": 1045
+          }
+        },
+        "46": {
+          "value": 1046,
+          "params": {
+            "address": 46,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 46",
+            "value": 1046
+          }
+        },
+        "47": {
+          "value": 1047,
+          "params": {
+            "address": 47,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 47",
+            "value": 1047
+          }
+        },
+        "48": {
+          "value": 1048,
+          "params": {
+            "address": 48,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 48",
+            "value": 1048
+          }
+        },
+        "49": {
+          "value": 1049,
+          "params": {
+            "address": 49,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 49",
+            "value": 1049
+          }
+        },
+        "50": {
+          "value": 1050,
+          "params": {
+            "address": 50,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 50",
+            "value": 1050
+          }
+        },
+        "51": {
+          "value": 1051,
+          "params": {
+            "address": 51,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 51",
+            "value": 1051
+          }
+        },
+        "52": {
+          "value": 1052,
+          "params": {
+            "address": 52,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 52",
+            "value": 1052
+          }
+        },
+        "53": {
+          "value": 1053,
+          "params": {
+            "address": 53,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 53",
+            "value": 1053
+          }
+        },
+        "54": {
+          "value": 1054,
+          "params": {
+            "address": 54,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 54",
+            "value": 1054
+          }
+        },
+        "55": {
+          "value": 1055,
+          "params": {
+            "address": 55,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 55",
+            "value": 1055
+          }
+        },
+        "56": {
+          "value": 1056,
+          "params": {
+            "address": 56,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 56",
+            "value": 1056
+          }
+        },
+        "57": {
+          "value": 1057,
+          "params": {
+            "address": 57,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 57",
+            "value": 1057
+          }
+        },
+        "58": {
+          "value": 1058,
+          "params": {
+            "address": 58,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 58",
+            "value": 1058
+          }
+        },
+        "59": {
+          "value": 1059,
+          "params": {
+            "address": 59,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 59",
+            "value": 1059
+          }
+        },
+        "60": {
+          "value": 1060,
+          "params": {
+            "address": 60,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 60",
+            "value": 1060
+          }
+        },
+        "61": {
+          "value": 1061,
+          "params": {
+            "address": 61,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 61",
+            "value": 1061
+          }
+        },
+        "62": {
+          "value": 1062,
+          "params": {
+            "address": 62,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 62",
+            "value": 1062
+          }
+        },
+        "63": {
+          "value": 1063,
+          "params": {
+            "address": 63,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 63",
+            "value": 1063
+          }
+        },
+        "64": {
+          "value": 1064,
+          "params": {
+            "address": 64,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 64",
+            "value": 1064
+          }
+        },
+        "65": {
+          "value": 1065,
+          "params": {
+            "address": 65,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 65",
+            "value": 1065
+          }
+        },
+        "66": {
+          "value": 1066,
+          "params": {
+            "address": 66,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 66",
+            "value": 1066
+          }
+        },
+        "67": {
+          "value": 1067,
+          "params": {
+            "address": 67,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 67",
+            "value": 1067
+          }
+        },
+        "68": {
+          "value": 1068,
+          "params": {
+            "address": 68,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 68",
+            "value": 1068
+          }
+        },
+        "69": {
+          "value": 1069,
+          "params": {
+            "address": 69,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 69",
+            "value": 1069
+          }
+        },
+        "70": {
+          "value": 1070,
+          "params": {
+            "address": 70,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 70",
+            "value": 1070
+          }
+        },
+        "71": {
+          "value": 1071,
+          "params": {
+            "address": 71,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 71",
+            "value": 1071
+          }
+        },
+        "72": {
+          "value": 1072,
+          "params": {
+            "address": 72,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 72",
+            "value": 1072
+          }
+        },
+        "73": {
+          "value": 1073,
+          "params": {
+            "address": 73,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 73",
+            "value": 1073
+          }
+        },
+        "74": {
+          "value": 1074,
+          "params": {
+            "address": 74,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 74",
+            "value": 1074
+          }
+        },
+        "75": {
+          "value": 1075,
+          "params": {
+            "address": 75,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 75",
+            "value": 1075
+          }
+        },
+        "76": {
+          "value": 1076,
+          "params": {
+            "address": 76,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 76",
+            "value": 1076
+          }
+        },
+        "77": {
+          "value": 1077,
+          "params": {
+            "address": 77,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 77",
+            "value": 1077
+          }
+        },
+        "78": {
+          "value": 1078,
+          "params": {
+            "address": 78,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 78",
+            "value": 1078
+          }
+        },
+        "79": {
+          "value": 1079,
+          "params": {
+            "address": 79,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 79",
+            "value": 1079
+          }
+        },
+        "80": {
+          "value": 1080,
+          "params": {
+            "address": 80,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 80",
+            "value": 1080
+          }
+        },
+        "81": {
+          "value": 1081,
+          "params": {
+            "address": 81,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 81",
+            "value": 1081
+          }
+        },
+        "82": {
+          "value": 1082,
+          "params": {
+            "address": 82,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 82",
+            "value": 1082
+          }
+        },
+        "83": {
+          "value": 1083,
+          "params": {
+            "address": 83,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 83",
+            "value": 1083
+          }
+        },
+        "84": {
+          "value": 1084,
+          "params": {
+            "address": 84,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 84",
+            "value": 1084
+          }
+        },
+        "85": {
+          "value": 1085,
+          "params": {
+            "address": 85,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 85",
+            "value": 1085
+          }
+        },
+        "86": {
+          "value": 1086,
+          "params": {
+            "address": 86,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 86",
+            "value": 1086
+          }
+        },
+        "87": {
+          "value": 1087,
+          "params": {
+            "address": 87,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 87",
+            "value": 1087
+          }
+        },
+        "88": {
+          "value": 1088,
+          "params": {
+            "address": 88,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 88",
+            "value": 1088
+          }
+        },
+        "89": {
+          "value": 1089,
+          "params": {
+            "address": 89,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 89",
+            "value": 1089
+          }
+        },
+        "90": {
+          "value": 1090,
+          "params": {
+            "address": 90,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 90",
+            "value": 1090
+          }
+        },
+        "91": {
+          "value": 1091,
+          "params": {
+            "address": 91,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 91",
+            "value": 1091
+          }
+        },
+        "92": {
+          "value": 1092,
+          "params": {
+            "address": 92,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 92",
+            "value": 1092
+          }
+        },
+        "93": {
+          "value": 1093,
+          "params": {
+            "address": 93,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 93",
+            "value": 1093
+          }
+        },
+        "94": {
+          "value": 1094,
+          "params": {
+            "address": 94,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 94",
+            "value": 1094
+          }
+        },
+        "95": {
+          "value": 1095,
+          "params": {
+            "address": 95,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 95",
+            "value": 1095
+          }
+        },
+        "96": {
+          "value": 1096,
+          "params": {
+            "address": 96,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 96",
+            "value": 1096
+          }
+        },
+        "97": {
+          "value": 1097,
+          "params": {
+            "address": 97,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 97",
+            "value": 1097
+          }
+        },
+        "98": {
+          "value": 1098,
+          "params": {
+            "address": 98,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 98",
+            "value": 1098
+          }
+        },
+        "99": {
+          "value": 1099,
+          "params": {
+            "address": 99,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 99",
+            "value": 1099
+          }
+        },
+        "100": {
+          "value": 1100,
+          "params": {
+            "address": 100,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 100",
+            "value": 1100
+          }
+        },
+        "101": {
+          "value": 1101,
+          "params": {
+            "address": 101,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 101",
+            "value": 1101
+          }
+        },
+        "102": {
+          "value": 1102,
+          "params": {
+            "address": 102,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 102",
+            "value": 1102
+          }
+        },
+        "103": {
+          "value": 1103,
+          "params": {
+            "address": 103,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 103",
+            "value": 1103
+          }
+        },
+        "104": {
+          "value": 1104,
+          "params": {
+            "address": 104,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 104",
+            "value": 1104
+          }
+        },
+        "105": {
+          "value": 1105,
+          "params": {
+            "address": 105,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 105",
+            "value": 1105
+          }
+        },
+        "106": {
+          "value": 1106,
+          "params": {
+            "address": 106,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 106",
+            "value": 1106
+          }
+        },
+        "107": {
+          "value": 1107,
+          "params": {
+            "address": 107,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 107",
+            "value": 1107
+          }
+        },
+        "108": {
+          "value": 1108,
+          "params": {
+            "address": 108,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 108",
+            "value": 1108
+          }
+        },
+        "109": {
+          "value": 1109,
+          "params": {
+            "address": 109,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 109",
+            "value": 1109
+          }
+        },
+        "110": {
+          "value": 1110,
+          "params": {
+            "address": 110,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 110",
+            "value": 1110
+          }
+        },
+        "111": {
+          "value": 1111,
+          "params": {
+            "address": 111,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 111",
+            "value": 1111
+          }
+        },
+        "112": {
+          "value": 1112,
+          "params": {
+            "address": 112,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 112",
+            "value": 1112
+          }
+        },
+        "113": {
+          "value": 1113,
+          "params": {
+            "address": 113,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 113",
+            "value": 1113
+          }
+        },
+        "114": {
+          "value": 1114,
+          "params": {
+            "address": 114,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 114",
+            "value": 1114
+          }
+        },
+        "115": {
+          "value": 1115,
+          "params": {
+            "address": 115,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 115",
+            "value": 1115
+          }
+        },
+        "116": {
+          "value": 1116,
+          "params": {
+            "address": 116,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 116",
+            "value": 1116
+          }
+        },
+        "117": {
+          "value": 1117,
+          "params": {
+            "address": 117,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 117",
+            "value": 1117
+          }
+        },
+        "118": {
+          "value": 1118,
+          "params": {
+            "address": 118,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 118",
+            "value": 1118
+          }
+        },
+        "119": {
+          "value": 1119,
+          "params": {
+            "address": 119,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 119",
+            "value": 1119
+          }
+        },
+        "120": {
+          "value": 1120,
+          "params": {
+            "address": 120,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 120",
+            "value": 1120
+          }
+        },
+        "121": {
+          "value": 1121,
+          "params": {
+            "address": 121,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 121",
+            "value": 1121
+          }
+        },
+        "122": {
+          "value": 1122,
+          "params": {
+            "address": 122,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 122",
+            "value": 1122
+          }
+        },
+        "123": {
+          "value": 1123,
+          "params": {
+            "address": 123,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 123",
+            "value": 1123
+          }
+        },
+        "124": {
+          "value": 1124,
+          "params": {
+            "address": 124,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 124",
+            "value": 1124
+          }
+        },
+        "125": {
+          "value": 1125,
+          "params": {
+            "address": 125,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 125",
+            "value": 1125
+          }
+        },
+        "126": {
+          "value": 1126,
+          "params": {
+            "address": 126,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 126",
+            "value": 1126
+          }
+        },
+        "127": {
+          "value": 1127,
+          "params": {
+            "address": 127,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 127",
+            "value": 1127
+          }
+        },
+        "128": {
+          "value": 1128,
+          "params": {
+            "address": 128,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 128",
+            "value": 1128
+          }
+        },
+        "129": {
+          "value": 1129,
+          "params": {
+            "address": 129,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 129",
+            "value": 1129
+          }
+        },
+        "130": {
+          "value": 1130,
+          "params": {
+            "address": 130,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 130",
+            "value": 1130
+          }
+        },
+        "131": {
+          "value": 1131,
+          "params": {
+            "address": 131,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 131",
+            "value": 1131
+          }
+        },
+        "132": {
+          "value": 1132,
+          "params": {
+            "address": 132,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 132",
+            "value": 1132
+          }
+        },
+        "133": {
+          "value": 1133,
+          "params": {
+            "address": 133,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 133",
+            "value": 1133
+          }
+        },
+        "134": {
+          "value": 1134,
+          "params": {
+            "address": 134,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 134",
+            "value": 1134
+          }
+        },
+        "135": {
+          "value": 1135,
+          "params": {
+            "address": 135,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 135",
+            "value": 1135
+          }
+        },
+        "136": {
+          "value": 1136,
+          "params": {
+            "address": 136,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 136",
+            "value": 1136
+          }
+        },
+        "137": {
+          "value": 1137,
+          "params": {
+            "address": 137,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 137",
+            "value": 1137
+          }
+        },
+        "138": {
+          "value": 1138,
+          "params": {
+            "address": 138,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 138",
+            "value": 1138
+          }
+        },
+        "139": {
+          "value": 1139,
+          "params": {
+            "address": 139,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 139",
+            "value": 1139
+          }
+        },
+        "140": {
+          "value": 1140,
+          "params": {
+            "address": 140,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 140",
+            "value": 1140
+          }
+        },
+        "141": {
+          "value": 1141,
+          "params": {
+            "address": 141,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 141",
+            "value": 1141
+          }
+        },
+        "142": {
+          "value": 1142,
+          "params": {
+            "address": 142,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 142",
+            "value": 1142
+          }
+        },
+        "143": {
+          "value": 1143,
+          "params": {
+            "address": 143,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 143",
+            "value": 1143
+          }
+        },
+        "144": {
+          "value": 1144,
+          "params": {
+            "address": 144,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 144",
+            "value": 1144
+          }
+        },
+        "145": {
+          "value": 1145,
+          "params": {
+            "address": 145,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 145",
+            "value": 1145
+          }
+        },
+        "146": {
+          "value": 1146,
+          "params": {
+            "address": 146,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 146",
+            "value": 1146
+          }
+        },
+        "147": {
+          "value": 1147,
+          "params": {
+            "address": 147,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 147",
+            "value": 1147
+          }
+        },
+        "148": {
+          "value": 1148,
+          "params": {
+            "address": 148,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 148",
+            "value": 1148
+          }
+        },
+        "149": {
+          "value": 1149,
+          "params": {
+            "address": 149,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 149",
+            "value": 1149
+          }
+        },
+        "150": {
+          "value": 1150,
+          "params": {
+            "address": 150,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 150",
+            "value": 1150
+          }
+        },
+        "151": {
+          "value": 1151,
+          "params": {
+            "address": 151,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 151",
+            "value": 1151
+          }
+        },
+        "152": {
+          "value": 1152,
+          "params": {
+            "address": 152,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 152",
+            "value": 1152
+          }
+        },
+        "153": {
+          "value": 1153,
+          "params": {
+            "address": 153,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 153",
+            "value": 1153
+          }
+        },
+        "154": {
+          "value": 1154,
+          "params": {
+            "address": 154,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 154",
+            "value": 1154
+          }
+        },
+        "155": {
+          "value": 1155,
+          "params": {
+            "address": 155,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 155",
+            "value": 1155
+          }
+        },
+        "156": {
+          "value": 1156,
+          "params": {
+            "address": 156,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 156",
+            "value": 1156
+          }
+        },
+        "157": {
+          "value": 1157,
+          "params": {
+            "address": 157,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 157",
+            "value": 1157
+          }
+        },
+        "158": {
+          "value": 1158,
+          "params": {
+            "address": 158,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 158",
+            "value": 1158
+          }
+        },
+        "159": {
+          "value": 1159,
+          "params": {
+            "address": 159,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 159",
+            "value": 1159
+          }
+        },
+        "160": {
+          "value": 1160,
+          "params": {
+            "address": 160,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 160",
+            "value": 1160
+          }
+        },
+        "161": {
+          "value": 1161,
+          "params": {
+            "address": 161,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 161",
+            "value": 1161
+          }
+        },
+        "162": {
+          "value": 1162,
+          "params": {
+            "address": 162,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 162",
+            "value": 1162
+          }
+        },
+        "163": {
+          "value": 1163,
+          "params": {
+            "address": 163,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 163",
+            "value": 1163
+          }
+        },
+        "164": {
+          "value": 1164,
+          "params": {
+            "address": 164,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 164",
+            "value": 1164
+          }
+        },
+        "165": {
+          "value": 1165,
+          "params": {
+            "address": 165,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 165",
+            "value": 1165
+          }
+        },
+        "166": {
+          "value": 1166,
+          "params": {
+            "address": 166,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 166",
+            "value": 1166
+          }
+        },
+        "167": {
+          "value": 1167,
+          "params": {
+            "address": 167,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 167",
+            "value": 1167
+          }
+        },
+        "168": {
+          "value": 1168,
+          "params": {
+            "address": 168,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 168",
+            "value": 1168
+          }
+        },
+        "169": {
+          "value": 1169,
+          "params": {
+            "address": 169,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 169",
+            "value": 1169
+          }
+        },
+        "170": {
+          "value": 1170,
+          "params": {
+            "address": 170,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 170",
+            "value": 1170
+          }
+        },
+        "171": {
+          "value": 1171,
+          "params": {
+            "address": 171,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 171",
+            "value": 1171
+          }
+        },
+        "172": {
+          "value": 1172,
+          "params": {
+            "address": 172,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 172",
+            "value": 1172
+          }
+        },
+        "173": {
+          "value": 1173,
+          "params": {
+            "address": 173,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 173",
+            "value": 1173
+          }
+        },
+        "174": {
+          "value": 1174,
+          "params": {
+            "address": 174,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 174",
+            "value": 1174
+          }
+        },
+        "175": {
+          "value": 1175,
+          "params": {
+            "address": 175,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 175",
+            "value": 1175
+          }
+        },
+        "176": {
+          "value": 1176,
+          "params": {
+            "address": 176,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 176",
+            "value": 1176
+          }
+        },
+        "177": {
+          "value": 1177,
+          "params": {
+            "address": 177,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 177",
+            "value": 1177
+          }
+        },
+        "178": {
+          "value": 1178,
+          "params": {
+            "address": 178,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 178",
+            "value": 1178
+          }
+        },
+        "179": {
+          "value": 1179,
+          "params": {
+            "address": 179,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 179",
+            "value": 1179
+          }
+        },
+        "180": {
+          "value": 1180,
+          "params": {
+            "address": 180,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 180",
+            "value": 1180
+          }
+        },
+        "181": {
+          "value": 1181,
+          "params": {
+            "address": 181,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 181",
+            "value": 1181
+          }
+        },
+        "182": {
+          "value": 1182,
+          "params": {
+            "address": 182,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 182",
+            "value": 1182
+          }
+        },
+        "183": {
+          "value": 1183,
+          "params": {
+            "address": 183,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 183",
+            "value": 1183
+          }
+        },
+        "184": {
+          "value": 1184,
+          "params": {
+            "address": 184,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 184",
+            "value": 1184
+          }
+        },
+        "185": {
+          "value": 1185,
+          "params": {
+            "address": 185,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 185",
+            "value": 1185
+          }
+        },
+        "186": {
+          "value": 1186,
+          "params": {
+            "address": 186,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 186",
+            "value": 1186
+          }
+        },
+        "187": {
+          "value": 1187,
+          "params": {
+            "address": 187,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 187",
+            "value": 1187
+          }
+        },
+        "188": {
+          "value": 1188,
+          "params": {
+            "address": 188,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 188",
+            "value": 1188
+          }
+        },
+        "189": {
+          "value": 1189,
+          "params": {
+            "address": 189,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 189",
+            "value": 1189
+          }
+        },
+        "190": {
+          "value": 1190,
+          "params": {
+            "address": 190,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 190",
+            "value": 1190
+          }
+        },
+        "191": {
+          "value": 1191,
+          "params": {
+            "address": 191,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 191",
+            "value": 1191
+          }
+        },
+        "192": {
+          "value": 1192,
+          "params": {
+            "address": 192,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 192",
+            "value": 1192
+          }
+        },
+        "193": {
+          "value": 1193,
+          "params": {
+            "address": 193,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 193",
+            "value": 1193
+          }
+        },
+        "194": {
+          "value": 1194,
+          "params": {
+            "address": 194,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 194",
+            "value": 1194
+          }
+        },
+        "195": {
+          "value": 1195,
+          "params": {
+            "address": 195,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 195",
+            "value": 1195
+          }
+        },
+        "196": {
+          "value": 1196,
+          "params": {
+            "address": 196,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 196",
+            "value": 1196
+          }
+        },
+        "197": {
+          "value": 1197,
+          "params": {
+            "address": 197,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 197",
+            "value": 1197
+          }
+        },
+        "198": {
+          "value": 1198,
+          "params": {
+            "address": 198,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 198",
+            "value": 1198
+          }
+        },
+        "199": {
+          "value": 1199,
+          "params": {
+            "address": 199,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 199",
+            "value": 1199
+          }
+        },
+        "200": {
+          "value": 1200,
+          "params": {
+            "address": 200,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 200",
+            "value": 1200
+          }
+        },
+        "201": {
+          "value": 1201,
+          "params": {
+            "address": 201,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 201",
+            "value": 1201
+          }
+        },
+        "202": {
+          "value": 1202,
+          "params": {
+            "address": 202,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 202",
+            "value": 1202
+          }
+        },
+        "203": {
+          "value": 1203,
+          "params": {
+            "address": 203,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 203",
+            "value": 1203
+          }
+        },
+        "204": {
+          "value": 1204,
+          "params": {
+            "address": 204,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 204",
+            "value": 1204
+          }
+        },
+        "205": {
+          "value": 1205,
+          "params": {
+            "address": 205,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 205",
+            "value": 1205
+          }
+        },
+        "206": {
+          "value": 1206,
+          "params": {
+            "address": 206,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 206",
+            "value": 1206
+          }
+        },
+        "207": {
+          "value": 1207,
+          "params": {
+            "address": 207,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 207",
+            "value": 1207
+          }
+        },
+        "208": {
+          "value": 1208,
+          "params": {
+            "address": 208,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 208",
+            "value": 1208
+          }
+        },
+        "209": {
+          "value": 1209,
+          "params": {
+            "address": 209,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 209",
+            "value": 1209
+          }
+        },
+        "210": {
+          "value": 1210,
+          "params": {
+            "address": 210,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 210",
+            "value": 1210
+          }
+        },
+        "211": {
+          "value": 1211,
+          "params": {
+            "address": 211,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 211",
+            "value": 1211
+          }
+        },
+        "212": {
+          "value": 1212,
+          "params": {
+            "address": 212,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 212",
+            "value": 1212
+          }
+        },
+        "213": {
+          "value": 1213,
+          "params": {
+            "address": 213,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 213",
+            "value": 1213
+          }
+        },
+        "214": {
+          "value": 1214,
+          "params": {
+            "address": 214,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 214",
+            "value": 1214
+          }
+        },
+        "215": {
+          "value": 1215,
+          "params": {
+            "address": 215,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 215",
+            "value": 1215
+          }
+        },
+        "216": {
+          "value": 1216,
+          "params": {
+            "address": 216,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 216",
+            "value": 1216
+          }
+        },
+        "217": {
+          "value": 1217,
+          "params": {
+            "address": 217,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 217",
+            "value": 1217
+          }
+        },
+        "218": {
+          "value": 1218,
+          "params": {
+            "address": 218,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 218",
+            "value": 1218
+          }
+        },
+        "219": {
+          "value": 1219,
+          "params": {
+            "address": 219,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 219",
+            "value": 1219
+          }
+        },
+        "220": {
+          "value": 1220,
+          "params": {
+            "address": 220,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 220",
+            "value": 1220
+          }
+        },
+        "221": {
+          "value": 1221,
+          "params": {
+            "address": 221,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 221",
+            "value": 1221
+          }
+        },
+        "222": {
+          "value": 1222,
+          "params": {
+            "address": 222,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 222",
+            "value": 1222
+          }
+        },
+        "223": {
+          "value": 1223,
+          "params": {
+            "address": 223,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 223",
+            "value": 1223
+          }
+        },
+        "224": {
+          "value": 1224,
+          "params": {
+            "address": 224,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 224",
+            "value": 1224
+          }
+        },
+        "225": {
+          "value": 1225,
+          "params": {
+            "address": 225,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 225",
+            "value": 1225
+          }
+        },
+        "226": {
+          "value": 1226,
+          "params": {
+            "address": 226,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 226",
+            "value": 1226
+          }
+        },
+        "227": {
+          "value": 1227,
+          "params": {
+            "address": 227,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 227",
+            "value": 1227
+          }
+        },
+        "228": {
+          "value": 1228,
+          "params": {
+            "address": 228,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 228",
+            "value": 1228
+          }
+        },
+        "229": {
+          "value": 1229,
+          "params": {
+            "address": 229,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 229",
+            "value": 1229
+          }
+        },
+        "230": {
+          "value": 1230,
+          "params": {
+            "address": 230,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 230",
+            "value": 1230
+          }
+        },
+        "231": {
+          "value": 1231,
+          "params": {
+            "address": 231,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 231",
+            "value": 1231
+          }
+        },
+        "232": {
+          "value": 1232,
+          "params": {
+            "address": 232,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 232",
+            "value": 1232
+          }
+        },
+        "233": {
+          "value": 1233,
+          "params": {
+            "address": 233,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 233",
+            "value": 1233
+          }
+        },
+        "234": {
+          "value": 1234,
+          "params": {
+            "address": 234,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 234",
+            "value": 1234
+          }
+        },
+        "235": {
+          "value": 1235,
+          "params": {
+            "address": 235,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 235",
+            "value": 1235
+          }
+        },
+        "236": {
+          "value": 1236,
+          "params": {
+            "address": 236,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 236",
+            "value": 1236
+          }
+        },
+        "237": {
+          "value": 1237,
+          "params": {
+            "address": 237,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 237",
+            "value": 1237
+          }
+        },
+        "238": {
+          "value": 1238,
+          "params": {
+            "address": 238,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 238",
+            "value": 1238
+          }
+        },
+        "239": {
+          "value": 1239,
+          "params": {
+            "address": 239,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 239",
+            "value": 1239
+          }
+        },
+        "240": {
+          "value": 1240,
+          "params": {
+            "address": 240,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 240",
+            "value": 1240
+          }
+        },
+        "241": {
+          "value": 1241,
+          "params": {
+            "address": 241,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 241",
+            "value": 1241
+          }
+        },
+        "242": {
+          "value": 1242,
+          "params": {
+            "address": 242,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 242",
+            "value": 1242
+          }
+        },
+        "243": {
+          "value": 1243,
+          "params": {
+            "address": 243,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 243",
+            "value": 1243
+          }
+        },
+        "244": {
+          "value": 1244,
+          "params": {
+            "address": 244,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 244",
+            "value": 1244
+          }
+        },
+        "245": {
+          "value": 1245,
+          "params": {
+            "address": 245,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 245",
+            "value": 1245
+          }
+        },
+        "246": {
+          "value": 1246,
+          "params": {
+            "address": 246,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 246",
+            "value": 1246
+          }
+        },
+        "247": {
+          "value": 1247,
+          "params": {
+            "address": 247,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 247",
+            "value": 1247
+          }
+        },
+        "248": {
+          "value": 1248,
+          "params": {
+            "address": 248,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 248",
+            "value": 1248
+          }
+        },
+        "249": {
+          "value": 1249,
+          "params": {
+            "address": 249,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 249",
+            "value": 1249
+          }
+        },
+        "250": {
+          "value": 1250,
+          "params": {
+            "address": 250,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 250",
+            "value": 1250
+          }
+        },
+        "251": {
+          "value": 1251,
+          "params": {
+            "address": 251,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 251",
+            "value": 1251
+          }
+        },
+        "252": {
+          "value": 1252,
+          "params": {
+            "address": 252,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 252",
+            "value": 1252
+          }
+        },
+        "253": {
+          "value": 1253,
+          "params": {
+            "address": 253,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 253",
+            "value": 1253
+          }
+        },
+        "254": {
+          "value": 1254,
+          "params": {
+            "address": 254,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 254",
+            "value": 1254
+          }
+        },
+        "255": {
+          "value": 1255,
+          "params": {
+            "address": 255,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 255",
+            "value": 1255
+          }
+        },
+        "256": {
+          "value": 1256,
+          "params": {
+            "address": 256,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 256",
+            "value": 1256
+          }
+        },
+        "257": {
+          "value": 1257,
+          "params": {
+            "address": 257,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 257",
+            "value": 1257
+          }
+        },
+        "258": {
+          "value": 1258,
+          "params": {
+            "address": 258,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 258",
+            "value": 1258
+          }
+        },
+        "259": {
+          "value": 1259,
+          "params": {
+            "address": 259,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 259",
+            "value": 1259
+          }
+        },
+        "260": {
+          "value": 1260,
+          "params": {
+            "address": 260,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 260",
+            "value": 1260
+          }
+        },
+        "261": {
+          "value": 1261,
+          "params": {
+            "address": 261,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 261",
+            "value": 1261
+          }
+        },
+        "262": {
+          "value": 1262,
+          "params": {
+            "address": 262,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 262",
+            "value": 1262
+          }
+        },
+        "263": {
+          "value": 1263,
+          "params": {
+            "address": 263,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 263",
+            "value": 1263
+          }
+        },
+        "264": {
+          "value": 1264,
+          "params": {
+            "address": 264,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 264",
+            "value": 1264
+          }
+        },
+        "265": {
+          "value": 1265,
+          "params": {
+            "address": 265,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 265",
+            "value": 1265
+          }
+        },
+        "266": {
+          "value": 1266,
+          "params": {
+            "address": 266,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 266",
+            "value": 1266
+          }
+        },
+        "267": {
+          "value": 1267,
+          "params": {
+            "address": 267,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 267",
+            "value": 1267
+          }
+        },
+        "268": {
+          "value": 1268,
+          "params": {
+            "address": 268,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 268",
+            "value": 1268
+          }
+        },
+        "269": {
+          "value": 1269,
+          "params": {
+            "address": 269,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 269",
+            "value": 1269
+          }
+        },
+        "270": {
+          "value": 1270,
+          "params": {
+            "address": 270,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 270",
+            "value": 1270
+          }
+        },
+        "271": {
+          "value": 1271,
+          "params": {
+            "address": 271,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 271",
+            "value": 1271
+          }
+        },
+        "272": {
+          "value": 1272,
+          "params": {
+            "address": 272,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 272",
+            "value": 1272
+          }
+        },
+        "273": {
+          "value": 1273,
+          "params": {
+            "address": 273,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 273",
+            "value": 1273
+          }
+        },
+        "274": {
+          "value": 1274,
+          "params": {
+            "address": 274,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 274",
+            "value": 1274
+          }
+        },
+        "275": {
+          "value": 1275,
+          "params": {
+            "address": 275,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 275",
+            "value": 1275
+          }
+        },
+        "276": {
+          "value": 1276,
+          "params": {
+            "address": 276,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 276",
+            "value": 1276
+          }
+        },
+        "277": {
+          "value": 1277,
+          "params": {
+            "address": 277,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 277",
+            "value": 1277
+          }
+        },
+        "278": {
+          "value": 1278,
+          "params": {
+            "address": 278,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 278",
+            "value": 1278
+          }
+        },
+        "279": {
+          "value": 1279,
+          "params": {
+            "address": 279,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 279",
+            "value": 1279
+          }
+        },
+        "280": {
+          "value": 1280,
+          "params": {
+            "address": 280,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 280",
+            "value": 1280
+          }
+        },
+        "281": {
+          "value": 1281,
+          "params": {
+            "address": 281,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 281",
+            "value": 1281
+          }
+        },
+        "282": {
+          "value": 1282,
+          "params": {
+            "address": 282,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 282",
+            "value": 1282
+          }
+        },
+        "283": {
+          "value": 1283,
+          "params": {
+            "address": 283,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 283",
+            "value": 1283
+          }
+        },
+        "284": {
+          "value": 1284,
+          "params": {
+            "address": 284,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 284",
+            "value": 1284
+          }
+        },
+        "285": {
+          "value": 1285,
+          "params": {
+            "address": 285,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 285",
+            "value": 1285
+          }
+        },
+        "286": {
+          "value": 1286,
+          "params": {
+            "address": 286,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 286",
+            "value": 1286
+          }
+        },
+        "287": {
+          "value": 1287,
+          "params": {
+            "address": 287,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 287",
+            "value": 1287
+          }
+        },
+        "288": {
+          "value": 1288,
+          "params": {
+            "address": 288,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 288",
+            "value": 1288
+          }
+        },
+        "289": {
+          "value": 1289,
+          "params": {
+            "address": 289,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 289",
+            "value": 1289
+          }
+        },
+        "290": {
+          "value": 1290,
+          "params": {
+            "address": 290,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 290",
+            "value": 1290
+          }
+        },
+        "291": {
+          "value": 1291,
+          "params": {
+            "address": 291,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 291",
+            "value": 1291
+          }
+        },
+        "292": {
+          "value": 1292,
+          "params": {
+            "address": 292,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 292",
+            "value": 1292
+          }
+        },
+        "293": {
+          "value": 1293,
+          "params": {
+            "address": 293,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 293",
+            "value": 1293
+          }
+        },
+        "294": {
+          "value": 1294,
+          "params": {
+            "address": 294,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 294",
+            "value": 1294
+          }
+        },
+        "295": {
+          "value": 1295,
+          "params": {
+            "address": 295,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 295",
+            "value": 1295
+          }
+        },
+        "296": {
+          "value": 1296,
+          "params": {
+            "address": 296,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 296",
+            "value": 1296
+          }
+        },
+        "297": {
+          "value": 1297,
+          "params": {
+            "address": 297,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 297",
+            "value": 1297
+          }
+        },
+        "298": {
+          "value": 1298,
+          "params": {
+            "address": 298,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 298",
+            "value": 1298
+          }
+        },
+        "299": {
+          "value": 1299,
+          "params": {
+            "address": 299,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 299",
+            "value": 1299
+          }
+        },
+        "300": {
+          "value": 1300,
+          "params": {
+            "address": 300,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 300",
+            "value": 1300
+          }
+        },
+        "301": {
+          "value": 1301,
+          "params": {
+            "address": 301,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 301",
+            "value": 1301
+          }
+        },
+        "302": {
+          "value": 1302,
+          "params": {
+            "address": 302,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 302",
+            "value": 1302
+          }
+        },
+        "303": {
+          "value": 1303,
+          "params": {
+            "address": 303,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 303",
+            "value": 1303
+          }
+        },
+        "304": {
+          "value": 1304,
+          "params": {
+            "address": 304,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 304",
+            "value": 1304
+          }
+        },
+        "305": {
+          "value": 1305,
+          "params": {
+            "address": 305,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 305",
+            "value": 1305
+          }
+        },
+        "306": {
+          "value": 1306,
+          "params": {
+            "address": 306,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 306",
+            "value": 1306
+          }
+        },
+        "307": {
+          "value": 1307,
+          "params": {
+            "address": 307,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 307",
+            "value": 1307
+          }
+        },
+        "308": {
+          "value": 1308,
+          "params": {
+            "address": 308,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 308",
+            "value": 1308
+          }
+        },
+        "309": {
+          "value": 1309,
+          "params": {
+            "address": 309,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 309",
+            "value": 1309
+          }
+        },
+        "310": {
+          "value": 1310,
+          "params": {
+            "address": 310,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 310",
+            "value": 1310
+          }
+        },
+        "311": {
+          "value": 1311,
+          "params": {
+            "address": 311,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 311",
+            "value": 1311
+          }
+        },
+        "312": {
+          "value": 1312,
+          "params": {
+            "address": 312,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 312",
+            "value": 1312
+          }
+        },
+        "313": {
+          "value": 1313,
+          "params": {
+            "address": 313,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 313",
+            "value": 1313
+          }
+        },
+        "314": {
+          "value": 1314,
+          "params": {
+            "address": 314,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 314",
+            "value": 1314
+          }
+        },
+        "315": {
+          "value": 1315,
+          "params": {
+            "address": 315,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 315",
+            "value": 1315
+          }
+        },
+        "316": {
+          "value": 1316,
+          "params": {
+            "address": 316,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 316",
+            "value": 1316
+          }
+        },
+        "317": {
+          "value": 1317,
+          "params": {
+            "address": 317,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 317",
+            "value": 1317
+          }
+        },
+        "318": {
+          "value": 1318,
+          "params": {
+            "address": 318,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 318",
+            "value": 1318
+          }
+        },
+        "319": {
+          "value": 1319,
+          "params": {
+            "address": 319,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 319",
+            "value": 1319
+          }
+        },
+        "320": {
+          "value": 1320,
+          "params": {
+            "address": 320,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 320",
+            "value": 1320
+          }
+        },
+        "321": {
+          "value": 1321,
+          "params": {
+            "address": 321,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 321",
+            "value": 1321
+          }
+        },
+        "322": {
+          "value": 1322,
+          "params": {
+            "address": 322,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 322",
+            "value": 1322
+          }
+        },
+        "323": {
+          "value": 1323,
+          "params": {
+            "address": 323,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 323",
+            "value": 1323
+          }
+        },
+        "324": {
+          "value": 1324,
+          "params": {
+            "address": 324,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 324",
+            "value": 1324
+          }
+        },
+        "325": {
+          "value": 1325,
+          "params": {
+            "address": 325,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 325",
+            "value": 1325
+          }
+        },
+        "326": {
+          "value": 1326,
+          "params": {
+            "address": 326,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 326",
+            "value": 1326
+          }
+        },
+        "327": {
+          "value": 1327,
+          "params": {
+            "address": 327,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 327",
+            "value": 1327
+          }
+        },
+        "328": {
+          "value": 1328,
+          "params": {
+            "address": 328,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 328",
+            "value": 1328
+          }
+        },
+        "329": {
+          "value": 1329,
+          "params": {
+            "address": 329,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 329",
+            "value": 1329
+          }
+        },
+        "330": {
+          "value": 1330,
+          "params": {
+            "address": 330,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 330",
+            "value": 1330
+          }
+        },
+        "331": {
+          "value": 1331,
+          "params": {
+            "address": 331,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 331",
+            "value": 1331
+          }
+        },
+        "332": {
+          "value": 1332,
+          "params": {
+            "address": 332,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 332",
+            "value": 1332
+          }
+        },
+        "333": {
+          "value": 1333,
+          "params": {
+            "address": 333,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 333",
+            "value": 1333
+          }
+        },
+        "334": {
+          "value": 1334,
+          "params": {
+            "address": 334,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 334",
+            "value": 1334
+          }
+        },
+        "335": {
+          "value": 1335,
+          "params": {
+            "address": 335,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 335",
+            "value": 1335
+          }
+        },
+        "336": {
+          "value": 1336,
+          "params": {
+            "address": 336,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 336",
+            "value": 1336
+          }
+        },
+        "337": {
+          "value": 1337,
+          "params": {
+            "address": 337,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 337",
+            "value": 1337
+          }
+        },
+        "338": {
+          "value": 1338,
+          "params": {
+            "address": 338,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 338",
+            "value": 1338
+          }
+        },
+        "339": {
+          "value": 1339,
+          "params": {
+            "address": 339,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 339",
+            "value": 1339
+          }
+        },
+        "340": {
+          "value": 1340,
+          "params": {
+            "address": 340,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 340",
+            "value": 1340
+          }
+        },
+        "341": {
+          "value": 1341,
+          "params": {
+            "address": 341,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 341",
+            "value": 1341
+          }
+        },
+        "342": {
+          "value": 1342,
+          "params": {
+            "address": 342,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 342",
+            "value": 1342
+          }
+        },
+        "343": {
+          "value": 1343,
+          "params": {
+            "address": 343,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 343",
+            "value": 1343
+          }
+        },
+        "344": {
+          "value": 1344,
+          "params": {
+            "address": 344,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 344",
+            "value": 1344
+          }
+        },
+        "345": {
+          "value": 1345,
+          "params": {
+            "address": 345,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 345",
+            "value": 1345
+          }
+        },
+        "346": {
+          "value": 1346,
+          "params": {
+            "address": 346,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 346",
+            "value": 1346
+          }
+        },
+        "347": {
+          "value": 1347,
+          "params": {
+            "address": 347,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 347",
+            "value": 1347
+          }
+        },
+        "348": {
+          "value": 1348,
+          "params": {
+            "address": 348,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 348",
+            "value": 1348
+          }
+        },
+        "349": {
+          "value": 1349,
+          "params": {
+            "address": 349,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 349",
+            "value": 1349
+          }
+        },
+        "350": {
+          "value": 1350,
+          "params": {
+            "address": 350,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 350",
+            "value": 1350
+          }
+        },
+        "351": {
+          "value": 1351,
+          "params": {
+            "address": 351,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 351",
+            "value": 1351
+          }
+        },
+        "352": {
+          "value": 1352,
+          "params": {
+            "address": 352,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 352",
+            "value": 1352
+          }
+        },
+        "353": {
+          "value": 1353,
+          "params": {
+            "address": 353,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 353",
+            "value": 1353
+          }
+        },
+        "354": {
+          "value": 1354,
+          "params": {
+            "address": 354,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 354",
+            "value": 1354
+          }
+        },
+        "355": {
+          "value": 1355,
+          "params": {
+            "address": 355,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 355",
+            "value": 1355
+          }
+        },
+        "356": {
+          "value": 1356,
+          "params": {
+            "address": 356,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 356",
+            "value": 1356
+          }
+        },
+        "357": {
+          "value": 1357,
+          "params": {
+            "address": 357,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 357",
+            "value": 1357
+          }
+        },
+        "358": {
+          "value": 1358,
+          "params": {
+            "address": 358,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 358",
+            "value": 1358
+          }
+        },
+        "359": {
+          "value": 1359,
+          "params": {
+            "address": 359,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 359",
+            "value": 1359
+          }
+        },
+        "360": {
+          "value": 1360,
+          "params": {
+            "address": 360,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 360",
+            "value": 1360
+          }
+        },
+        "361": {
+          "value": 1361,
+          "params": {
+            "address": 361,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 361",
+            "value": 1361
+          }
+        },
+        "362": {
+          "value": 1362,
+          "params": {
+            "address": 362,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 362",
+            "value": 1362
+          }
+        },
+        "363": {
+          "value": 1363,
+          "params": {
+            "address": 363,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 363",
+            "value": 1363
+          }
+        },
+        "364": {
+          "value": 1364,
+          "params": {
+            "address": 364,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 364",
+            "value": 1364
+          }
+        },
+        "365": {
+          "value": 1365,
+          "params": {
+            "address": 365,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 365",
+            "value": 1365
+          }
+        },
+        "366": {
+          "value": 1366,
+          "params": {
+            "address": 366,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 366",
+            "value": 1366
+          }
+        },
+        "367": {
+          "value": 1367,
+          "params": {
+            "address": 367,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 367",
+            "value": 1367
+          }
+        },
+        "368": {
+          "value": 1368,
+          "params": {
+            "address": 368,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 368",
+            "value": 1368
+          }
+        },
+        "369": {
+          "value": 1369,
+          "params": {
+            "address": 369,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 369",
+            "value": 1369
+          }
+        },
+        "370": {
+          "value": 1370,
+          "params": {
+            "address": 370,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 370",
+            "value": 1370
+          }
+        },
+        "371": {
+          "value": 1371,
+          "params": {
+            "address": 371,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 371",
+            "value": 1371
+          }
+        },
+        "372": {
+          "value": 1372,
+          "params": {
+            "address": 372,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 372",
+            "value": 1372
+          }
+        },
+        "373": {
+          "value": 1373,
+          "params": {
+            "address": 373,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 373",
+            "value": 1373
+          }
+        },
+        "374": {
+          "value": 1374,
+          "params": {
+            "address": 374,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 374",
+            "value": 1374
+          }
+        },
+        "375": {
+          "value": 1375,
+          "params": {
+            "address": 375,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 375",
+            "value": 1375
+          }
+        },
+        "376": {
+          "value": 1376,
+          "params": {
+            "address": 376,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 376",
+            "value": 1376
+          }
+        },
+        "377": {
+          "value": 1377,
+          "params": {
+            "address": 377,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 377",
+            "value": 1377
+          }
+        },
+        "378": {
+          "value": 1378,
+          "params": {
+            "address": 378,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 378",
+            "value": 1378
+          }
+        },
+        "379": {
+          "value": 1379,
+          "params": {
+            "address": 379,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 379",
+            "value": 1379
+          }
+        },
+        "380": {
+          "value": 1380,
+          "params": {
+            "address": 380,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 380",
+            "value": 1380
+          }
+        },
+        "381": {
+          "value": 1381,
+          "params": {
+            "address": 381,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 381",
+            "value": 1381
+          }
+        },
+        "382": {
+          "value": 1382,
+          "params": {
+            "address": 382,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 382",
+            "value": 1382
+          }
+        },
+        "383": {
+          "value": 1383,
+          "params": {
+            "address": 383,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 383",
+            "value": 1383
+          }
+        },
+        "384": {
+          "value": 1384,
+          "params": {
+            "address": 384,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 384",
+            "value": 1384
+          }
+        },
+        "385": {
+          "value": 1385,
+          "params": {
+            "address": 385,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 385",
+            "value": 1385
+          }
+        },
+        "386": {
+          "value": 1386,
+          "params": {
+            "address": 386,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 386",
+            "value": 1386
+          }
+        },
+        "387": {
+          "value": 1387,
+          "params": {
+            "address": 387,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 387",
+            "value": 1387
+          }
+        },
+        "388": {
+          "value": 1388,
+          "params": {
+            "address": 388,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 388",
+            "value": 1388
+          }
+        },
+        "389": {
+          "value": 1389,
+          "params": {
+            "address": 389,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 389",
+            "value": 1389
+          }
+        },
+        "390": {
+          "value": 1390,
+          "params": {
+            "address": 390,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 390",
+            "value": 1390
+          }
+        },
+        "391": {
+          "value": 1391,
+          "params": {
+            "address": 391,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 391",
+            "value": 1391
+          }
+        },
+        "392": {
+          "value": 1392,
+          "params": {
+            "address": 392,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 392",
+            "value": 1392
+          }
+        },
+        "393": {
+          "value": 1393,
+          "params": {
+            "address": 393,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 393",
+            "value": 1393
+          }
+        },
+        "394": {
+          "value": 1394,
+          "params": {
+            "address": 394,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 394",
+            "value": 1394
+          }
+        },
+        "395": {
+          "value": 1395,
+          "params": {
+            "address": 395,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 395",
+            "value": 1395
+          }
+        },
+        "396": {
+          "value": 1396,
+          "params": {
+            "address": 396,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 396",
+            "value": 1396
+          }
+        },
+        "397": {
+          "value": 1397,
+          "params": {
+            "address": 397,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 397",
+            "value": 1397
+          }
+        },
+        "398": {
+          "value": 1398,
+          "params": {
+            "address": 398,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 398",
+            "value": 1398
+          }
+        },
+        "399": {
+          "value": 1399,
+          "params": {
+            "address": 399,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 399",
+            "value": 1399
+          }
+        },
+        "400": {
+          "value": 1400,
+          "params": {
+            "address": 400,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 400",
+            "value": 1400
+          }
+        },
+        "401": {
+          "value": 1401,
+          "params": {
+            "address": 401,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 401",
+            "value": 1401
+          }
+        },
+        "402": {
+          "value": 1402,
+          "params": {
+            "address": 402,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 402",
+            "value": 1402
+          }
+        },
+        "403": {
+          "value": 1403,
+          "params": {
+            "address": 403,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 403",
+            "value": 1403
+          }
+        },
+        "404": {
+          "value": 1404,
+          "params": {
+            "address": 404,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 404",
+            "value": 1404
+          }
+        },
+        "405": {
+          "value": 1405,
+          "params": {
+            "address": 405,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 405",
+            "value": 1405
+          }
+        },
+        "406": {
+          "value": 1406,
+          "params": {
+            "address": 406,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 406",
+            "value": 1406
+          }
+        },
+        "407": {
+          "value": 1407,
+          "params": {
+            "address": 407,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 407",
+            "value": 1407
+          }
+        },
+        "408": {
+          "value": 1408,
+          "params": {
+            "address": 408,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 408",
+            "value": 1408
+          }
+        },
+        "409": {
+          "value": 1409,
+          "params": {
+            "address": 409,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 409",
+            "value": 1409
+          }
+        },
+        "410": {
+          "value": 1410,
+          "params": {
+            "address": 410,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 410",
+            "value": 1410
+          }
+        },
+        "411": {
+          "value": 1411,
+          "params": {
+            "address": 411,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 411",
+            "value": 1411
+          }
+        },
+        "412": {
+          "value": 1412,
+          "params": {
+            "address": 412,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 412",
+            "value": 1412
+          }
+        },
+        "413": {
+          "value": 1413,
+          "params": {
+            "address": 413,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 413",
+            "value": 1413
+          }
+        },
+        "414": {
+          "value": 1414,
+          "params": {
+            "address": 414,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 414",
+            "value": 1414
+          }
+        },
+        "415": {
+          "value": 1415,
+          "params": {
+            "address": 415,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 415",
+            "value": 1415
+          }
+        },
+        "416": {
+          "value": 1416,
+          "params": {
+            "address": 416,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 416",
+            "value": 1416
+          }
+        },
+        "417": {
+          "value": 1417,
+          "params": {
+            "address": 417,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 417",
+            "value": 1417
+          }
+        },
+        "418": {
+          "value": 1418,
+          "params": {
+            "address": 418,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 418",
+            "value": 1418
+          }
+        },
+        "419": {
+          "value": 1419,
+          "params": {
+            "address": 419,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 419",
+            "value": 1419
+          }
+        },
+        "420": {
+          "value": 1420,
+          "params": {
+            "address": 420,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 420",
+            "value": 1420
+          }
+        },
+        "421": {
+          "value": 1421,
+          "params": {
+            "address": 421,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 421",
+            "value": 1421
+          }
+        },
+        "422": {
+          "value": 1422,
+          "params": {
+            "address": 422,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 422",
+            "value": 1422
+          }
+        },
+        "423": {
+          "value": 1423,
+          "params": {
+            "address": 423,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 423",
+            "value": 1423
+          }
+        },
+        "424": {
+          "value": 1424,
+          "params": {
+            "address": 424,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 424",
+            "value": 1424
+          }
+        },
+        "425": {
+          "value": 1425,
+          "params": {
+            "address": 425,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 425",
+            "value": 1425
+          }
+        },
+        "426": {
+          "value": 1426,
+          "params": {
+            "address": 426,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 426",
+            "value": 1426
+          }
+        },
+        "427": {
+          "value": 1427,
+          "params": {
+            "address": 427,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 427",
+            "value": 1427
+          }
+        },
+        "428": {
+          "value": 1428,
+          "params": {
+            "address": 428,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 428",
+            "value": 1428
+          }
+        },
+        "429": {
+          "value": 1429,
+          "params": {
+            "address": 429,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 429",
+            "value": 1429
+          }
+        },
+        "430": {
+          "value": 1430,
+          "params": {
+            "address": 430,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 430",
+            "value": 1430
+          }
+        },
+        "431": {
+          "value": 1431,
+          "params": {
+            "address": 431,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 431",
+            "value": 1431
+          }
+        },
+        "432": {
+          "value": 1432,
+          "params": {
+            "address": 432,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 432",
+            "value": 1432
+          }
+        },
+        "433": {
+          "value": 1433,
+          "params": {
+            "address": 433,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 433",
+            "value": 1433
+          }
+        },
+        "434": {
+          "value": 1434,
+          "params": {
+            "address": 434,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 434",
+            "value": 1434
+          }
+        },
+        "435": {
+          "value": 1435,
+          "params": {
+            "address": 435,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 435",
+            "value": 1435
+          }
+        },
+        "436": {
+          "value": 1436,
+          "params": {
+            "address": 436,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 436",
+            "value": 1436
+          }
+        },
+        "437": {
+          "value": 1437,
+          "params": {
+            "address": 437,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 437",
+            "value": 1437
+          }
+        },
+        "438": {
+          "value": 1438,
+          "params": {
+            "address": 438,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 438",
+            "value": 1438
+          }
+        },
+        "439": {
+          "value": 1439,
+          "params": {
+            "address": 439,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 439",
+            "value": 1439
+          }
+        },
+        "440": {
+          "value": 1440,
+          "params": {
+            "address": 440,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 440",
+            "value": 1440
+          }
+        },
+        "441": {
+          "value": 1441,
+          "params": {
+            "address": 441,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 441",
+            "value": 1441
+          }
+        },
+        "442": {
+          "value": 1442,
+          "params": {
+            "address": 442,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 442",
+            "value": 1442
+          }
+        },
+        "443": {
+          "value": 1443,
+          "params": {
+            "address": 443,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 443",
+            "value": 1443
+          }
+        },
+        "444": {
+          "value": 1444,
+          "params": {
+            "address": 444,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 444",
+            "value": 1444
+          }
+        },
+        "445": {
+          "value": 1445,
+          "params": {
+            "address": 445,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 445",
+            "value": 1445
+          }
+        },
+        "446": {
+          "value": 1446,
+          "params": {
+            "address": 446,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 446",
+            "value": 1446
+          }
+        },
+        "447": {
+          "value": 1447,
+          "params": {
+            "address": 447,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 447",
+            "value": 1447
+          }
+        },
+        "448": {
+          "value": 1448,
+          "params": {
+            "address": 448,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 448",
+            "value": 1448
+          }
+        },
+        "449": {
+          "value": 1449,
+          "params": {
+            "address": 449,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 449",
+            "value": 1449
+          }
+        },
+        "450": {
+          "value": 1450,
+          "params": {
+            "address": 450,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 450",
+            "value": 1450
+          }
+        },
+        "451": {
+          "value": 1451,
+          "params": {
+            "address": 451,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 451",
+            "value": 1451
+          }
+        },
+        "452": {
+          "value": 1452,
+          "params": {
+            "address": 452,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 452",
+            "value": 1452
+          }
+        },
+        "453": {
+          "value": 1453,
+          "params": {
+            "address": 453,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 453",
+            "value": 1453
+          }
+        },
+        "454": {
+          "value": 1454,
+          "params": {
+            "address": 454,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 454",
+            "value": 1454
+          }
+        },
+        "455": {
+          "value": 1455,
+          "params": {
+            "address": 455,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 455",
+            "value": 1455
+          }
+        },
+        "456": {
+          "value": 1456,
+          "params": {
+            "address": 456,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 456",
+            "value": 1456
+          }
+        },
+        "457": {
+          "value": 1457,
+          "params": {
+            "address": 457,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 457",
+            "value": 1457
+          }
+        },
+        "458": {
+          "value": 1458,
+          "params": {
+            "address": 458,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 458",
+            "value": 1458
+          }
+        },
+        "459": {
+          "value": 1459,
+          "params": {
+            "address": 459,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 459",
+            "value": 1459
+          }
+        },
+        "460": {
+          "value": 1460,
+          "params": {
+            "address": 460,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 460",
+            "value": 1460
+          }
+        },
+        "461": {
+          "value": 1461,
+          "params": {
+            "address": 461,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 461",
+            "value": 1461
+          }
+        },
+        "462": {
+          "value": 1462,
+          "params": {
+            "address": 462,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 462",
+            "value": 1462
+          }
+        },
+        "463": {
+          "value": 1463,
+          "params": {
+            "address": 463,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 463",
+            "value": 1463
+          }
+        },
+        "464": {
+          "value": 1464,
+          "params": {
+            "address": 464,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 464",
+            "value": 1464
+          }
+        },
+        "465": {
+          "value": 1465,
+          "params": {
+            "address": 465,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 465",
+            "value": 1465
+          }
+        },
+        "466": {
+          "value": 1466,
+          "params": {
+            "address": 466,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 466",
+            "value": 1466
+          }
+        },
+        "467": {
+          "value": 1467,
+          "params": {
+            "address": 467,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 467",
+            "value": 1467
+          }
+        },
+        "468": {
+          "value": 1468,
+          "params": {
+            "address": 468,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 468",
+            "value": 1468
+          }
+        },
+        "469": {
+          "value": 1469,
+          "params": {
+            "address": 469,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 469",
+            "value": 1469
+          }
+        },
+        "470": {
+          "value": 1470,
+          "params": {
+            "address": 470,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 470",
+            "value": 1470
+          }
+        },
+        "471": {
+          "value": 1471,
+          "params": {
+            "address": 471,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 471",
+            "value": 1471
+          }
+        },
+        "472": {
+          "value": 1472,
+          "params": {
+            "address": 472,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 472",
+            "value": 1472
+          }
+        },
+        "473": {
+          "value": 1473,
+          "params": {
+            "address": 473,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 473",
+            "value": 1473
+          }
+        },
+        "474": {
+          "value": 1474,
+          "params": {
+            "address": 474,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 474",
+            "value": 1474
+          }
+        },
+        "475": {
+          "value": 1475,
+          "params": {
+            "address": 475,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 475",
+            "value": 1475
+          }
+        },
+        "476": {
+          "value": 1476,
+          "params": {
+            "address": 476,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 476",
+            "value": 1476
+          }
+        },
+        "477": {
+          "value": 1477,
+          "params": {
+            "address": 477,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 477",
+            "value": 1477
+          }
+        },
+        "478": {
+          "value": 1478,
+          "params": {
+            "address": 478,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 478",
+            "value": 1478
+          }
+        },
+        "479": {
+          "value": 1479,
+          "params": {
+            "address": 479,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 479",
+            "value": 1479
+          }
+        },
+        "480": {
+          "value": 1480,
+          "params": {
+            "address": 480,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 480",
+            "value": 1480
+          }
+        },
+        "481": {
+          "value": 1481,
+          "params": {
+            "address": 481,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 481",
+            "value": 1481
+          }
+        },
+        "482": {
+          "value": 1482,
+          "params": {
+            "address": 482,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 482",
+            "value": 1482
+          }
+        },
+        "483": {
+          "value": 1483,
+          "params": {
+            "address": 483,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 483",
+            "value": 1483
+          }
+        },
+        "484": {
+          "value": 1484,
+          "params": {
+            "address": 484,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 484",
+            "value": 1484
+          }
+        },
+        "485": {
+          "value": 1485,
+          "params": {
+            "address": 485,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 485",
+            "value": 1485
+          }
+        },
+        "486": {
+          "value": 1486,
+          "params": {
+            "address": 486,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 486",
+            "value": 1486
+          }
+        },
+        "487": {
+          "value": 1487,
+          "params": {
+            "address": 487,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 487",
+            "value": 1487
+          }
+        },
+        "488": {
+          "value": 1488,
+          "params": {
+            "address": 488,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 488",
+            "value": 1488
+          }
+        },
+        "489": {
+          "value": 1489,
+          "params": {
+            "address": 489,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 489",
+            "value": 1489
+          }
+        },
+        "490": {
+          "value": 1490,
+          "params": {
+            "address": 490,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 490",
+            "value": 1490
+          }
+        },
+        "491": {
+          "value": 1491,
+          "params": {
+            "address": 491,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 491",
+            "value": 1491
+          }
+        },
+        "492": {
+          "value": 1492,
+          "params": {
+            "address": 492,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 492",
+            "value": 1492
+          }
+        },
+        "493": {
+          "value": 1493,
+          "params": {
+            "address": 493,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 493",
+            "value": 1493
+          }
+        },
+        "494": {
+          "value": 1494,
+          "params": {
+            "address": 494,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 494",
+            "value": 1494
+          }
+        },
+        "495": {
+          "value": 1495,
+          "params": {
+            "address": 495,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 495",
+            "value": 1495
+          }
+        },
+        "496": {
+          "value": 1496,
+          "params": {
+            "address": 496,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 496",
+            "value": 1496
+          }
+        },
+        "497": {
+          "value": 1497,
+          "params": {
+            "address": 497,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 497",
+            "value": 1497
+          }
+        },
+        "498": {
+          "value": 1498,
+          "params": {
+            "address": 498,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 498",
+            "value": 1498
+          }
+        },
+        "499": {
+          "value": 1499,
+          "params": {
+            "address": 499,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 499",
+            "value": 1499
+          }
+        },
+        "500": {
+          "value": 1000,
+          "params": {
+            "address": 500,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 500",
+            "value": 1000
+          }
+        },
+        "501": {
+          "value": 1001,
+          "params": {
+            "address": 501,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 501",
+            "value": 1001
+          }
+        },
+        "502": {
+          "value": 1002,
+          "params": {
+            "address": 502,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 502",
+            "value": 1002
+          }
+        },
+        "503": {
+          "value": 1003,
+          "params": {
+            "address": 503,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 503",
+            "value": 1003
+          }
+        },
+        "504": {
+          "value": 1004,
+          "params": {
+            "address": 504,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 504",
+            "value": 1004
+          }
+        },
+        "505": {
+          "value": 1005,
+          "params": {
+            "address": 505,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 505",
+            "value": 1005
+          }
+        },
+        "506": {
+          "value": 1006,
+          "params": {
+            "address": 506,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 506",
+            "value": 1006
+          }
+        },
+        "507": {
+          "value": 1007,
+          "params": {
+            "address": 507,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 507",
+            "value": 1007
+          }
+        },
+        "508": {
+          "value": 1008,
+          "params": {
+            "address": 508,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 508",
+            "value": 1008
+          }
+        },
+        "509": {
+          "value": 1009,
+          "params": {
+            "address": 509,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 509",
+            "value": 1009
+          }
+        },
+        "510": {
+          "value": 1010,
+          "params": {
+            "address": 510,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 510",
+            "value": 1010
+          }
+        },
+        "511": {
+          "value": 1011,
+          "params": {
+            "address": 511,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 511",
+            "value": 1011
+          }
+        },
+        "512": {
+          "value": 1012,
+          "params": {
+            "address": 512,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 512",
+            "value": 1012
+          }
+        },
+        "513": {
+          "value": 1013,
+          "params": {
+            "address": 513,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 513",
+            "value": 1013
+          }
+        },
+        "514": {
+          "value": 1014,
+          "params": {
+            "address": 514,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 514",
+            "value": 1014
+          }
+        },
+        "515": {
+          "value": 1015,
+          "params": {
+            "address": 515,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 515",
+            "value": 1015
+          }
+        },
+        "516": {
+          "value": 1016,
+          "params": {
+            "address": 516,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 516",
+            "value": 1016
+          }
+        },
+        "517": {
+          "value": 1017,
+          "params": {
+            "address": 517,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 517",
+            "value": 1017
+          }
+        },
+        "518": {
+          "value": 1018,
+          "params": {
+            "address": 518,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 518",
+            "value": 1018
+          }
+        },
+        "519": {
+          "value": 1019,
+          "params": {
+            "address": 519,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 519",
+            "value": 1019
+          }
+        },
+        "520": {
+          "value": 1020,
+          "params": {
+            "address": 520,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 520",
+            "value": 1020
+          }
+        },
+        "521": {
+          "value": 1021,
+          "params": {
+            "address": 521,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 521",
+            "value": 1021
+          }
+        },
+        "522": {
+          "value": 1022,
+          "params": {
+            "address": 522,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 522",
+            "value": 1022
+          }
+        },
+        "523": {
+          "value": 1023,
+          "params": {
+            "address": 523,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 523",
+            "value": 1023
+          }
+        },
+        "524": {
+          "value": 1024,
+          "params": {
+            "address": 524,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 524",
+            "value": 1024
+          }
+        },
+        "525": {
+          "value": 1025,
+          "params": {
+            "address": 525,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 525",
+            "value": 1025
+          }
+        },
+        "526": {
+          "value": 1026,
+          "params": {
+            "address": 526,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 526",
+            "value": 1026
+          }
+        },
+        "527": {
+          "value": 1027,
+          "params": {
+            "address": 527,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 527",
+            "value": 1027
+          }
+        },
+        "528": {
+          "value": 1028,
+          "params": {
+            "address": 528,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 528",
+            "value": 1028
+          }
+        },
+        "529": {
+          "value": 1029,
+          "params": {
+            "address": 529,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 529",
+            "value": 1029
+          }
+        },
+        "530": {
+          "value": 1030,
+          "params": {
+            "address": 530,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 530",
+            "value": 1030
+          }
+        },
+        "531": {
+          "value": 1031,
+          "params": {
+            "address": 531,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 531",
+            "value": 1031
+          }
+        },
+        "532": {
+          "value": 1032,
+          "params": {
+            "address": 532,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 532",
+            "value": 1032
+          }
+        },
+        "533": {
+          "value": 1033,
+          "params": {
+            "address": 533,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 533",
+            "value": 1033
+          }
+        },
+        "534": {
+          "value": 1034,
+          "params": {
+            "address": 534,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 534",
+            "value": 1034
+          }
+        },
+        "535": {
+          "value": 1035,
+          "params": {
+            "address": 535,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 535",
+            "value": 1035
+          }
+        },
+        "536": {
+          "value": 1036,
+          "params": {
+            "address": 536,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 536",
+            "value": 1036
+          }
+        },
+        "537": {
+          "value": 1037,
+          "params": {
+            "address": 537,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 537",
+            "value": 1037
+          }
+        },
+        "538": {
+          "value": 1038,
+          "params": {
+            "address": 538,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 538",
+            "value": 1038
+          }
+        },
+        "539": {
+          "value": 1039,
+          "params": {
+            "address": 539,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 539",
+            "value": 1039
+          }
+        },
+        "540": {
+          "value": 1040,
+          "params": {
+            "address": 540,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 540",
+            "value": 1040
+          }
+        },
+        "541": {
+          "value": 1041,
+          "params": {
+            "address": 541,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 541",
+            "value": 1041
+          }
+        },
+        "542": {
+          "value": 1042,
+          "params": {
+            "address": 542,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 542",
+            "value": 1042
+          }
+        },
+        "543": {
+          "value": 1043,
+          "params": {
+            "address": 543,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 543",
+            "value": 1043
+          }
+        },
+        "544": {
+          "value": 1044,
+          "params": {
+            "address": 544,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 544",
+            "value": 1044
+          }
+        },
+        "545": {
+          "value": 1045,
+          "params": {
+            "address": 545,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 545",
+            "value": 1045
+          }
+        },
+        "546": {
+          "value": 1046,
+          "params": {
+            "address": 546,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 546",
+            "value": 1046
+          }
+        },
+        "547": {
+          "value": 1047,
+          "params": {
+            "address": 547,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 547",
+            "value": 1047
+          }
+        },
+        "548": {
+          "value": 1048,
+          "params": {
+            "address": 548,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 548",
+            "value": 1048
+          }
+        },
+        "549": {
+          "value": 1049,
+          "params": {
+            "address": 549,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 549",
+            "value": 1049
+          }
+        },
+        "550": {
+          "value": 1050,
+          "params": {
+            "address": 550,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 550",
+            "value": 1050
+          }
+        },
+        "551": {
+          "value": 1051,
+          "params": {
+            "address": 551,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 551",
+            "value": 1051
+          }
+        },
+        "552": {
+          "value": 1052,
+          "params": {
+            "address": 552,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 552",
+            "value": 1052
+          }
+        },
+        "553": {
+          "value": 1053,
+          "params": {
+            "address": 553,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 553",
+            "value": 1053
+          }
+        },
+        "554": {
+          "value": 1054,
+          "params": {
+            "address": 554,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 554",
+            "value": 1054
+          }
+        },
+        "555": {
+          "value": 1055,
+          "params": {
+            "address": 555,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 555",
+            "value": 1055
+          }
+        },
+        "556": {
+          "value": 1056,
+          "params": {
+            "address": 556,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 556",
+            "value": 1056
+          }
+        },
+        "557": {
+          "value": 1057,
+          "params": {
+            "address": 557,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 557",
+            "value": 1057
+          }
+        },
+        "558": {
+          "value": 1058,
+          "params": {
+            "address": 558,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 558",
+            "value": 1058
+          }
+        },
+        "559": {
+          "value": 1059,
+          "params": {
+            "address": 559,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 559",
+            "value": 1059
+          }
+        },
+        "560": {
+          "value": 1060,
+          "params": {
+            "address": 560,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 560",
+            "value": 1060
+          }
+        },
+        "561": {
+          "value": 1061,
+          "params": {
+            "address": 561,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 561",
+            "value": 1061
+          }
+        },
+        "562": {
+          "value": 1062,
+          "params": {
+            "address": 562,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 562",
+            "value": 1062
+          }
+        },
+        "563": {
+          "value": 1063,
+          "params": {
+            "address": 563,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 563",
+            "value": 1063
+          }
+        },
+        "564": {
+          "value": 1064,
+          "params": {
+            "address": 564,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 564",
+            "value": 1064
+          }
+        },
+        "565": {
+          "value": 1065,
+          "params": {
+            "address": 565,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 565",
+            "value": 1065
+          }
+        },
+        "566": {
+          "value": 1066,
+          "params": {
+            "address": 566,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 566",
+            "value": 1066
+          }
+        },
+        "567": {
+          "value": 1067,
+          "params": {
+            "address": 567,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 567",
+            "value": 1067
+          }
+        },
+        "568": {
+          "value": 1068,
+          "params": {
+            "address": 568,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 568",
+            "value": 1068
+          }
+        },
+        "569": {
+          "value": 1069,
+          "params": {
+            "address": 569,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 569",
+            "value": 1069
+          }
+        },
+        "570": {
+          "value": 1070,
+          "params": {
+            "address": 570,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 570",
+            "value": 1070
+          }
+        },
+        "571": {
+          "value": 1071,
+          "params": {
+            "address": 571,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 571",
+            "value": 1071
+          }
+        },
+        "572": {
+          "value": 1072,
+          "params": {
+            "address": 572,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 572",
+            "value": 1072
+          }
+        },
+        "573": {
+          "value": 1073,
+          "params": {
+            "address": 573,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 573",
+            "value": 1073
+          }
+        },
+        "574": {
+          "value": 1074,
+          "params": {
+            "address": 574,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 574",
+            "value": 1074
+          }
+        },
+        "575": {
+          "value": 1075,
+          "params": {
+            "address": 575,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 575",
+            "value": 1075
+          }
+        },
+        "576": {
+          "value": 1076,
+          "params": {
+            "address": 576,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 576",
+            "value": 1076
+          }
+        },
+        "577": {
+          "value": 1077,
+          "params": {
+            "address": 577,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 577",
+            "value": 1077
+          }
+        },
+        "578": {
+          "value": 1078,
+          "params": {
+            "address": 578,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 578",
+            "value": 1078
+          }
+        },
+        "579": {
+          "value": 1079,
+          "params": {
+            "address": 579,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 579",
+            "value": 1079
+          }
+        },
+        "580": {
+          "value": 1080,
+          "params": {
+            "address": 580,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 580",
+            "value": 1080
+          }
+        },
+        "581": {
+          "value": 1081,
+          "params": {
+            "address": 581,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 581",
+            "value": 1081
+          }
+        },
+        "582": {
+          "value": 1082,
+          "params": {
+            "address": 582,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 582",
+            "value": 1082
+          }
+        },
+        "583": {
+          "value": 1083,
+          "params": {
+            "address": 583,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 583",
+            "value": 1083
+          }
+        },
+        "584": {
+          "value": 1084,
+          "params": {
+            "address": 584,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 584",
+            "value": 1084
+          }
+        },
+        "585": {
+          "value": 1085,
+          "params": {
+            "address": 585,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 585",
+            "value": 1085
+          }
+        },
+        "586": {
+          "value": 1086,
+          "params": {
+            "address": 586,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 586",
+            "value": 1086
+          }
+        },
+        "587": {
+          "value": 1087,
+          "params": {
+            "address": 587,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 587",
+            "value": 1087
+          }
+        },
+        "588": {
+          "value": 1088,
+          "params": {
+            "address": 588,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 588",
+            "value": 1088
+          }
+        },
+        "589": {
+          "value": 1089,
+          "params": {
+            "address": 589,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 589",
+            "value": 1089
+          }
+        },
+        "590": {
+          "value": 1090,
+          "params": {
+            "address": 590,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 590",
+            "value": 1090
+          }
+        },
+        "591": {
+          "value": 1091,
+          "params": {
+            "address": 591,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 591",
+            "value": 1091
+          }
+        },
+        "592": {
+          "value": 1092,
+          "params": {
+            "address": 592,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 592",
+            "value": 1092
+          }
+        },
+        "593": {
+          "value": 1093,
+          "params": {
+            "address": 593,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 593",
+            "value": 1093
+          }
+        },
+        "594": {
+          "value": 1094,
+          "params": {
+            "address": 594,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 594",
+            "value": 1094
+          }
+        },
+        "595": {
+          "value": 1095,
+          "params": {
+            "address": 595,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 595",
+            "value": 1095
+          }
+        },
+        "596": {
+          "value": 1096,
+          "params": {
+            "address": 596,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 596",
+            "value": 1096
+          }
+        },
+        "597": {
+          "value": 1097,
+          "params": {
+            "address": 597,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 597",
+            "value": 1097
+          }
+        },
+        "598": {
+          "value": 1098,
+          "params": {
+            "address": 598,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 598",
+            "value": 1098
+          }
+        },
+        "599": {
+          "value": 1099,
+          "params": {
+            "address": 599,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 599",
+            "value": 1099
+          }
+        },
+        "600": {
+          "value": 1100,
+          "params": {
+            "address": 600,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 600",
+            "value": 1100
+          }
+        },
+        "601": {
+          "value": 1101,
+          "params": {
+            "address": 601,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 601",
+            "value": 1101
+          }
+        },
+        "602": {
+          "value": 1102,
+          "params": {
+            "address": 602,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 602",
+            "value": 1102
+          }
+        },
+        "603": {
+          "value": 1103,
+          "params": {
+            "address": 603,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 603",
+            "value": 1103
+          }
+        },
+        "604": {
+          "value": 1104,
+          "params": {
+            "address": 604,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 604",
+            "value": 1104
+          }
+        },
+        "605": {
+          "value": 1105,
+          "params": {
+            "address": 605,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 605",
+            "value": 1105
+          }
+        },
+        "606": {
+          "value": 1106,
+          "params": {
+            "address": 606,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 606",
+            "value": 1106
+          }
+        },
+        "607": {
+          "value": 1107,
+          "params": {
+            "address": 607,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 607",
+            "value": 1107
+          }
+        },
+        "608": {
+          "value": 1108,
+          "params": {
+            "address": 608,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 608",
+            "value": 1108
+          }
+        },
+        "609": {
+          "value": 1109,
+          "params": {
+            "address": 609,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 609",
+            "value": 1109
+          }
+        },
+        "610": {
+          "value": 1110,
+          "params": {
+            "address": 610,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 610",
+            "value": 1110
+          }
+        },
+        "611": {
+          "value": 1111,
+          "params": {
+            "address": 611,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 611",
+            "value": 1111
+          }
+        },
+        "612": {
+          "value": 1112,
+          "params": {
+            "address": 612,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 612",
+            "value": 1112
+          }
+        },
+        "613": {
+          "value": 1113,
+          "params": {
+            "address": 613,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 613",
+            "value": 1113
+          }
+        },
+        "614": {
+          "value": 1114,
+          "params": {
+            "address": 614,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 614",
+            "value": 1114
+          }
+        },
+        "615": {
+          "value": 1115,
+          "params": {
+            "address": 615,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 615",
+            "value": 1115
+          }
+        },
+        "616": {
+          "value": 1116,
+          "params": {
+            "address": 616,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 616",
+            "value": 1116
+          }
+        },
+        "617": {
+          "value": 1117,
+          "params": {
+            "address": 617,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 617",
+            "value": 1117
+          }
+        },
+        "618": {
+          "value": 1118,
+          "params": {
+            "address": 618,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 618",
+            "value": 1118
+          }
+        },
+        "619": {
+          "value": 1119,
+          "params": {
+            "address": 619,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 619",
+            "value": 1119
+          }
+        },
+        "620": {
+          "value": 1120,
+          "params": {
+            "address": 620,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 620",
+            "value": 1120
+          }
+        },
+        "621": {
+          "value": 1121,
+          "params": {
+            "address": 621,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 621",
+            "value": 1121
+          }
+        },
+        "622": {
+          "value": 1122,
+          "params": {
+            "address": 622,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 622",
+            "value": 1122
+          }
+        },
+        "623": {
+          "value": 1123,
+          "params": {
+            "address": 623,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 623",
+            "value": 1123
+          }
+        },
+        "624": {
+          "value": 1124,
+          "params": {
+            "address": 624,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 624",
+            "value": 1124
+          }
+        },
+        "625": {
+          "value": 1125,
+          "params": {
+            "address": 625,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 625",
+            "value": 1125
+          }
+        },
+        "626": {
+          "value": 1126,
+          "params": {
+            "address": 626,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 626",
+            "value": 1126
+          }
+        },
+        "627": {
+          "value": 1127,
+          "params": {
+            "address": 627,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 627",
+            "value": 1127
+          }
+        },
+        "628": {
+          "value": 1128,
+          "params": {
+            "address": 628,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 628",
+            "value": 1128
+          }
+        },
+        "629": {
+          "value": 1129,
+          "params": {
+            "address": 629,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 629",
+            "value": 1129
+          }
+        },
+        "630": {
+          "value": 1130,
+          "params": {
+            "address": 630,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 630",
+            "value": 1130
+          }
+        },
+        "631": {
+          "value": 1131,
+          "params": {
+            "address": 631,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 631",
+            "value": 1131
+          }
+        },
+        "632": {
+          "value": 1132,
+          "params": {
+            "address": 632,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 632",
+            "value": 1132
+          }
+        },
+        "633": {
+          "value": 1133,
+          "params": {
+            "address": 633,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 633",
+            "value": 1133
+          }
+        },
+        "634": {
+          "value": 1134,
+          "params": {
+            "address": 634,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 634",
+            "value": 1134
+          }
+        },
+        "635": {
+          "value": 1135,
+          "params": {
+            "address": 635,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 635",
+            "value": 1135
+          }
+        },
+        "636": {
+          "value": 1136,
+          "params": {
+            "address": 636,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 636",
+            "value": 1136
+          }
+        },
+        "637": {
+          "value": 1137,
+          "params": {
+            "address": 637,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 637",
+            "value": 1137
+          }
+        },
+        "638": {
+          "value": 1138,
+          "params": {
+            "address": 638,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 638",
+            "value": 1138
+          }
+        },
+        "639": {
+          "value": 1139,
+          "params": {
+            "address": 639,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 639",
+            "value": 1139
+          }
+        },
+        "640": {
+          "value": 1140,
+          "params": {
+            "address": 640,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 640",
+            "value": 1140
+          }
+        },
+        "641": {
+          "value": 1141,
+          "params": {
+            "address": 641,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 641",
+            "value": 1141
+          }
+        },
+        "642": {
+          "value": 1142,
+          "params": {
+            "address": 642,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 642",
+            "value": 1142
+          }
+        },
+        "643": {
+          "value": 1143,
+          "params": {
+            "address": 643,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 643",
+            "value": 1143
+          }
+        },
+        "644": {
+          "value": 1144,
+          "params": {
+            "address": 644,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 644",
+            "value": 1144
+          }
+        },
+        "645": {
+          "value": 1145,
+          "params": {
+            "address": 645,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 645",
+            "value": 1145
+          }
+        },
+        "646": {
+          "value": 1146,
+          "params": {
+            "address": 646,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 646",
+            "value": 1146
+          }
+        },
+        "647": {
+          "value": 1147,
+          "params": {
+            "address": 647,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 647",
+            "value": 1147
+          }
+        },
+        "648": {
+          "value": 1148,
+          "params": {
+            "address": 648,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 648",
+            "value": 1148
+          }
+        },
+        "649": {
+          "value": 1149,
+          "params": {
+            "address": 649,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 649",
+            "value": 1149
+          }
+        },
+        "650": {
+          "value": 1150,
+          "params": {
+            "address": 650,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 650",
+            "value": 1150
+          }
+        },
+        "651": {
+          "value": 1151,
+          "params": {
+            "address": 651,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 651",
+            "value": 1151
+          }
+        },
+        "652": {
+          "value": 1152,
+          "params": {
+            "address": 652,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 652",
+            "value": 1152
+          }
+        },
+        "653": {
+          "value": 1153,
+          "params": {
+            "address": 653,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 653",
+            "value": 1153
+          }
+        },
+        "654": {
+          "value": 1154,
+          "params": {
+            "address": 654,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 654",
+            "value": 1154
+          }
+        },
+        "655": {
+          "value": 1155,
+          "params": {
+            "address": 655,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 655",
+            "value": 1155
+          }
+        },
+        "656": {
+          "value": 1156,
+          "params": {
+            "address": 656,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 656",
+            "value": 1156
+          }
+        },
+        "657": {
+          "value": 1157,
+          "params": {
+            "address": 657,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 657",
+            "value": 1157
+          }
+        },
+        "658": {
+          "value": 1158,
+          "params": {
+            "address": 658,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 658",
+            "value": 1158
+          }
+        },
+        "659": {
+          "value": 1159,
+          "params": {
+            "address": 659,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 659",
+            "value": 1159
+          }
+        },
+        "660": {
+          "value": 1160,
+          "params": {
+            "address": 660,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 660",
+            "value": 1160
+          }
+        },
+        "661": {
+          "value": 1161,
+          "params": {
+            "address": 661,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 661",
+            "value": 1161
+          }
+        },
+        "662": {
+          "value": 1162,
+          "params": {
+            "address": 662,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 662",
+            "value": 1162
+          }
+        },
+        "663": {
+          "value": 1163,
+          "params": {
+            "address": 663,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 663",
+            "value": 1163
+          }
+        },
+        "664": {
+          "value": 1164,
+          "params": {
+            "address": 664,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 664",
+            "value": 1164
+          }
+        },
+        "665": {
+          "value": 1165,
+          "params": {
+            "address": 665,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 665",
+            "value": 1165
+          }
+        },
+        "666": {
+          "value": 1166,
+          "params": {
+            "address": 666,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 666",
+            "value": 1166
+          }
+        },
+        "667": {
+          "value": 1167,
+          "params": {
+            "address": 667,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 667",
+            "value": 1167
+          }
+        },
+        "668": {
+          "value": 1168,
+          "params": {
+            "address": 668,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 668",
+            "value": 1168
+          }
+        },
+        "669": {
+          "value": 1169,
+          "params": {
+            "address": 669,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 669",
+            "value": 1169
+          }
+        },
+        "670": {
+          "value": 1170,
+          "params": {
+            "address": 670,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 670",
+            "value": 1170
+          }
+        },
+        "671": {
+          "value": 1171,
+          "params": {
+            "address": 671,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 671",
+            "value": 1171
+          }
+        },
+        "672": {
+          "value": 1172,
+          "params": {
+            "address": 672,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 672",
+            "value": 1172
+          }
+        },
+        "673": {
+          "value": 1173,
+          "params": {
+            "address": 673,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 673",
+            "value": 1173
+          }
+        },
+        "674": {
+          "value": 1174,
+          "params": {
+            "address": 674,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 674",
+            "value": 1174
+          }
+        },
+        "675": {
+          "value": 1175,
+          "params": {
+            "address": 675,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 675",
+            "value": 1175
+          }
+        },
+        "676": {
+          "value": 1176,
+          "params": {
+            "address": 676,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 676",
+            "value": 1176
+          }
+        },
+        "677": {
+          "value": 1177,
+          "params": {
+            "address": 677,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 677",
+            "value": 1177
+          }
+        },
+        "678": {
+          "value": 1178,
+          "params": {
+            "address": 678,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 678",
+            "value": 1178
+          }
+        },
+        "679": {
+          "value": 1179,
+          "params": {
+            "address": 679,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 679",
+            "value": 1179
+          }
+        },
+        "680": {
+          "value": 1180,
+          "params": {
+            "address": 680,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 680",
+            "value": 1180
+          }
+        },
+        "681": {
+          "value": 1181,
+          "params": {
+            "address": 681,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 681",
+            "value": 1181
+          }
+        },
+        "682": {
+          "value": 1182,
+          "params": {
+            "address": 682,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 682",
+            "value": 1182
+          }
+        },
+        "683": {
+          "value": 1183,
+          "params": {
+            "address": 683,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 683",
+            "value": 1183
+          }
+        },
+        "684": {
+          "value": 1184,
+          "params": {
+            "address": 684,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 684",
+            "value": 1184
+          }
+        },
+        "685": {
+          "value": 1185,
+          "params": {
+            "address": 685,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 685",
+            "value": 1185
+          }
+        },
+        "686": {
+          "value": 1186,
+          "params": {
+            "address": 686,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 686",
+            "value": 1186
+          }
+        },
+        "687": {
+          "value": 1187,
+          "params": {
+            "address": 687,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 687",
+            "value": 1187
+          }
+        },
+        "688": {
+          "value": 1188,
+          "params": {
+            "address": 688,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 688",
+            "value": 1188
+          }
+        },
+        "689": {
+          "value": 1189,
+          "params": {
+            "address": 689,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 689",
+            "value": 1189
+          }
+        },
+        "690": {
+          "value": 1190,
+          "params": {
+            "address": 690,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 690",
+            "value": 1190
+          }
+        },
+        "691": {
+          "value": 1191,
+          "params": {
+            "address": 691,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 691",
+            "value": 1191
+          }
+        },
+        "692": {
+          "value": 1192,
+          "params": {
+            "address": 692,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 692",
+            "value": 1192
+          }
+        },
+        "693": {
+          "value": 1193,
+          "params": {
+            "address": 693,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 693",
+            "value": 1193
+          }
+        },
+        "694": {
+          "value": 1194,
+          "params": {
+            "address": 694,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 694",
+            "value": 1194
+          }
+        },
+        "695": {
+          "value": 1195,
+          "params": {
+            "address": 695,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 695",
+            "value": 1195
+          }
+        },
+        "696": {
+          "value": 1196,
+          "params": {
+            "address": 696,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 696",
+            "value": 1196
+          }
+        },
+        "697": {
+          "value": 1197,
+          "params": {
+            "address": 697,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 697",
+            "value": 1197
+          }
+        },
+        "698": {
+          "value": 1198,
+          "params": {
+            "address": 698,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 698",
+            "value": 1198
+          }
+        },
+        "699": {
+          "value": 1199,
+          "params": {
+            "address": 699,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 699",
+            "value": 1199
+          }
+        },
+        "700": {
+          "value": 1200,
+          "params": {
+            "address": 700,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 700",
+            "value": 1200
+          }
+        },
+        "701": {
+          "value": 1201,
+          "params": {
+            "address": 701,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 701",
+            "value": 1201
+          }
+        },
+        "702": {
+          "value": 1202,
+          "params": {
+            "address": 702,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 702",
+            "value": 1202
+          }
+        },
+        "703": {
+          "value": 1203,
+          "params": {
+            "address": 703,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 703",
+            "value": 1203
+          }
+        },
+        "704": {
+          "value": 1204,
+          "params": {
+            "address": 704,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 704",
+            "value": 1204
+          }
+        },
+        "705": {
+          "value": 1205,
+          "params": {
+            "address": 705,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 705",
+            "value": 1205
+          }
+        },
+        "706": {
+          "value": 1206,
+          "params": {
+            "address": 706,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 706",
+            "value": 1206
+          }
+        },
+        "707": {
+          "value": 1207,
+          "params": {
+            "address": 707,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 707",
+            "value": 1207
+          }
+        },
+        "708": {
+          "value": 1208,
+          "params": {
+            "address": 708,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 708",
+            "value": 1208
+          }
+        },
+        "709": {
+          "value": 1209,
+          "params": {
+            "address": 709,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 709",
+            "value": 1209
+          }
+        },
+        "710": {
+          "value": 1210,
+          "params": {
+            "address": 710,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 710",
+            "value": 1210
+          }
+        },
+        "711": {
+          "value": 1211,
+          "params": {
+            "address": 711,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 711",
+            "value": 1211
+          }
+        },
+        "712": {
+          "value": 1212,
+          "params": {
+            "address": 712,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 712",
+            "value": 1212
+          }
+        },
+        "713": {
+          "value": 1213,
+          "params": {
+            "address": 713,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 713",
+            "value": 1213
+          }
+        },
+        "714": {
+          "value": 1214,
+          "params": {
+            "address": 714,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 714",
+            "value": 1214
+          }
+        },
+        "715": {
+          "value": 1215,
+          "params": {
+            "address": 715,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 715",
+            "value": 1215
+          }
+        },
+        "716": {
+          "value": 1216,
+          "params": {
+            "address": 716,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 716",
+            "value": 1216
+          }
+        },
+        "717": {
+          "value": 1217,
+          "params": {
+            "address": 717,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 717",
+            "value": 1217
+          }
+        },
+        "718": {
+          "value": 1218,
+          "params": {
+            "address": 718,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 718",
+            "value": 1218
+          }
+        },
+        "719": {
+          "value": 1219,
+          "params": {
+            "address": 719,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 719",
+            "value": 1219
+          }
+        },
+        "720": {
+          "value": 1220,
+          "params": {
+            "address": 720,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 720",
+            "value": 1220
+          }
+        },
+        "721": {
+          "value": 1221,
+          "params": {
+            "address": 721,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 721",
+            "value": 1221
+          }
+        },
+        "722": {
+          "value": 1222,
+          "params": {
+            "address": 722,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 722",
+            "value": 1222
+          }
+        },
+        "723": {
+          "value": 1223,
+          "params": {
+            "address": 723,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 723",
+            "value": 1223
+          }
+        },
+        "724": {
+          "value": 1224,
+          "params": {
+            "address": 724,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 724",
+            "value": 1224
+          }
+        },
+        "725": {
+          "value": 1225,
+          "params": {
+            "address": 725,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 725",
+            "value": 1225
+          }
+        },
+        "726": {
+          "value": 1226,
+          "params": {
+            "address": 726,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 726",
+            "value": 1226
+          }
+        },
+        "727": {
+          "value": 1227,
+          "params": {
+            "address": 727,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 727",
+            "value": 1227
+          }
+        },
+        "728": {
+          "value": 1228,
+          "params": {
+            "address": 728,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 728",
+            "value": 1228
+          }
+        },
+        "729": {
+          "value": 1229,
+          "params": {
+            "address": 729,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 729",
+            "value": 1229
+          }
+        },
+        "730": {
+          "value": 1230,
+          "params": {
+            "address": 730,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 730",
+            "value": 1230
+          }
+        },
+        "731": {
+          "value": 1231,
+          "params": {
+            "address": 731,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 731",
+            "value": 1231
+          }
+        },
+        "732": {
+          "value": 1232,
+          "params": {
+            "address": 732,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 732",
+            "value": 1232
+          }
+        },
+        "733": {
+          "value": 1233,
+          "params": {
+            "address": 733,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 733",
+            "value": 1233
+          }
+        },
+        "734": {
+          "value": 1234,
+          "params": {
+            "address": 734,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 734",
+            "value": 1234
+          }
+        },
+        "735": {
+          "value": 1235,
+          "params": {
+            "address": 735,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 735",
+            "value": 1235
+          }
+        },
+        "736": {
+          "value": 1236,
+          "params": {
+            "address": 736,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 736",
+            "value": 1236
+          }
+        },
+        "737": {
+          "value": 1237,
+          "params": {
+            "address": 737,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 737",
+            "value": 1237
+          }
+        },
+        "738": {
+          "value": 1238,
+          "params": {
+            "address": 738,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 738",
+            "value": 1238
+          }
+        },
+        "739": {
+          "value": 1239,
+          "params": {
+            "address": 739,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 739",
+            "value": 1239
+          }
+        },
+        "740": {
+          "value": 1240,
+          "params": {
+            "address": 740,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 740",
+            "value": 1240
+          }
+        },
+        "741": {
+          "value": 1241,
+          "params": {
+            "address": 741,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 741",
+            "value": 1241
+          }
+        },
+        "742": {
+          "value": 1242,
+          "params": {
+            "address": 742,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 742",
+            "value": 1242
+          }
+        },
+        "743": {
+          "value": 1243,
+          "params": {
+            "address": 743,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 743",
+            "value": 1243
+          }
+        },
+        "744": {
+          "value": 1244,
+          "params": {
+            "address": 744,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 744",
+            "value": 1244
+          }
+        },
+        "745": {
+          "value": 1245,
+          "params": {
+            "address": 745,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 745",
+            "value": 1245
+          }
+        },
+        "746": {
+          "value": 1246,
+          "params": {
+            "address": 746,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 746",
+            "value": 1246
+          }
+        },
+        "747": {
+          "value": 1247,
+          "params": {
+            "address": 747,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 747",
+            "value": 1247
+          }
+        },
+        "748": {
+          "value": 1248,
+          "params": {
+            "address": 748,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 748",
+            "value": 1248
+          }
+        },
+        "749": {
+          "value": 1249,
+          "params": {
+            "address": 749,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 749",
+            "value": 1249
+          }
+        },
+        "750": {
+          "value": 1250,
+          "params": {
+            "address": 750,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 750",
+            "value": 1250
+          }
+        },
+        "751": {
+          "value": 1251,
+          "params": {
+            "address": 751,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 751",
+            "value": 1251
+          }
+        },
+        "752": {
+          "value": 1252,
+          "params": {
+            "address": 752,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 752",
+            "value": 1252
+          }
+        },
+        "753": {
+          "value": 1253,
+          "params": {
+            "address": 753,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 753",
+            "value": 1253
+          }
+        },
+        "754": {
+          "value": 1254,
+          "params": {
+            "address": 754,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 754",
+            "value": 1254
+          }
+        },
+        "755": {
+          "value": 1255,
+          "params": {
+            "address": 755,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 755",
+            "value": 1255
+          }
+        },
+        "756": {
+          "value": 1256,
+          "params": {
+            "address": 756,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 756",
+            "value": 1256
+          }
+        },
+        "757": {
+          "value": 1257,
+          "params": {
+            "address": 757,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 757",
+            "value": 1257
+          }
+        },
+        "758": {
+          "value": 1258,
+          "params": {
+            "address": 758,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 758",
+            "value": 1258
+          }
+        },
+        "759": {
+          "value": 1259,
+          "params": {
+            "address": 759,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 759",
+            "value": 1259
+          }
+        },
+        "760": {
+          "value": 1260,
+          "params": {
+            "address": 760,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 760",
+            "value": 1260
+          }
+        },
+        "761": {
+          "value": 1261,
+          "params": {
+            "address": 761,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 761",
+            "value": 1261
+          }
+        },
+        "762": {
+          "value": 1262,
+          "params": {
+            "address": 762,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 762",
+            "value": 1262
+          }
+        },
+        "763": {
+          "value": 1263,
+          "params": {
+            "address": 763,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 763",
+            "value": 1263
+          }
+        },
+        "764": {
+          "value": 1264,
+          "params": {
+            "address": 764,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 764",
+            "value": 1264
+          }
+        },
+        "765": {
+          "value": 1265,
+          "params": {
+            "address": 765,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 765",
+            "value": 1265
+          }
+        },
+        "766": {
+          "value": 1266,
+          "params": {
+            "address": 766,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 766",
+            "value": 1266
+          }
+        },
+        "767": {
+          "value": 1267,
+          "params": {
+            "address": 767,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 767",
+            "value": 1267
+          }
+        },
+        "768": {
+          "value": 1268,
+          "params": {
+            "address": 768,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 768",
+            "value": 1268
+          }
+        },
+        "769": {
+          "value": 1269,
+          "params": {
+            "address": 769,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 769",
+            "value": 1269
+          }
+        },
+        "770": {
+          "value": 1270,
+          "params": {
+            "address": 770,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 770",
+            "value": 1270
+          }
+        },
+        "771": {
+          "value": 1271,
+          "params": {
+            "address": 771,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 771",
+            "value": 1271
+          }
+        },
+        "772": {
+          "value": 1272,
+          "params": {
+            "address": 772,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 772",
+            "value": 1272
+          }
+        },
+        "773": {
+          "value": 1273,
+          "params": {
+            "address": 773,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 773",
+            "value": 1273
+          }
+        },
+        "774": {
+          "value": 1274,
+          "params": {
+            "address": 774,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 774",
+            "value": 1274
+          }
+        },
+        "775": {
+          "value": 1275,
+          "params": {
+            "address": 775,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 775",
+            "value": 1275
+          }
+        },
+        "776": {
+          "value": 1276,
+          "params": {
+            "address": 776,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 776",
+            "value": 1276
+          }
+        },
+        "777": {
+          "value": 1277,
+          "params": {
+            "address": 777,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 777",
+            "value": 1277
+          }
+        },
+        "778": {
+          "value": 1278,
+          "params": {
+            "address": 778,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 778",
+            "value": 1278
+          }
+        },
+        "779": {
+          "value": 1279,
+          "params": {
+            "address": 779,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 779",
+            "value": 1279
+          }
+        },
+        "780": {
+          "value": 1280,
+          "params": {
+            "address": 780,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 780",
+            "value": 1280
+          }
+        },
+        "781": {
+          "value": 1281,
+          "params": {
+            "address": 781,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 781",
+            "value": 1281
+          }
+        },
+        "782": {
+          "value": 1282,
+          "params": {
+            "address": 782,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 782",
+            "value": 1282
+          }
+        },
+        "783": {
+          "value": 1283,
+          "params": {
+            "address": 783,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 783",
+            "value": 1283
+          }
+        },
+        "784": {
+          "value": 1284,
+          "params": {
+            "address": 784,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 784",
+            "value": 1284
+          }
+        },
+        "785": {
+          "value": 1285,
+          "params": {
+            "address": 785,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 785",
+            "value": 1285
+          }
+        },
+        "786": {
+          "value": 1286,
+          "params": {
+            "address": 786,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 786",
+            "value": 1286
+          }
+        },
+        "787": {
+          "value": 1287,
+          "params": {
+            "address": 787,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 787",
+            "value": 1287
+          }
+        },
+        "788": {
+          "value": 1288,
+          "params": {
+            "address": 788,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 788",
+            "value": 1288
+          }
+        },
+        "789": {
+          "value": 1289,
+          "params": {
+            "address": 789,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 789",
+            "value": 1289
+          }
+        },
+        "790": {
+          "value": 1290,
+          "params": {
+            "address": 790,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 790",
+            "value": 1290
+          }
+        },
+        "791": {
+          "value": 1291,
+          "params": {
+            "address": 791,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 791",
+            "value": 1291
+          }
+        },
+        "792": {
+          "value": 1292,
+          "params": {
+            "address": 792,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 792",
+            "value": 1292
+          }
+        },
+        "793": {
+          "value": 1293,
+          "params": {
+            "address": 793,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 793",
+            "value": 1293
+          }
+        },
+        "794": {
+          "value": 1294,
+          "params": {
+            "address": 794,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 794",
+            "value": 1294
+          }
+        },
+        "795": {
+          "value": 1295,
+          "params": {
+            "address": 795,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 795",
+            "value": 1295
+          }
+        },
+        "796": {
+          "value": 1296,
+          "params": {
+            "address": 796,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 796",
+            "value": 1296
+          }
+        },
+        "797": {
+          "value": 1297,
+          "params": {
+            "address": 797,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 797",
+            "value": 1297
+          }
+        },
+        "798": {
+          "value": 1298,
+          "params": {
+            "address": 798,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 798",
+            "value": 1298
+          }
+        },
+        "799": {
+          "value": 1299,
+          "params": {
+            "address": 799,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 799",
+            "value": 1299
+          }
+        },
+        "800": {
+          "value": 1300,
+          "params": {
+            "address": 800,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 800",
+            "value": 1300
+          }
+        },
+        "801": {
+          "value": 1301,
+          "params": {
+            "address": 801,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 801",
+            "value": 1301
+          }
+        },
+        "802": {
+          "value": 1302,
+          "params": {
+            "address": 802,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 802",
+            "value": 1302
+          }
+        },
+        "803": {
+          "value": 1303,
+          "params": {
+            "address": 803,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 803",
+            "value": 1303
+          }
+        },
+        "804": {
+          "value": 1304,
+          "params": {
+            "address": 804,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 804",
+            "value": 1304
+          }
+        },
+        "805": {
+          "value": 1305,
+          "params": {
+            "address": 805,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 805",
+            "value": 1305
+          }
+        },
+        "806": {
+          "value": 1306,
+          "params": {
+            "address": 806,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 806",
+            "value": 1306
+          }
+        },
+        "807": {
+          "value": 1307,
+          "params": {
+            "address": 807,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 807",
+            "value": 1307
+          }
+        },
+        "808": {
+          "value": 1308,
+          "params": {
+            "address": 808,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 808",
+            "value": 1308
+          }
+        },
+        "809": {
+          "value": 1309,
+          "params": {
+            "address": 809,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 809",
+            "value": 1309
+          }
+        },
+        "810": {
+          "value": 1310,
+          "params": {
+            "address": 810,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 810",
+            "value": 1310
+          }
+        },
+        "811": {
+          "value": 1311,
+          "params": {
+            "address": 811,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 811",
+            "value": 1311
+          }
+        },
+        "812": {
+          "value": 1312,
+          "params": {
+            "address": 812,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 812",
+            "value": 1312
+          }
+        },
+        "813": {
+          "value": 1313,
+          "params": {
+            "address": 813,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 813",
+            "value": 1313
+          }
+        },
+        "814": {
+          "value": 1314,
+          "params": {
+            "address": 814,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 814",
+            "value": 1314
+          }
+        },
+        "815": {
+          "value": 1315,
+          "params": {
+            "address": 815,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 815",
+            "value": 1315
+          }
+        },
+        "816": {
+          "value": 1316,
+          "params": {
+            "address": 816,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 816",
+            "value": 1316
+          }
+        },
+        "817": {
+          "value": 1317,
+          "params": {
+            "address": 817,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 817",
+            "value": 1317
+          }
+        },
+        "818": {
+          "value": 1318,
+          "params": {
+            "address": 818,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 818",
+            "value": 1318
+          }
+        },
+        "819": {
+          "value": 1319,
+          "params": {
+            "address": 819,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 819",
+            "value": 1319
+          }
+        },
+        "820": {
+          "value": 1320,
+          "params": {
+            "address": 820,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 820",
+            "value": 1320
+          }
+        },
+        "821": {
+          "value": 1321,
+          "params": {
+            "address": 821,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 821",
+            "value": 1321
+          }
+        },
+        "822": {
+          "value": 1322,
+          "params": {
+            "address": 822,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 822",
+            "value": 1322
+          }
+        },
+        "823": {
+          "value": 1323,
+          "params": {
+            "address": 823,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 823",
+            "value": 1323
+          }
+        },
+        "824": {
+          "value": 1324,
+          "params": {
+            "address": 824,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 824",
+            "value": 1324
+          }
+        },
+        "825": {
+          "value": 1325,
+          "params": {
+            "address": 825,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 825",
+            "value": 1325
+          }
+        },
+        "826": {
+          "value": 1326,
+          "params": {
+            "address": 826,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 826",
+            "value": 1326
+          }
+        },
+        "827": {
+          "value": 1327,
+          "params": {
+            "address": 827,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 827",
+            "value": 1327
+          }
+        },
+        "828": {
+          "value": 1328,
+          "params": {
+            "address": 828,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 828",
+            "value": 1328
+          }
+        },
+        "829": {
+          "value": 1329,
+          "params": {
+            "address": 829,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 829",
+            "value": 1329
+          }
+        },
+        "830": {
+          "value": 1330,
+          "params": {
+            "address": 830,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 830",
+            "value": 1330
+          }
+        },
+        "831": {
+          "value": 1331,
+          "params": {
+            "address": 831,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 831",
+            "value": 1331
+          }
+        },
+        "832": {
+          "value": 1332,
+          "params": {
+            "address": 832,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 832",
+            "value": 1332
+          }
+        },
+        "833": {
+          "value": 1333,
+          "params": {
+            "address": 833,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 833",
+            "value": 1333
+          }
+        },
+        "834": {
+          "value": 1334,
+          "params": {
+            "address": 834,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 834",
+            "value": 1334
+          }
+        },
+        "835": {
+          "value": 1335,
+          "params": {
+            "address": 835,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 835",
+            "value": 1335
+          }
+        },
+        "836": {
+          "value": 1336,
+          "params": {
+            "address": 836,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 836",
+            "value": 1336
+          }
+        },
+        "837": {
+          "value": 1337,
+          "params": {
+            "address": 837,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 837",
+            "value": 1337
+          }
+        },
+        "838": {
+          "value": 1338,
+          "params": {
+            "address": 838,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 838",
+            "value": 1338
+          }
+        },
+        "839": {
+          "value": 1339,
+          "params": {
+            "address": 839,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 839",
+            "value": 1339
+          }
+        },
+        "840": {
+          "value": 1340,
+          "params": {
+            "address": 840,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 840",
+            "value": 1340
+          }
+        },
+        "841": {
+          "value": 1341,
+          "params": {
+            "address": 841,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 841",
+            "value": 1341
+          }
+        },
+        "842": {
+          "value": 1342,
+          "params": {
+            "address": 842,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 842",
+            "value": 1342
+          }
+        },
+        "843": {
+          "value": 1343,
+          "params": {
+            "address": 843,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 843",
+            "value": 1343
+          }
+        },
+        "844": {
+          "value": 1344,
+          "params": {
+            "address": 844,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 844",
+            "value": 1344
+          }
+        },
+        "845": {
+          "value": 1345,
+          "params": {
+            "address": 845,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 845",
+            "value": 1345
+          }
+        },
+        "846": {
+          "value": 1346,
+          "params": {
+            "address": 846,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 846",
+            "value": 1346
+          }
+        },
+        "847": {
+          "value": 1347,
+          "params": {
+            "address": 847,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 847",
+            "value": 1347
+          }
+        },
+        "848": {
+          "value": 1348,
+          "params": {
+            "address": 848,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 848",
+            "value": 1348
+          }
+        },
+        "849": {
+          "value": 1349,
+          "params": {
+            "address": 849,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 849",
+            "value": 1349
+          }
+        },
+        "850": {
+          "value": 1350,
+          "params": {
+            "address": 850,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 850",
+            "value": 1350
+          }
+        },
+        "851": {
+          "value": 1351,
+          "params": {
+            "address": 851,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 851",
+            "value": 1351
+          }
+        },
+        "852": {
+          "value": 1352,
+          "params": {
+            "address": 852,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 852",
+            "value": 1352
+          }
+        },
+        "853": {
+          "value": 1353,
+          "params": {
+            "address": 853,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 853",
+            "value": 1353
+          }
+        },
+        "854": {
+          "value": 1354,
+          "params": {
+            "address": 854,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 854",
+            "value": 1354
+          }
+        },
+        "855": {
+          "value": 1355,
+          "params": {
+            "address": 855,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 855",
+            "value": 1355
+          }
+        },
+        "856": {
+          "value": 1356,
+          "params": {
+            "address": 856,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 856",
+            "value": 1356
+          }
+        },
+        "857": {
+          "value": 1357,
+          "params": {
+            "address": 857,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 857",
+            "value": 1357
+          }
+        },
+        "858": {
+          "value": 1358,
+          "params": {
+            "address": 858,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 858",
+            "value": 1358
+          }
+        },
+        "859": {
+          "value": 1359,
+          "params": {
+            "address": 859,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 859",
+            "value": 1359
+          }
+        },
+        "860": {
+          "value": 1360,
+          "params": {
+            "address": 860,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 860",
+            "value": 1360
+          }
+        },
+        "861": {
+          "value": 1361,
+          "params": {
+            "address": 861,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 861",
+            "value": 1361
+          }
+        },
+        "862": {
+          "value": 1362,
+          "params": {
+            "address": 862,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 862",
+            "value": 1362
+          }
+        },
+        "863": {
+          "value": 1363,
+          "params": {
+            "address": 863,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 863",
+            "value": 1363
+          }
+        },
+        "864": {
+          "value": 1364,
+          "params": {
+            "address": 864,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 864",
+            "value": 1364
+          }
+        },
+        "865": {
+          "value": 1365,
+          "params": {
+            "address": 865,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 865",
+            "value": 1365
+          }
+        },
+        "866": {
+          "value": 1366,
+          "params": {
+            "address": 866,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 866",
+            "value": 1366
+          }
+        },
+        "867": {
+          "value": 1367,
+          "params": {
+            "address": 867,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 867",
+            "value": 1367
+          }
+        },
+        "868": {
+          "value": 1368,
+          "params": {
+            "address": 868,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 868",
+            "value": 1368
+          }
+        },
+        "869": {
+          "value": 1369,
+          "params": {
+            "address": 869,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 869",
+            "value": 1369
+          }
+        },
+        "870": {
+          "value": 1370,
+          "params": {
+            "address": 870,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 870",
+            "value": 1370
+          }
+        },
+        "871": {
+          "value": 1371,
+          "params": {
+            "address": 871,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 871",
+            "value": 1371
+          }
+        },
+        "872": {
+          "value": 1372,
+          "params": {
+            "address": 872,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 872",
+            "value": 1372
+          }
+        },
+        "873": {
+          "value": 1373,
+          "params": {
+            "address": 873,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 873",
+            "value": 1373
+          }
+        },
+        "874": {
+          "value": 1374,
+          "params": {
+            "address": 874,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 874",
+            "value": 1374
+          }
+        },
+        "875": {
+          "value": 1375,
+          "params": {
+            "address": 875,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 875",
+            "value": 1375
+          }
+        },
+        "876": {
+          "value": 1376,
+          "params": {
+            "address": 876,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 876",
+            "value": 1376
+          }
+        },
+        "877": {
+          "value": 1377,
+          "params": {
+            "address": 877,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 877",
+            "value": 1377
+          }
+        },
+        "878": {
+          "value": 1378,
+          "params": {
+            "address": 878,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 878",
+            "value": 1378
+          }
+        },
+        "879": {
+          "value": 1379,
+          "params": {
+            "address": 879,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 879",
+            "value": 1379
+          }
+        },
+        "880": {
+          "value": 1380,
+          "params": {
+            "address": 880,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 880",
+            "value": 1380
+          }
+        },
+        "881": {
+          "value": 1381,
+          "params": {
+            "address": 881,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 881",
+            "value": 1381
+          }
+        },
+        "882": {
+          "value": 1382,
+          "params": {
+            "address": 882,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 882",
+            "value": 1382
+          }
+        },
+        "883": {
+          "value": 1383,
+          "params": {
+            "address": 883,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 883",
+            "value": 1383
+          }
+        },
+        "884": {
+          "value": 1384,
+          "params": {
+            "address": 884,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 884",
+            "value": 1384
+          }
+        },
+        "885": {
+          "value": 1385,
+          "params": {
+            "address": 885,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 885",
+            "value": 1385
+          }
+        },
+        "886": {
+          "value": 1386,
+          "params": {
+            "address": 886,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 886",
+            "value": 1386
+          }
+        },
+        "887": {
+          "value": 1387,
+          "params": {
+            "address": 887,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 887",
+            "value": 1387
+          }
+        },
+        "888": {
+          "value": 1388,
+          "params": {
+            "address": 888,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 888",
+            "value": 1388
+          }
+        },
+        "889": {
+          "value": 1389,
+          "params": {
+            "address": 889,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 889",
+            "value": 1389
+          }
+        },
+        "890": {
+          "value": 1390,
+          "params": {
+            "address": 890,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 890",
+            "value": 1390
+          }
+        },
+        "891": {
+          "value": 1391,
+          "params": {
+            "address": 891,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 891",
+            "value": 1391
+          }
+        },
+        "892": {
+          "value": 1392,
+          "params": {
+            "address": 892,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 892",
+            "value": 1392
+          }
+        },
+        "893": {
+          "value": 1393,
+          "params": {
+            "address": 893,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 893",
+            "value": 1393
+          }
+        },
+        "894": {
+          "value": 1394,
+          "params": {
+            "address": 894,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 894",
+            "value": 1394
+          }
+        },
+        "895": {
+          "value": 1395,
+          "params": {
+            "address": 895,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 895",
+            "value": 1395
+          }
+        },
+        "896": {
+          "value": 1396,
+          "params": {
+            "address": 896,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 896",
+            "value": 1396
+          }
+        },
+        "897": {
+          "value": 1397,
+          "params": {
+            "address": 897,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 897",
+            "value": 1397
+          }
+        },
+        "898": {
+          "value": 1398,
+          "params": {
+            "address": 898,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 898",
+            "value": 1398
+          }
+        },
+        "899": {
+          "value": 1399,
+          "params": {
+            "address": 899,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 899",
+            "value": 1399
+          }
+        },
+        "900": {
+          "value": 1400,
+          "params": {
+            "address": 900,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 900",
+            "value": 1400
+          }
+        },
+        "901": {
+          "value": 1401,
+          "params": {
+            "address": 901,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 901",
+            "value": 1401
+          }
+        },
+        "902": {
+          "value": 1402,
+          "params": {
+            "address": 902,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 902",
+            "value": 1402
+          }
+        },
+        "903": {
+          "value": 1403,
+          "params": {
+            "address": 903,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 903",
+            "value": 1403
+          }
+        },
+        "904": {
+          "value": 1404,
+          "params": {
+            "address": 904,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 904",
+            "value": 1404
+          }
+        },
+        "905": {
+          "value": 1405,
+          "params": {
+            "address": 905,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 905",
+            "value": 1405
+          }
+        },
+        "906": {
+          "value": 1406,
+          "params": {
+            "address": 906,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 906",
+            "value": 1406
+          }
+        },
+        "907": {
+          "value": 1407,
+          "params": {
+            "address": 907,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 907",
+            "value": 1407
+          }
+        },
+        "908": {
+          "value": 1408,
+          "params": {
+            "address": 908,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 908",
+            "value": 1408
+          }
+        },
+        "909": {
+          "value": 1409,
+          "params": {
+            "address": 909,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 909",
+            "value": 1409
+          }
+        },
+        "910": {
+          "value": 1410,
+          "params": {
+            "address": 910,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 910",
+            "value": 1410
+          }
+        },
+        "911": {
+          "value": 1411,
+          "params": {
+            "address": 911,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 911",
+            "value": 1411
+          }
+        },
+        "912": {
+          "value": 1412,
+          "params": {
+            "address": 912,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 912",
+            "value": 1412
+          }
+        },
+        "913": {
+          "value": 1413,
+          "params": {
+            "address": 913,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 913",
+            "value": 1413
+          }
+        },
+        "914": {
+          "value": 1414,
+          "params": {
+            "address": 914,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 914",
+            "value": 1414
+          }
+        },
+        "915": {
+          "value": 1415,
+          "params": {
+            "address": 915,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 915",
+            "value": 1415
+          }
+        },
+        "916": {
+          "value": 1416,
+          "params": {
+            "address": 916,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 916",
+            "value": 1416
+          }
+        },
+        "917": {
+          "value": 1417,
+          "params": {
+            "address": 917,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 917",
+            "value": 1417
+          }
+        },
+        "918": {
+          "value": 1418,
+          "params": {
+            "address": 918,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 918",
+            "value": 1418
+          }
+        },
+        "919": {
+          "value": 1419,
+          "params": {
+            "address": 919,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 919",
+            "value": 1419
+          }
+        },
+        "920": {
+          "value": 1420,
+          "params": {
+            "address": 920,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 920",
+            "value": 1420
+          }
+        },
+        "921": {
+          "value": 1421,
+          "params": {
+            "address": 921,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 921",
+            "value": 1421
+          }
+        },
+        "922": {
+          "value": 1422,
+          "params": {
+            "address": 922,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 922",
+            "value": 1422
+          }
+        },
+        "923": {
+          "value": 1423,
+          "params": {
+            "address": 923,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 923",
+            "value": 1423
+          }
+        },
+        "924": {
+          "value": 1424,
+          "params": {
+            "address": 924,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 924",
+            "value": 1424
+          }
+        },
+        "925": {
+          "value": 1425,
+          "params": {
+            "address": 925,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 925",
+            "value": 1425
+          }
+        },
+        "926": {
+          "value": 1426,
+          "params": {
+            "address": 926,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 926",
+            "value": 1426
+          }
+        },
+        "927": {
+          "value": 1427,
+          "params": {
+            "address": 927,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 927",
+            "value": 1427
+          }
+        },
+        "928": {
+          "value": 1428,
+          "params": {
+            "address": 928,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 928",
+            "value": 1428
+          }
+        },
+        "929": {
+          "value": 1429,
+          "params": {
+            "address": 929,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 929",
+            "value": 1429
+          }
+        },
+        "930": {
+          "value": 1430,
+          "params": {
+            "address": 930,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 930",
+            "value": 1430
+          }
+        },
+        "931": {
+          "value": 1431,
+          "params": {
+            "address": 931,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 931",
+            "value": 1431
+          }
+        },
+        "932": {
+          "value": 1432,
+          "params": {
+            "address": 932,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 932",
+            "value": 1432
+          }
+        },
+        "933": {
+          "value": 1433,
+          "params": {
+            "address": 933,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 933",
+            "value": 1433
+          }
+        },
+        "934": {
+          "value": 1434,
+          "params": {
+            "address": 934,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 934",
+            "value": 1434
+          }
+        },
+        "935": {
+          "value": 1435,
+          "params": {
+            "address": 935,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 935",
+            "value": 1435
+          }
+        },
+        "936": {
+          "value": 1436,
+          "params": {
+            "address": 936,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 936",
+            "value": 1436
+          }
+        },
+        "937": {
+          "value": 1437,
+          "params": {
+            "address": 937,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 937",
+            "value": 1437
+          }
+        },
+        "938": {
+          "value": 1438,
+          "params": {
+            "address": 938,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 938",
+            "value": 1438
+          }
+        },
+        "939": {
+          "value": 1439,
+          "params": {
+            "address": 939,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 939",
+            "value": 1439
+          }
+        },
+        "940": {
+          "value": 1440,
+          "params": {
+            "address": 940,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 940",
+            "value": 1440
+          }
+        },
+        "941": {
+          "value": 1441,
+          "params": {
+            "address": 941,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 941",
+            "value": 1441
+          }
+        },
+        "942": {
+          "value": 1442,
+          "params": {
+            "address": 942,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 942",
+            "value": 1442
+          }
+        },
+        "943": {
+          "value": 1443,
+          "params": {
+            "address": 943,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 943",
+            "value": 1443
+          }
+        },
+        "944": {
+          "value": 1444,
+          "params": {
+            "address": 944,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 944",
+            "value": 1444
+          }
+        },
+        "945": {
+          "value": 1445,
+          "params": {
+            "address": 945,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 945",
+            "value": 1445
+          }
+        },
+        "946": {
+          "value": 1446,
+          "params": {
+            "address": 946,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 946",
+            "value": 1446
+          }
+        },
+        "947": {
+          "value": 1447,
+          "params": {
+            "address": 947,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 947",
+            "value": 1447
+          }
+        },
+        "948": {
+          "value": 1448,
+          "params": {
+            "address": 948,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 948",
+            "value": 1448
+          }
+        },
+        "949": {
+          "value": 1449,
+          "params": {
+            "address": 949,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 949",
+            "value": 1449
+          }
+        },
+        "950": {
+          "value": 1450,
+          "params": {
+            "address": 950,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 950",
+            "value": 1450
+          }
+        },
+        "951": {
+          "value": 1451,
+          "params": {
+            "address": 951,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 951",
+            "value": 1451
+          }
+        },
+        "952": {
+          "value": 1452,
+          "params": {
+            "address": 952,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 952",
+            "value": 1452
+          }
+        },
+        "953": {
+          "value": 1453,
+          "params": {
+            "address": 953,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 953",
+            "value": 1453
+          }
+        },
+        "954": {
+          "value": 1454,
+          "params": {
+            "address": 954,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 954",
+            "value": 1454
+          }
+        },
+        "955": {
+          "value": 1455,
+          "params": {
+            "address": 955,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 955",
+            "value": 1455
+          }
+        },
+        "956": {
+          "value": 1456,
+          "params": {
+            "address": 956,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 956",
+            "value": 1456
+          }
+        },
+        "957": {
+          "value": 1457,
+          "params": {
+            "address": 957,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 957",
+            "value": 1457
+          }
+        },
+        "958": {
+          "value": 1458,
+          "params": {
+            "address": 958,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 958",
+            "value": 1458
+          }
+        },
+        "959": {
+          "value": 1459,
+          "params": {
+            "address": 959,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 959",
+            "value": 1459
+          }
+        },
+        "960": {
+          "value": 1460,
+          "params": {
+            "address": 960,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 960",
+            "value": 1460
+          }
+        },
+        "961": {
+          "value": 1461,
+          "params": {
+            "address": 961,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 961",
+            "value": 1461
+          }
+        },
+        "962": {
+          "value": 1462,
+          "params": {
+            "address": 962,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 962",
+            "value": 1462
+          }
+        },
+        "963": {
+          "value": 1463,
+          "params": {
+            "address": 963,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 963",
+            "value": 1463
+          }
+        },
+        "964": {
+          "value": 1464,
+          "params": {
+            "address": 964,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 964",
+            "value": 1464
+          }
+        },
+        "965": {
+          "value": 1465,
+          "params": {
+            "address": 965,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 965",
+            "value": 1465
+          }
+        },
+        "966": {
+          "value": 1466,
+          "params": {
+            "address": 966,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 966",
+            "value": 1466
+          }
+        },
+        "967": {
+          "value": 1467,
+          "params": {
+            "address": 967,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 967",
+            "value": 1467
+          }
+        },
+        "968": {
+          "value": 1468,
+          "params": {
+            "address": 968,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 968",
+            "value": 1468
+          }
+        },
+        "969": {
+          "value": 1469,
+          "params": {
+            "address": 969,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 969",
+            "value": 1469
+          }
+        },
+        "970": {
+          "value": 1470,
+          "params": {
+            "address": 970,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 970",
+            "value": 1470
+          }
+        },
+        "971": {
+          "value": 1471,
+          "params": {
+            "address": 971,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 971",
+            "value": 1471
+          }
+        },
+        "972": {
+          "value": 1472,
+          "params": {
+            "address": 972,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 972",
+            "value": 1472
+          }
+        },
+        "973": {
+          "value": 1473,
+          "params": {
+            "address": 973,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 973",
+            "value": 1473
+          }
+        },
+        "974": {
+          "value": 1474,
+          "params": {
+            "address": 974,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 974",
+            "value": 1474
+          }
+        },
+        "975": {
+          "value": 1475,
+          "params": {
+            "address": 975,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 975",
+            "value": 1475
+          }
+        },
+        "976": {
+          "value": 1476,
+          "params": {
+            "address": 976,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 976",
+            "value": 1476
+          }
+        },
+        "977": {
+          "value": 1477,
+          "params": {
+            "address": 977,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 977",
+            "value": 1477
+          }
+        },
+        "978": {
+          "value": 1478,
+          "params": {
+            "address": 978,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 978",
+            "value": 1478
+          }
+        },
+        "979": {
+          "value": 1479,
+          "params": {
+            "address": 979,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 979",
+            "value": 1479
+          }
+        },
+        "980": {
+          "value": 1480,
+          "params": {
+            "address": 980,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 980",
+            "value": 1480
+          }
+        },
+        "981": {
+          "value": 1481,
+          "params": {
+            "address": 981,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 981",
+            "value": 1481
+          }
+        },
+        "982": {
+          "value": 1482,
+          "params": {
+            "address": 982,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 982",
+            "value": 1482
+          }
+        },
+        "983": {
+          "value": 1483,
+          "params": {
+            "address": 983,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 983",
+            "value": 1483
+          }
+        },
+        "984": {
+          "value": 1484,
+          "params": {
+            "address": 984,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 984",
+            "value": 1484
+          }
+        },
+        "985": {
+          "value": 1485,
+          "params": {
+            "address": 985,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 985",
+            "value": 1485
+          }
+        },
+        "986": {
+          "value": 1486,
+          "params": {
+            "address": 986,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 986",
+            "value": 1486
+          }
+        },
+        "987": {
+          "value": 1487,
+          "params": {
+            "address": 987,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 987",
+            "value": 1487
+          }
+        },
+        "988": {
+          "value": 1488,
+          "params": {
+            "address": 988,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 988",
+            "value": 1488
+          }
+        },
+        "989": {
+          "value": 1489,
+          "params": {
+            "address": 989,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 989",
+            "value": 1489
+          }
+        },
+        "990": {
+          "value": 1490,
+          "params": {
+            "address": 990,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 990",
+            "value": 1490
+          }
+        },
+        "991": {
+          "value": 1491,
+          "params": {
+            "address": 991,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 991",
+            "value": 1491
+          }
+        },
+        "992": {
+          "value": 1492,
+          "params": {
+            "address": 992,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 992",
+            "value": 1492
+          }
+        },
+        "993": {
+          "value": 1493,
+          "params": {
+            "address": 993,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 993",
+            "value": 1493
+          }
+        },
+        "994": {
+          "value": 1494,
+          "params": {
+            "address": 994,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 994",
+            "value": 1494
+          }
+        },
+        "995": {
+          "value": 1495,
+          "params": {
+            "address": 995,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 995",
+            "value": 1495
+          }
+        },
+        "996": {
+          "value": 1496,
+          "params": {
+            "address": 996,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 996",
+            "value": 1496
+          }
+        },
+        "997": {
+          "value": 1497,
+          "params": {
+            "address": 997,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 997",
+            "value": 1497
+          }
+        },
+        "998": {
+          "value": 1498,
+          "params": {
+            "address": 998,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 998",
+            "value": 1498
+          }
+        },
+        "999": {
+          "value": 1499,
+          "params": {
+            "address": 999,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 999",
+            "value": 1499
+          }
+        },
+        "1000": {
+          "value": 1000,
+          "params": {
+            "address": 1000,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1000",
+            "value": 1000
+          }
+        },
+        "1001": {
+          "value": 1001,
+          "params": {
+            "address": 1001,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1001",
+            "value": 1001
+          }
+        },
+        "1002": {
+          "value": 1002,
+          "params": {
+            "address": 1002,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1002",
+            "value": 1002
+          }
+        },
+        "1003": {
+          "value": 1003,
+          "params": {
+            "address": 1003,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1003",
+            "value": 1003
+          }
+        },
+        "1004": {
+          "value": 1004,
+          "params": {
+            "address": 1004,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1004",
+            "value": 1004
+          }
+        },
+        "1005": {
+          "value": 1005,
+          "params": {
+            "address": 1005,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1005",
+            "value": 1005
+          }
+        },
+        "1006": {
+          "value": 1006,
+          "params": {
+            "address": 1006,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1006",
+            "value": 1006
+          }
+        },
+        "1007": {
+          "value": 1007,
+          "params": {
+            "address": 1007,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1007",
+            "value": 1007
+          }
+        },
+        "1008": {
+          "value": 1008,
+          "params": {
+            "address": 1008,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1008",
+            "value": 1008
+          }
+        },
+        "1009": {
+          "value": 1009,
+          "params": {
+            "address": 1009,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1009",
+            "value": 1009
+          }
+        },
+        "1010": {
+          "value": 1010,
+          "params": {
+            "address": 1010,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1010",
+            "value": 1010
+          }
+        },
+        "1011": {
+          "value": 1011,
+          "params": {
+            "address": 1011,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1011",
+            "value": 1011
+          }
+        },
+        "1012": {
+          "value": 1012,
+          "params": {
+            "address": 1012,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1012",
+            "value": 1012
+          }
+        },
+        "1013": {
+          "value": 1013,
+          "params": {
+            "address": 1013,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1013",
+            "value": 1013
+          }
+        },
+        "1014": {
+          "value": 1014,
+          "params": {
+            "address": 1014,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1014",
+            "value": 1014
+          }
+        },
+        "1015": {
+          "value": 1015,
+          "params": {
+            "address": 1015,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1015",
+            "value": 1015
+          }
+        },
+        "1016": {
+          "value": 1016,
+          "params": {
+            "address": 1016,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1016",
+            "value": 1016
+          }
+        },
+        "1017": {
+          "value": 1017,
+          "params": {
+            "address": 1017,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1017",
+            "value": 1017
+          }
+        },
+        "1018": {
+          "value": 1018,
+          "params": {
+            "address": 1018,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1018",
+            "value": 1018
+          }
+        },
+        "1019": {
+          "value": 1019,
+          "params": {
+            "address": 1019,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1019",
+            "value": 1019
+          }
+        },
+        "1020": {
+          "value": 1020,
+          "params": {
+            "address": 1020,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1020",
+            "value": 1020
+          }
+        },
+        "1021": {
+          "value": 1021,
+          "params": {
+            "address": 1021,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1021",
+            "value": 1021
+          }
+        },
+        "1022": {
+          "value": 1022,
+          "params": {
+            "address": 1022,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1022",
+            "value": 1022
+          }
+        },
+        "1023": {
+          "value": 1023,
+          "params": {
+            "address": 1023,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1023",
+            "value": 1023
+          }
+        },
+        "1024": {
+          "value": 1024,
+          "params": {
+            "address": 1024,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1024",
+            "value": 1024
+          }
+        },
+        "1025": {
+          "value": 1025,
+          "params": {
+            "address": 1025,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1025",
+            "value": 1025
+          }
+        },
+        "1026": {
+          "value": 1026,
+          "params": {
+            "address": 1026,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1026",
+            "value": 1026
+          }
+        },
+        "1027": {
+          "value": 1027,
+          "params": {
+            "address": 1027,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1027",
+            "value": 1027
+          }
+        },
+        "1028": {
+          "value": 1028,
+          "params": {
+            "address": 1028,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1028",
+            "value": 1028
+          }
+        },
+        "1029": {
+          "value": 1029,
+          "params": {
+            "address": 1029,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1029",
+            "value": 1029
+          }
+        },
+        "1030": {
+          "value": 1030,
+          "params": {
+            "address": 1030,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1030",
+            "value": 1030
+          }
+        },
+        "1031": {
+          "value": 1031,
+          "params": {
+            "address": 1031,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1031",
+            "value": 1031
+          }
+        },
+        "1032": {
+          "value": 1032,
+          "params": {
+            "address": 1032,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1032",
+            "value": 1032
+          }
+        },
+        "1033": {
+          "value": 1033,
+          "params": {
+            "address": 1033,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1033",
+            "value": 1033
+          }
+        },
+        "1034": {
+          "value": 1034,
+          "params": {
+            "address": 1034,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1034",
+            "value": 1034
+          }
+        },
+        "1035": {
+          "value": 1035,
+          "params": {
+            "address": 1035,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1035",
+            "value": 1035
+          }
+        },
+        "1036": {
+          "value": 1036,
+          "params": {
+            "address": 1036,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1036",
+            "value": 1036
+          }
+        },
+        "1037": {
+          "value": 1037,
+          "params": {
+            "address": 1037,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1037",
+            "value": 1037
+          }
+        },
+        "1038": {
+          "value": 1038,
+          "params": {
+            "address": 1038,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1038",
+            "value": 1038
+          }
+        },
+        "1039": {
+          "value": 1039,
+          "params": {
+            "address": 1039,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1039",
+            "value": 1039
+          }
+        },
+        "1040": {
+          "value": 1040,
+          "params": {
+            "address": 1040,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1040",
+            "value": 1040
+          }
+        },
+        "1041": {
+          "value": 1041,
+          "params": {
+            "address": 1041,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1041",
+            "value": 1041
+          }
+        },
+        "1042": {
+          "value": 1042,
+          "params": {
+            "address": 1042,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1042",
+            "value": 1042
+          }
+        },
+        "1043": {
+          "value": 1043,
+          "params": {
+            "address": 1043,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1043",
+            "value": 1043
+          }
+        },
+        "1044": {
+          "value": 1044,
+          "params": {
+            "address": 1044,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1044",
+            "value": 1044
+          }
+        },
+        "1045": {
+          "value": 1045,
+          "params": {
+            "address": 1045,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1045",
+            "value": 1045
+          }
+        },
+        "1046": {
+          "value": 1046,
+          "params": {
+            "address": 1046,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1046",
+            "value": 1046
+          }
+        },
+        "1047": {
+          "value": 1047,
+          "params": {
+            "address": 1047,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1047",
+            "value": 1047
+          }
+        },
+        "1048": {
+          "value": 1048,
+          "params": {
+            "address": 1048,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1048",
+            "value": 1048
+          }
+        },
+        "1049": {
+          "value": 1049,
+          "params": {
+            "address": 1049,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1049",
+            "value": 1049
+          }
+        },
+        "1050": {
+          "value": 1050,
+          "params": {
+            "address": 1050,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1050",
+            "value": 1050
+          }
+        },
+        "1051": {
+          "value": 1051,
+          "params": {
+            "address": 1051,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1051",
+            "value": 1051
+          }
+        },
+        "1052": {
+          "value": 1052,
+          "params": {
+            "address": 1052,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1052",
+            "value": 1052
+          }
+        },
+        "1053": {
+          "value": 1053,
+          "params": {
+            "address": 1053,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1053",
+            "value": 1053
+          }
+        },
+        "1054": {
+          "value": 1054,
+          "params": {
+            "address": 1054,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1054",
+            "value": 1054
+          }
+        },
+        "1055": {
+          "value": 1055,
+          "params": {
+            "address": 1055,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1055",
+            "value": 1055
+          }
+        },
+        "1056": {
+          "value": 1056,
+          "params": {
+            "address": 1056,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1056",
+            "value": 1056
+          }
+        },
+        "1057": {
+          "value": 1057,
+          "params": {
+            "address": 1057,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1057",
+            "value": 1057
+          }
+        },
+        "1058": {
+          "value": 1058,
+          "params": {
+            "address": 1058,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1058",
+            "value": 1058
+          }
+        },
+        "1059": {
+          "value": 1059,
+          "params": {
+            "address": 1059,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1059",
+            "value": 1059
+          }
+        },
+        "1060": {
+          "value": 1060,
+          "params": {
+            "address": 1060,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1060",
+            "value": 1060
+          }
+        },
+        "1061": {
+          "value": 1061,
+          "params": {
+            "address": 1061,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1061",
+            "value": 1061
+          }
+        },
+        "1062": {
+          "value": 1062,
+          "params": {
+            "address": 1062,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1062",
+            "value": 1062
+          }
+        },
+        "1063": {
+          "value": 1063,
+          "params": {
+            "address": 1063,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1063",
+            "value": 1063
+          }
+        },
+        "1064": {
+          "value": 1064,
+          "params": {
+            "address": 1064,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1064",
+            "value": 1064
+          }
+        },
+        "1065": {
+          "value": 1065,
+          "params": {
+            "address": 1065,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1065",
+            "value": 1065
+          }
+        },
+        "1066": {
+          "value": 1066,
+          "params": {
+            "address": 1066,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1066",
+            "value": 1066
+          }
+        },
+        "1067": {
+          "value": 1067,
+          "params": {
+            "address": 1067,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1067",
+            "value": 1067
+          }
+        },
+        "1068": {
+          "value": 1068,
+          "params": {
+            "address": 1068,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1068",
+            "value": 1068
+          }
+        },
+        "1069": {
+          "value": 1069,
+          "params": {
+            "address": 1069,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1069",
+            "value": 1069
+          }
+        },
+        "1070": {
+          "value": 1070,
+          "params": {
+            "address": 1070,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1070",
+            "value": 1070
+          }
+        },
+        "1071": {
+          "value": 1071,
+          "params": {
+            "address": 1071,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1071",
+            "value": 1071
+          }
+        },
+        "1072": {
+          "value": 1072,
+          "params": {
+            "address": 1072,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1072",
+            "value": 1072
+          }
+        },
+        "1073": {
+          "value": 1073,
+          "params": {
+            "address": 1073,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1073",
+            "value": 1073
+          }
+        },
+        "1074": {
+          "value": 1074,
+          "params": {
+            "address": 1074,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1074",
+            "value": 1074
+          }
+        },
+        "1075": {
+          "value": 1075,
+          "params": {
+            "address": 1075,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1075",
+            "value": 1075
+          }
+        },
+        "1076": {
+          "value": 1076,
+          "params": {
+            "address": 1076,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1076",
+            "value": 1076
+          }
+        },
+        "1077": {
+          "value": 1077,
+          "params": {
+            "address": 1077,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1077",
+            "value": 1077
+          }
+        },
+        "1078": {
+          "value": 1078,
+          "params": {
+            "address": 1078,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1078",
+            "value": 1078
+          }
+        },
+        "1079": {
+          "value": 1079,
+          "params": {
+            "address": 1079,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1079",
+            "value": 1079
+          }
+        },
+        "1080": {
+          "value": 1080,
+          "params": {
+            "address": 1080,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1080",
+            "value": 1080
+          }
+        },
+        "1081": {
+          "value": 1081,
+          "params": {
+            "address": 1081,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1081",
+            "value": 1081
+          }
+        },
+        "1082": {
+          "value": 1082,
+          "params": {
+            "address": 1082,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1082",
+            "value": 1082
+          }
+        },
+        "1083": {
+          "value": 1083,
+          "params": {
+            "address": 1083,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1083",
+            "value": 1083
+          }
+        },
+        "1084": {
+          "value": 1084,
+          "params": {
+            "address": 1084,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1084",
+            "value": 1084
+          }
+        },
+        "1085": {
+          "value": 1085,
+          "params": {
+            "address": 1085,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1085",
+            "value": 1085
+          }
+        },
+        "1086": {
+          "value": 1086,
+          "params": {
+            "address": 1086,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1086",
+            "value": 1086
+          }
+        },
+        "1087": {
+          "value": 1087,
+          "params": {
+            "address": 1087,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1087",
+            "value": 1087
+          }
+        },
+        "1088": {
+          "value": 1088,
+          "params": {
+            "address": 1088,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1088",
+            "value": 1088
+          }
+        },
+        "1089": {
+          "value": 1089,
+          "params": {
+            "address": 1089,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1089",
+            "value": 1089
+          }
+        },
+        "1090": {
+          "value": 1090,
+          "params": {
+            "address": 1090,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1090",
+            "value": 1090
+          }
+        },
+        "1091": {
+          "value": 1091,
+          "params": {
+            "address": 1091,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1091",
+            "value": 1091
+          }
+        },
+        "1092": {
+          "value": 1092,
+          "params": {
+            "address": 1092,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1092",
+            "value": 1092
+          }
+        },
+        "1093": {
+          "value": 1093,
+          "params": {
+            "address": 1093,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1093",
+            "value": 1093
+          }
+        },
+        "1094": {
+          "value": 1094,
+          "params": {
+            "address": 1094,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1094",
+            "value": 1094
+          }
+        },
+        "1095": {
+          "value": 1095,
+          "params": {
+            "address": 1095,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1095",
+            "value": 1095
+          }
+        },
+        "1096": {
+          "value": 1096,
+          "params": {
+            "address": 1096,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1096",
+            "value": 1096
+          }
+        },
+        "1097": {
+          "value": 1097,
+          "params": {
+            "address": 1097,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1097",
+            "value": 1097
+          }
+        },
+        "1098": {
+          "value": 1098,
+          "params": {
+            "address": 1098,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1098",
+            "value": 1098
+          }
+        },
+        "1099": {
+          "value": 1099,
+          "params": {
+            "address": 1099,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1099",
+            "value": 1099
+          }
+        },
+        "1100": {
+          "value": 1100,
+          "params": {
+            "address": 1100,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1100",
+            "value": 1100
+          }
+        },
+        "1101": {
+          "value": 1101,
+          "params": {
+            "address": 1101,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1101",
+            "value": 1101
+          }
+        },
+        "1102": {
+          "value": 1102,
+          "params": {
+            "address": 1102,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1102",
+            "value": 1102
+          }
+        },
+        "1103": {
+          "value": 1103,
+          "params": {
+            "address": 1103,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1103",
+            "value": 1103
+          }
+        },
+        "1104": {
+          "value": 1104,
+          "params": {
+            "address": 1104,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1104",
+            "value": 1104
+          }
+        },
+        "1105": {
+          "value": 1105,
+          "params": {
+            "address": 1105,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1105",
+            "value": 1105
+          }
+        },
+        "1106": {
+          "value": 1106,
+          "params": {
+            "address": 1106,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1106",
+            "value": 1106
+          }
+        },
+        "1107": {
+          "value": 1107,
+          "params": {
+            "address": 1107,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1107",
+            "value": 1107
+          }
+        },
+        "1108": {
+          "value": 1108,
+          "params": {
+            "address": 1108,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1108",
+            "value": 1108
+          }
+        },
+        "1109": {
+          "value": 1109,
+          "params": {
+            "address": 1109,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1109",
+            "value": 1109
+          }
+        },
+        "1110": {
+          "value": 1110,
+          "params": {
+            "address": 1110,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1110",
+            "value": 1110
+          }
+        },
+        "1111": {
+          "value": 1111,
+          "params": {
+            "address": 1111,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1111",
+            "value": 1111
+          }
+        },
+        "1112": {
+          "value": 1112,
+          "params": {
+            "address": 1112,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1112",
+            "value": 1112
+          }
+        },
+        "1113": {
+          "value": 1113,
+          "params": {
+            "address": 1113,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1113",
+            "value": 1113
+          }
+        },
+        "1114": {
+          "value": 1114,
+          "params": {
+            "address": 1114,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1114",
+            "value": 1114
+          }
+        },
+        "1115": {
+          "value": 1115,
+          "params": {
+            "address": 1115,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1115",
+            "value": 1115
+          }
+        },
+        "1116": {
+          "value": 1116,
+          "params": {
+            "address": 1116,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1116",
+            "value": 1116
+          }
+        },
+        "1117": {
+          "value": 1117,
+          "params": {
+            "address": 1117,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1117",
+            "value": 1117
+          }
+        },
+        "1118": {
+          "value": 1118,
+          "params": {
+            "address": 1118,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1118",
+            "value": 1118
+          }
+        },
+        "1119": {
+          "value": 1119,
+          "params": {
+            "address": 1119,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1119",
+            "value": 1119
+          }
+        },
+        "1120": {
+          "value": 1120,
+          "params": {
+            "address": 1120,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1120",
+            "value": 1120
+          }
+        },
+        "1121": {
+          "value": 1121,
+          "params": {
+            "address": 1121,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1121",
+            "value": 1121
+          }
+        },
+        "1122": {
+          "value": 1122,
+          "params": {
+            "address": 1122,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1122",
+            "value": 1122
+          }
+        },
+        "1123": {
+          "value": 1123,
+          "params": {
+            "address": 1123,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1123",
+            "value": 1123
+          }
+        },
+        "1124": {
+          "value": 1124,
+          "params": {
+            "address": 1124,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1124",
+            "value": 1124
+          }
+        },
+        "1125": {
+          "value": 1125,
+          "params": {
+            "address": 1125,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1125",
+            "value": 1125
+          }
+        },
+        "1126": {
+          "value": 1126,
+          "params": {
+            "address": 1126,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1126",
+            "value": 1126
+          }
+        },
+        "1127": {
+          "value": 1127,
+          "params": {
+            "address": 1127,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1127",
+            "value": 1127
+          }
+        },
+        "1128": {
+          "value": 1128,
+          "params": {
+            "address": 1128,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1128",
+            "value": 1128
+          }
+        },
+        "1129": {
+          "value": 1129,
+          "params": {
+            "address": 1129,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1129",
+            "value": 1129
+          }
+        },
+        "1130": {
+          "value": 1130,
+          "params": {
+            "address": 1130,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1130",
+            "value": 1130
+          }
+        },
+        "1131": {
+          "value": 1131,
+          "params": {
+            "address": 1131,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1131",
+            "value": 1131
+          }
+        },
+        "1132": {
+          "value": 1132,
+          "params": {
+            "address": 1132,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1132",
+            "value": 1132
+          }
+        },
+        "1133": {
+          "value": 1133,
+          "params": {
+            "address": 1133,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1133",
+            "value": 1133
+          }
+        },
+        "1134": {
+          "value": 1134,
+          "params": {
+            "address": 1134,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1134",
+            "value": 1134
+          }
+        },
+        "1135": {
+          "value": 1135,
+          "params": {
+            "address": 1135,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1135",
+            "value": 1135
+          }
+        },
+        "1136": {
+          "value": 1136,
+          "params": {
+            "address": 1136,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1136",
+            "value": 1136
+          }
+        },
+        "1137": {
+          "value": 1137,
+          "params": {
+            "address": 1137,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1137",
+            "value": 1137
+          }
+        },
+        "1138": {
+          "value": 1138,
+          "params": {
+            "address": 1138,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1138",
+            "value": 1138
+          }
+        },
+        "1139": {
+          "value": 1139,
+          "params": {
+            "address": 1139,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1139",
+            "value": 1139
+          }
+        },
+        "1140": {
+          "value": 1140,
+          "params": {
+            "address": 1140,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1140",
+            "value": 1140
+          }
+        },
+        "1141": {
+          "value": 1141,
+          "params": {
+            "address": 1141,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1141",
+            "value": 1141
+          }
+        },
+        "1142": {
+          "value": 1142,
+          "params": {
+            "address": 1142,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1142",
+            "value": 1142
+          }
+        },
+        "1143": {
+          "value": 1143,
+          "params": {
+            "address": 1143,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1143",
+            "value": 1143
+          }
+        },
+        "1144": {
+          "value": 1144,
+          "params": {
+            "address": 1144,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1144",
+            "value": 1144
+          }
+        },
+        "1145": {
+          "value": 1145,
+          "params": {
+            "address": 1145,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1145",
+            "value": 1145
+          }
+        },
+        "1146": {
+          "value": 1146,
+          "params": {
+            "address": 1146,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1146",
+            "value": 1146
+          }
+        },
+        "1147": {
+          "value": 1147,
+          "params": {
+            "address": 1147,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1147",
+            "value": 1147
+          }
+        },
+        "1148": {
+          "value": 1148,
+          "params": {
+            "address": 1148,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1148",
+            "value": 1148
+          }
+        },
+        "1149": {
+          "value": 1149,
+          "params": {
+            "address": 1149,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1149",
+            "value": 1149
+          }
+        },
+        "1150": {
+          "value": 1150,
+          "params": {
+            "address": 1150,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1150",
+            "value": 1150
+          }
+        },
+        "1151": {
+          "value": 1151,
+          "params": {
+            "address": 1151,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1151",
+            "value": 1151
+          }
+        },
+        "1152": {
+          "value": 1152,
+          "params": {
+            "address": 1152,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1152",
+            "value": 1152
+          }
+        },
+        "1153": {
+          "value": 1153,
+          "params": {
+            "address": 1153,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1153",
+            "value": 1153
+          }
+        },
+        "1154": {
+          "value": 1154,
+          "params": {
+            "address": 1154,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1154",
+            "value": 1154
+          }
+        },
+        "1155": {
+          "value": 1155,
+          "params": {
+            "address": 1155,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1155",
+            "value": 1155
+          }
+        },
+        "1156": {
+          "value": 1156,
+          "params": {
+            "address": 1156,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1156",
+            "value": 1156
+          }
+        },
+        "1157": {
+          "value": 1157,
+          "params": {
+            "address": 1157,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1157",
+            "value": 1157
+          }
+        },
+        "1158": {
+          "value": 1158,
+          "params": {
+            "address": 1158,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1158",
+            "value": 1158
+          }
+        },
+        "1159": {
+          "value": 1159,
+          "params": {
+            "address": 1159,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1159",
+            "value": 1159
+          }
+        },
+        "1160": {
+          "value": 1160,
+          "params": {
+            "address": 1160,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1160",
+            "value": 1160
+          }
+        },
+        "1161": {
+          "value": 1161,
+          "params": {
+            "address": 1161,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1161",
+            "value": 1161
+          }
+        },
+        "1162": {
+          "value": 1162,
+          "params": {
+            "address": 1162,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1162",
+            "value": 1162
+          }
+        },
+        "1163": {
+          "value": 1163,
+          "params": {
+            "address": 1163,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1163",
+            "value": 1163
+          }
+        },
+        "1164": {
+          "value": 1164,
+          "params": {
+            "address": 1164,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1164",
+            "value": 1164
+          }
+        },
+        "1165": {
+          "value": 1165,
+          "params": {
+            "address": 1165,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1165",
+            "value": 1165
+          }
+        },
+        "1166": {
+          "value": 1166,
+          "params": {
+            "address": 1166,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1166",
+            "value": 1166
+          }
+        },
+        "1167": {
+          "value": 1167,
+          "params": {
+            "address": 1167,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1167",
+            "value": 1167
+          }
+        },
+        "1168": {
+          "value": 1168,
+          "params": {
+            "address": 1168,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1168",
+            "value": 1168
+          }
+        },
+        "1169": {
+          "value": 1169,
+          "params": {
+            "address": 1169,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1169",
+            "value": 1169
+          }
+        },
+        "1170": {
+          "value": 1170,
+          "params": {
+            "address": 1170,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1170",
+            "value": 1170
+          }
+        },
+        "1171": {
+          "value": 1171,
+          "params": {
+            "address": 1171,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1171",
+            "value": 1171
+          }
+        },
+        "1172": {
+          "value": 1172,
+          "params": {
+            "address": 1172,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1172",
+            "value": 1172
+          }
+        },
+        "1173": {
+          "value": 1173,
+          "params": {
+            "address": 1173,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1173",
+            "value": 1173
+          }
+        },
+        "1174": {
+          "value": 1174,
+          "params": {
+            "address": 1174,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1174",
+            "value": 1174
+          }
+        },
+        "1175": {
+          "value": 1175,
+          "params": {
+            "address": 1175,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1175",
+            "value": 1175
+          }
+        },
+        "1176": {
+          "value": 1176,
+          "params": {
+            "address": 1176,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1176",
+            "value": 1176
+          }
+        },
+        "1177": {
+          "value": 1177,
+          "params": {
+            "address": 1177,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1177",
+            "value": 1177
+          }
+        },
+        "1178": {
+          "value": 1178,
+          "params": {
+            "address": 1178,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1178",
+            "value": 1178
+          }
+        },
+        "1179": {
+          "value": 1179,
+          "params": {
+            "address": 1179,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1179",
+            "value": 1179
+          }
+        },
+        "1180": {
+          "value": 1180,
+          "params": {
+            "address": 1180,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1180",
+            "value": 1180
+          }
+        },
+        "1181": {
+          "value": 1181,
+          "params": {
+            "address": 1181,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1181",
+            "value": 1181
+          }
+        },
+        "1182": {
+          "value": 1182,
+          "params": {
+            "address": 1182,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1182",
+            "value": 1182
+          }
+        },
+        "1183": {
+          "value": 1183,
+          "params": {
+            "address": 1183,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1183",
+            "value": 1183
+          }
+        },
+        "1184": {
+          "value": 1184,
+          "params": {
+            "address": 1184,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1184",
+            "value": 1184
+          }
+        },
+        "1185": {
+          "value": 1185,
+          "params": {
+            "address": 1185,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1185",
+            "value": 1185
+          }
+        },
+        "1186": {
+          "value": 1186,
+          "params": {
+            "address": 1186,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1186",
+            "value": 1186
+          }
+        },
+        "1187": {
+          "value": 1187,
+          "params": {
+            "address": 1187,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1187",
+            "value": 1187
+          }
+        },
+        "1188": {
+          "value": 1188,
+          "params": {
+            "address": 1188,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1188",
+            "value": 1188
+          }
+        },
+        "1189": {
+          "value": 1189,
+          "params": {
+            "address": 1189,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1189",
+            "value": 1189
+          }
+        },
+        "1190": {
+          "value": 1190,
+          "params": {
+            "address": 1190,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1190",
+            "value": 1190
+          }
+        },
+        "1191": {
+          "value": 1191,
+          "params": {
+            "address": 1191,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1191",
+            "value": 1191
+          }
+        },
+        "1192": {
+          "value": 1192,
+          "params": {
+            "address": 1192,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1192",
+            "value": 1192
+          }
+        },
+        "1193": {
+          "value": 1193,
+          "params": {
+            "address": 1193,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1193",
+            "value": 1193
+          }
+        },
+        "1194": {
+          "value": 1194,
+          "params": {
+            "address": 1194,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1194",
+            "value": 1194
+          }
+        },
+        "1195": {
+          "value": 1195,
+          "params": {
+            "address": 1195,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1195",
+            "value": 1195
+          }
+        },
+        "1196": {
+          "value": 1196,
+          "params": {
+            "address": 1196,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1196",
+            "value": 1196
+          }
+        },
+        "1197": {
+          "value": 1197,
+          "params": {
+            "address": 1197,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1197",
+            "value": 1197
+          }
+        },
+        "1198": {
+          "value": 1198,
+          "params": {
+            "address": 1198,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1198",
+            "value": 1198
+          }
+        },
+        "1199": {
+          "value": 1199,
+          "params": {
+            "address": 1199,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1199",
+            "value": 1199
+          }
+        },
+        "1200": {
+          "value": 1200,
+          "params": {
+            "address": 1200,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1200",
+            "value": 1200
+          }
+        },
+        "1201": {
+          "value": 1201,
+          "params": {
+            "address": 1201,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1201",
+            "value": 1201
+          }
+        },
+        "1202": {
+          "value": 1202,
+          "params": {
+            "address": 1202,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1202",
+            "value": 1202
+          }
+        },
+        "1203": {
+          "value": 1203,
+          "params": {
+            "address": 1203,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1203",
+            "value": 1203
+          }
+        },
+        "1204": {
+          "value": 1204,
+          "params": {
+            "address": 1204,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1204",
+            "value": 1204
+          }
+        },
+        "1205": {
+          "value": 1205,
+          "params": {
+            "address": 1205,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1205",
+            "value": 1205
+          }
+        },
+        "1206": {
+          "value": 1206,
+          "params": {
+            "address": 1206,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1206",
+            "value": 1206
+          }
+        },
+        "1207": {
+          "value": 1207,
+          "params": {
+            "address": 1207,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1207",
+            "value": 1207
+          }
+        },
+        "1208": {
+          "value": 1208,
+          "params": {
+            "address": 1208,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1208",
+            "value": 1208
+          }
+        },
+        "1209": {
+          "value": 1209,
+          "params": {
+            "address": 1209,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1209",
+            "value": 1209
+          }
+        },
+        "1210": {
+          "value": 1210,
+          "params": {
+            "address": 1210,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1210",
+            "value": 1210
+          }
+        },
+        "1211": {
+          "value": 1211,
+          "params": {
+            "address": 1211,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1211",
+            "value": 1211
+          }
+        },
+        "1212": {
+          "value": 1212,
+          "params": {
+            "address": 1212,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1212",
+            "value": 1212
+          }
+        },
+        "1213": {
+          "value": 1213,
+          "params": {
+            "address": 1213,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1213",
+            "value": 1213
+          }
+        },
+        "1214": {
+          "value": 1214,
+          "params": {
+            "address": 1214,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1214",
+            "value": 1214
+          }
+        },
+        "1215": {
+          "value": 1215,
+          "params": {
+            "address": 1215,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1215",
+            "value": 1215
+          }
+        },
+        "1216": {
+          "value": 1216,
+          "params": {
+            "address": 1216,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1216",
+            "value": 1216
+          }
+        },
+        "1217": {
+          "value": 1217,
+          "params": {
+            "address": 1217,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1217",
+            "value": 1217
+          }
+        },
+        "1218": {
+          "value": 1218,
+          "params": {
+            "address": 1218,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1218",
+            "value": 1218
+          }
+        },
+        "1219": {
+          "value": 1219,
+          "params": {
+            "address": 1219,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1219",
+            "value": 1219
+          }
+        },
+        "1220": {
+          "value": 1220,
+          "params": {
+            "address": 1220,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1220",
+            "value": 1220
+          }
+        },
+        "1221": {
+          "value": 1221,
+          "params": {
+            "address": 1221,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1221",
+            "value": 1221
+          }
+        },
+        "1222": {
+          "value": 1222,
+          "params": {
+            "address": 1222,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1222",
+            "value": 1222
+          }
+        },
+        "1223": {
+          "value": 1223,
+          "params": {
+            "address": 1223,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1223",
+            "value": 1223
+          }
+        },
+        "1224": {
+          "value": 1224,
+          "params": {
+            "address": 1224,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1224",
+            "value": 1224
+          }
+        },
+        "1225": {
+          "value": 1225,
+          "params": {
+            "address": 1225,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1225",
+            "value": 1225
+          }
+        },
+        "1226": {
+          "value": 1226,
+          "params": {
+            "address": 1226,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1226",
+            "value": 1226
+          }
+        },
+        "1227": {
+          "value": 1227,
+          "params": {
+            "address": 1227,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1227",
+            "value": 1227
+          }
+        },
+        "1228": {
+          "value": 1228,
+          "params": {
+            "address": 1228,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1228",
+            "value": 1228
+          }
+        },
+        "1229": {
+          "value": 1229,
+          "params": {
+            "address": 1229,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1229",
+            "value": 1229
+          }
+        },
+        "1230": {
+          "value": 1230,
+          "params": {
+            "address": 1230,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1230",
+            "value": 1230
+          }
+        },
+        "1231": {
+          "value": 1231,
+          "params": {
+            "address": 1231,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1231",
+            "value": 1231
+          }
+        },
+        "1232": {
+          "value": 1232,
+          "params": {
+            "address": 1232,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1232",
+            "value": 1232
+          }
+        },
+        "1233": {
+          "value": 1233,
+          "params": {
+            "address": 1233,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1233",
+            "value": 1233
+          }
+        },
+        "1234": {
+          "value": 1234,
+          "params": {
+            "address": 1234,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1234",
+            "value": 1234
+          }
+        },
+        "1235": {
+          "value": 1235,
+          "params": {
+            "address": 1235,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1235",
+            "value": 1235
+          }
+        },
+        "1236": {
+          "value": 1236,
+          "params": {
+            "address": 1236,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1236",
+            "value": 1236
+          }
+        },
+        "1237": {
+          "value": 1237,
+          "params": {
+            "address": 1237,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1237",
+            "value": 1237
+          }
+        },
+        "1238": {
+          "value": 1238,
+          "params": {
+            "address": 1238,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1238",
+            "value": 1238
+          }
+        },
+        "1239": {
+          "value": 1239,
+          "params": {
+            "address": 1239,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1239",
+            "value": 1239
+          }
+        },
+        "1240": {
+          "value": 1240,
+          "params": {
+            "address": 1240,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1240",
+            "value": 1240
+          }
+        },
+        "1241": {
+          "value": 1241,
+          "params": {
+            "address": 1241,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1241",
+            "value": 1241
+          }
+        },
+        "1242": {
+          "value": 1242,
+          "params": {
+            "address": 1242,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1242",
+            "value": 1242
+          }
+        },
+        "1243": {
+          "value": 1243,
+          "params": {
+            "address": 1243,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1243",
+            "value": 1243
+          }
+        },
+        "1244": {
+          "value": 1244,
+          "params": {
+            "address": 1244,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1244",
+            "value": 1244
+          }
+        },
+        "1245": {
+          "value": 1245,
+          "params": {
+            "address": 1245,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1245",
+            "value": 1245
+          }
+        },
+        "1246": {
+          "value": 1246,
+          "params": {
+            "address": 1246,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1246",
+            "value": 1246
+          }
+        },
+        "1247": {
+          "value": 1247,
+          "params": {
+            "address": 1247,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1247",
+            "value": 1247
+          }
+        },
+        "1248": {
+          "value": 1248,
+          "params": {
+            "address": 1248,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1248",
+            "value": 1248
+          }
+        },
+        "1249": {
+          "value": 1249,
+          "params": {
+            "address": 1249,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1249",
+            "value": 1249
+          }
+        },
+        "1250": {
+          "value": 1250,
+          "params": {
+            "address": 1250,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1250",
+            "value": 1250
+          }
+        },
+        "1251": {
+          "value": 1251,
+          "params": {
+            "address": 1251,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1251",
+            "value": 1251
+          }
+        },
+        "1252": {
+          "value": 1252,
+          "params": {
+            "address": 1252,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1252",
+            "value": 1252
+          }
+        },
+        "1253": {
+          "value": 1253,
+          "params": {
+            "address": 1253,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1253",
+            "value": 1253
+          }
+        },
+        "1254": {
+          "value": 1254,
+          "params": {
+            "address": 1254,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1254",
+            "value": 1254
+          }
+        },
+        "1255": {
+          "value": 1255,
+          "params": {
+            "address": 1255,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1255",
+            "value": 1255
+          }
+        },
+        "1256": {
+          "value": 1256,
+          "params": {
+            "address": 1256,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1256",
+            "value": 1256
+          }
+        },
+        "1257": {
+          "value": 1257,
+          "params": {
+            "address": 1257,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1257",
+            "value": 1257
+          }
+        },
+        "1258": {
+          "value": 1258,
+          "params": {
+            "address": 1258,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1258",
+            "value": 1258
+          }
+        },
+        "1259": {
+          "value": 1259,
+          "params": {
+            "address": 1259,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1259",
+            "value": 1259
+          }
+        },
+        "1260": {
+          "value": 1260,
+          "params": {
+            "address": 1260,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1260",
+            "value": 1260
+          }
+        },
+        "1261": {
+          "value": 1261,
+          "params": {
+            "address": 1261,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1261",
+            "value": 1261
+          }
+        },
+        "1262": {
+          "value": 1262,
+          "params": {
+            "address": 1262,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1262",
+            "value": 1262
+          }
+        },
+        "1263": {
+          "value": 1263,
+          "params": {
+            "address": 1263,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1263",
+            "value": 1263
+          }
+        },
+        "1264": {
+          "value": 1264,
+          "params": {
+            "address": 1264,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1264",
+            "value": 1264
+          }
+        },
+        "1265": {
+          "value": 1265,
+          "params": {
+            "address": 1265,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1265",
+            "value": 1265
+          }
+        },
+        "1266": {
+          "value": 1266,
+          "params": {
+            "address": 1266,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1266",
+            "value": 1266
+          }
+        },
+        "1267": {
+          "value": 1267,
+          "params": {
+            "address": 1267,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1267",
+            "value": 1267
+          }
+        },
+        "1268": {
+          "value": 1268,
+          "params": {
+            "address": 1268,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1268",
+            "value": 1268
+          }
+        },
+        "1269": {
+          "value": 1269,
+          "params": {
+            "address": 1269,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1269",
+            "value": 1269
+          }
+        },
+        "1270": {
+          "value": 1270,
+          "params": {
+            "address": 1270,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1270",
+            "value": 1270
+          }
+        },
+        "1271": {
+          "value": 1271,
+          "params": {
+            "address": 1271,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1271",
+            "value": 1271
+          }
+        },
+        "1272": {
+          "value": 1272,
+          "params": {
+            "address": 1272,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1272",
+            "value": 1272
+          }
+        },
+        "1273": {
+          "value": 1273,
+          "params": {
+            "address": 1273,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1273",
+            "value": 1273
+          }
+        },
+        "1274": {
+          "value": 1274,
+          "params": {
+            "address": 1274,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1274",
+            "value": 1274
+          }
+        },
+        "1275": {
+          "value": 1275,
+          "params": {
+            "address": 1275,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1275",
+            "value": 1275
+          }
+        },
+        "1276": {
+          "value": 1276,
+          "params": {
+            "address": 1276,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1276",
+            "value": 1276
+          }
+        },
+        "1277": {
+          "value": 1277,
+          "params": {
+            "address": 1277,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1277",
+            "value": 1277
+          }
+        },
+        "1278": {
+          "value": 1278,
+          "params": {
+            "address": 1278,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1278",
+            "value": 1278
+          }
+        },
+        "1279": {
+          "value": 1279,
+          "params": {
+            "address": 1279,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1279",
+            "value": 1279
+          }
+        },
+        "1280": {
+          "value": 1280,
+          "params": {
+            "address": 1280,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1280",
+            "value": 1280
+          }
+        },
+        "1281": {
+          "value": 1281,
+          "params": {
+            "address": 1281,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1281",
+            "value": 1281
+          }
+        },
+        "1282": {
+          "value": 1282,
+          "params": {
+            "address": 1282,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1282",
+            "value": 1282
+          }
+        },
+        "1283": {
+          "value": 1283,
+          "params": {
+            "address": 1283,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1283",
+            "value": 1283
+          }
+        },
+        "1284": {
+          "value": 1284,
+          "params": {
+            "address": 1284,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1284",
+            "value": 1284
+          }
+        },
+        "1285": {
+          "value": 1285,
+          "params": {
+            "address": 1285,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1285",
+            "value": 1285
+          }
+        },
+        "1286": {
+          "value": 1286,
+          "params": {
+            "address": 1286,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1286",
+            "value": 1286
+          }
+        },
+        "1287": {
+          "value": 1287,
+          "params": {
+            "address": 1287,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1287",
+            "value": 1287
+          }
+        },
+        "1288": {
+          "value": 1288,
+          "params": {
+            "address": 1288,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1288",
+            "value": 1288
+          }
+        },
+        "1289": {
+          "value": 1289,
+          "params": {
+            "address": 1289,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1289",
+            "value": 1289
+          }
+        },
+        "1290": {
+          "value": 1290,
+          "params": {
+            "address": 1290,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1290",
+            "value": 1290
+          }
+        },
+        "1291": {
+          "value": 1291,
+          "params": {
+            "address": 1291,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1291",
+            "value": 1291
+          }
+        },
+        "1292": {
+          "value": 1292,
+          "params": {
+            "address": 1292,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1292",
+            "value": 1292
+          }
+        },
+        "1293": {
+          "value": 1293,
+          "params": {
+            "address": 1293,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1293",
+            "value": 1293
+          }
+        },
+        "1294": {
+          "value": 1294,
+          "params": {
+            "address": 1294,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1294",
+            "value": 1294
+          }
+        },
+        "1295": {
+          "value": 1295,
+          "params": {
+            "address": 1295,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1295",
+            "value": 1295
+          }
+        },
+        "1296": {
+          "value": 1296,
+          "params": {
+            "address": 1296,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1296",
+            "value": 1296
+          }
+        },
+        "1297": {
+          "value": 1297,
+          "params": {
+            "address": 1297,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1297",
+            "value": 1297
+          }
+        },
+        "1298": {
+          "value": 1298,
+          "params": {
+            "address": 1298,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1298",
+            "value": 1298
+          }
+        },
+        "1299": {
+          "value": 1299,
+          "params": {
+            "address": 1299,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1299",
+            "value": 1299
+          }
+        },
+        "1300": {
+          "value": 1300,
+          "params": {
+            "address": 1300,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1300",
+            "value": 1300
+          }
+        },
+        "1301": {
+          "value": 1301,
+          "params": {
+            "address": 1301,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1301",
+            "value": 1301
+          }
+        },
+        "1302": {
+          "value": 1302,
+          "params": {
+            "address": 1302,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1302",
+            "value": 1302
+          }
+        },
+        "1303": {
+          "value": 1303,
+          "params": {
+            "address": 1303,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1303",
+            "value": 1303
+          }
+        },
+        "1304": {
+          "value": 1304,
+          "params": {
+            "address": 1304,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1304",
+            "value": 1304
+          }
+        },
+        "1305": {
+          "value": 1305,
+          "params": {
+            "address": 1305,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1305",
+            "value": 1305
+          }
+        },
+        "1306": {
+          "value": 1306,
+          "params": {
+            "address": 1306,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1306",
+            "value": 1306
+          }
+        },
+        "1307": {
+          "value": 1307,
+          "params": {
+            "address": 1307,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1307",
+            "value": 1307
+          }
+        },
+        "1308": {
+          "value": 1308,
+          "params": {
+            "address": 1308,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1308",
+            "value": 1308
+          }
+        },
+        "1309": {
+          "value": 1309,
+          "params": {
+            "address": 1309,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1309",
+            "value": 1309
+          }
+        },
+        "1310": {
+          "value": 1310,
+          "params": {
+            "address": 1310,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1310",
+            "value": 1310
+          }
+        },
+        "1311": {
+          "value": 1311,
+          "params": {
+            "address": 1311,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1311",
+            "value": 1311
+          }
+        },
+        "1312": {
+          "value": 1312,
+          "params": {
+            "address": 1312,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1312",
+            "value": 1312
+          }
+        },
+        "1313": {
+          "value": 1313,
+          "params": {
+            "address": 1313,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1313",
+            "value": 1313
+          }
+        },
+        "1314": {
+          "value": 1314,
+          "params": {
+            "address": 1314,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1314",
+            "value": 1314
+          }
+        },
+        "1315": {
+          "value": 1315,
+          "params": {
+            "address": 1315,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1315",
+            "value": 1315
+          }
+        },
+        "1316": {
+          "value": 1316,
+          "params": {
+            "address": 1316,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1316",
+            "value": 1316
+          }
+        },
+        "1317": {
+          "value": 1317,
+          "params": {
+            "address": 1317,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1317",
+            "value": 1317
+          }
+        },
+        "1318": {
+          "value": 1318,
+          "params": {
+            "address": 1318,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1318",
+            "value": 1318
+          }
+        },
+        "1319": {
+          "value": 1319,
+          "params": {
+            "address": 1319,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1319",
+            "value": 1319
+          }
+        },
+        "1320": {
+          "value": 1320,
+          "params": {
+            "address": 1320,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1320",
+            "value": 1320
+          }
+        },
+        "1321": {
+          "value": 1321,
+          "params": {
+            "address": 1321,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1321",
+            "value": 1321
+          }
+        },
+        "1322": {
+          "value": 1322,
+          "params": {
+            "address": 1322,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1322",
+            "value": 1322
+          }
+        },
+        "1323": {
+          "value": 1323,
+          "params": {
+            "address": 1323,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1323",
+            "value": 1323
+          }
+        },
+        "1324": {
+          "value": 1324,
+          "params": {
+            "address": 1324,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1324",
+            "value": 1324
+          }
+        },
+        "1325": {
+          "value": 1325,
+          "params": {
+            "address": 1325,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1325",
+            "value": 1325
+          }
+        },
+        "1326": {
+          "value": 1326,
+          "params": {
+            "address": 1326,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1326",
+            "value": 1326
+          }
+        },
+        "1327": {
+          "value": 1327,
+          "params": {
+            "address": 1327,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1327",
+            "value": 1327
+          }
+        },
+        "1328": {
+          "value": 1328,
+          "params": {
+            "address": 1328,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1328",
+            "value": 1328
+          }
+        },
+        "1329": {
+          "value": 1329,
+          "params": {
+            "address": 1329,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1329",
+            "value": 1329
+          }
+        },
+        "1330": {
+          "value": 1330,
+          "params": {
+            "address": 1330,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1330",
+            "value": 1330
+          }
+        },
+        "1331": {
+          "value": 1331,
+          "params": {
+            "address": 1331,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1331",
+            "value": 1331
+          }
+        },
+        "1332": {
+          "value": 1332,
+          "params": {
+            "address": 1332,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1332",
+            "value": 1332
+          }
+        },
+        "1333": {
+          "value": 1333,
+          "params": {
+            "address": 1333,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1333",
+            "value": 1333
+          }
+        },
+        "1334": {
+          "value": 1334,
+          "params": {
+            "address": 1334,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1334",
+            "value": 1334
+          }
+        },
+        "1335": {
+          "value": 1335,
+          "params": {
+            "address": 1335,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1335",
+            "value": 1335
+          }
+        },
+        "1336": {
+          "value": 1336,
+          "params": {
+            "address": 1336,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1336",
+            "value": 1336
+          }
+        },
+        "1337": {
+          "value": 1337,
+          "params": {
+            "address": 1337,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1337",
+            "value": 1337
+          }
+        },
+        "1338": {
+          "value": 1338,
+          "params": {
+            "address": 1338,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1338",
+            "value": 1338
+          }
+        },
+        "1339": {
+          "value": 1339,
+          "params": {
+            "address": 1339,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1339",
+            "value": 1339
+          }
+        },
+        "1340": {
+          "value": 1340,
+          "params": {
+            "address": 1340,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1340",
+            "value": 1340
+          }
+        },
+        "1341": {
+          "value": 1341,
+          "params": {
+            "address": 1341,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1341",
+            "value": 1341
+          }
+        },
+        "1342": {
+          "value": 1342,
+          "params": {
+            "address": 1342,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1342",
+            "value": 1342
+          }
+        },
+        "1343": {
+          "value": 1343,
+          "params": {
+            "address": 1343,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1343",
+            "value": 1343
+          }
+        },
+        "1344": {
+          "value": 1344,
+          "params": {
+            "address": 1344,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1344",
+            "value": 1344
+          }
+        },
+        "1345": {
+          "value": 1345,
+          "params": {
+            "address": 1345,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1345",
+            "value": 1345
+          }
+        },
+        "1346": {
+          "value": 1346,
+          "params": {
+            "address": 1346,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1346",
+            "value": 1346
+          }
+        },
+        "1347": {
+          "value": 1347,
+          "params": {
+            "address": 1347,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1347",
+            "value": 1347
+          }
+        },
+        "1348": {
+          "value": 1348,
+          "params": {
+            "address": 1348,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1348",
+            "value": 1348
+          }
+        },
+        "1349": {
+          "value": 1349,
+          "params": {
+            "address": 1349,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1349",
+            "value": 1349
+          }
+        },
+        "1350": {
+          "value": 1350,
+          "params": {
+            "address": 1350,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1350",
+            "value": 1350
+          }
+        },
+        "1351": {
+          "value": 1351,
+          "params": {
+            "address": 1351,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1351",
+            "value": 1351
+          }
+        },
+        "1352": {
+          "value": 1352,
+          "params": {
+            "address": 1352,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1352",
+            "value": 1352
+          }
+        },
+        "1353": {
+          "value": 1353,
+          "params": {
+            "address": 1353,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1353",
+            "value": 1353
+          }
+        },
+        "1354": {
+          "value": 1354,
+          "params": {
+            "address": 1354,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1354",
+            "value": 1354
+          }
+        },
+        "1355": {
+          "value": 1355,
+          "params": {
+            "address": 1355,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1355",
+            "value": 1355
+          }
+        },
+        "1356": {
+          "value": 1356,
+          "params": {
+            "address": 1356,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1356",
+            "value": 1356
+          }
+        },
+        "1357": {
+          "value": 1357,
+          "params": {
+            "address": 1357,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1357",
+            "value": 1357
+          }
+        },
+        "1358": {
+          "value": 1358,
+          "params": {
+            "address": 1358,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1358",
+            "value": 1358
+          }
+        },
+        "1359": {
+          "value": 1359,
+          "params": {
+            "address": 1359,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1359",
+            "value": 1359
+          }
+        },
+        "1360": {
+          "value": 1360,
+          "params": {
+            "address": 1360,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1360",
+            "value": 1360
+          }
+        },
+        "1361": {
+          "value": 1361,
+          "params": {
+            "address": 1361,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1361",
+            "value": 1361
+          }
+        },
+        "1362": {
+          "value": 1362,
+          "params": {
+            "address": 1362,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1362",
+            "value": 1362
+          }
+        },
+        "1363": {
+          "value": 1363,
+          "params": {
+            "address": 1363,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1363",
+            "value": 1363
+          }
+        },
+        "1364": {
+          "value": 1364,
+          "params": {
+            "address": 1364,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1364",
+            "value": 1364
+          }
+        },
+        "1365": {
+          "value": 1365,
+          "params": {
+            "address": 1365,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1365",
+            "value": 1365
+          }
+        },
+        "1366": {
+          "value": 1366,
+          "params": {
+            "address": 1366,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1366",
+            "value": 1366
+          }
+        },
+        "1367": {
+          "value": 1367,
+          "params": {
+            "address": 1367,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1367",
+            "value": 1367
+          }
+        },
+        "1368": {
+          "value": 1368,
+          "params": {
+            "address": 1368,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1368",
+            "value": 1368
+          }
+        },
+        "1369": {
+          "value": 1369,
+          "params": {
+            "address": 1369,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1369",
+            "value": 1369
+          }
+        },
+        "1370": {
+          "value": 1370,
+          "params": {
+            "address": 1370,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1370",
+            "value": 1370
+          }
+        },
+        "1371": {
+          "value": 1371,
+          "params": {
+            "address": 1371,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1371",
+            "value": 1371
+          }
+        },
+        "1372": {
+          "value": 1372,
+          "params": {
+            "address": 1372,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1372",
+            "value": 1372
+          }
+        },
+        "1373": {
+          "value": 1373,
+          "params": {
+            "address": 1373,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1373",
+            "value": 1373
+          }
+        },
+        "1374": {
+          "value": 1374,
+          "params": {
+            "address": 1374,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1374",
+            "value": 1374
+          }
+        },
+        "1375": {
+          "value": 1375,
+          "params": {
+            "address": 1375,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1375",
+            "value": 1375
+          }
+        },
+        "1376": {
+          "value": 1376,
+          "params": {
+            "address": 1376,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1376",
+            "value": 1376
+          }
+        },
+        "1377": {
+          "value": 1377,
+          "params": {
+            "address": 1377,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1377",
+            "value": 1377
+          }
+        },
+        "1378": {
+          "value": 1378,
+          "params": {
+            "address": 1378,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1378",
+            "value": 1378
+          }
+        },
+        "1379": {
+          "value": 1379,
+          "params": {
+            "address": 1379,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1379",
+            "value": 1379
+          }
+        },
+        "1380": {
+          "value": 1380,
+          "params": {
+            "address": 1380,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1380",
+            "value": 1380
+          }
+        },
+        "1381": {
+          "value": 1381,
+          "params": {
+            "address": 1381,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1381",
+            "value": 1381
+          }
+        },
+        "1382": {
+          "value": 1382,
+          "params": {
+            "address": 1382,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1382",
+            "value": 1382
+          }
+        },
+        "1383": {
+          "value": 1383,
+          "params": {
+            "address": 1383,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1383",
+            "value": 1383
+          }
+        },
+        "1384": {
+          "value": 1384,
+          "params": {
+            "address": 1384,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1384",
+            "value": 1384
+          }
+        },
+        "1385": {
+          "value": 1385,
+          "params": {
+            "address": 1385,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1385",
+            "value": 1385
+          }
+        },
+        "1386": {
+          "value": 1386,
+          "params": {
+            "address": 1386,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1386",
+            "value": 1386
+          }
+        },
+        "1387": {
+          "value": 1387,
+          "params": {
+            "address": 1387,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1387",
+            "value": 1387
+          }
+        },
+        "1388": {
+          "value": 1388,
+          "params": {
+            "address": 1388,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1388",
+            "value": 1388
+          }
+        },
+        "1389": {
+          "value": 1389,
+          "params": {
+            "address": 1389,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1389",
+            "value": 1389
+          }
+        },
+        "1390": {
+          "value": 1390,
+          "params": {
+            "address": 1390,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1390",
+            "value": 1390
+          }
+        },
+        "1391": {
+          "value": 1391,
+          "params": {
+            "address": 1391,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1391",
+            "value": 1391
+          }
+        },
+        "1392": {
+          "value": 1392,
+          "params": {
+            "address": 1392,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1392",
+            "value": 1392
+          }
+        },
+        "1393": {
+          "value": 1393,
+          "params": {
+            "address": 1393,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1393",
+            "value": 1393
+          }
+        },
+        "1394": {
+          "value": 1394,
+          "params": {
+            "address": 1394,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1394",
+            "value": 1394
+          }
+        },
+        "1395": {
+          "value": 1395,
+          "params": {
+            "address": 1395,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1395",
+            "value": 1395
+          }
+        },
+        "1396": {
+          "value": 1396,
+          "params": {
+            "address": 1396,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1396",
+            "value": 1396
+          }
+        },
+        "1397": {
+          "value": 1397,
+          "params": {
+            "address": 1397,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1397",
+            "value": 1397
+          }
+        },
+        "1398": {
+          "value": 1398,
+          "params": {
+            "address": 1398,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1398",
+            "value": 1398
+          }
+        },
+        "1399": {
+          "value": 1399,
+          "params": {
+            "address": 1399,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1399",
+            "value": 1399
+          }
+        },
+        "1400": {
+          "value": 1400,
+          "params": {
+            "address": 1400,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1400",
+            "value": 1400
+          }
+        },
+        "1401": {
+          "value": 1401,
+          "params": {
+            "address": 1401,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1401",
+            "value": 1401
+          }
+        },
+        "1402": {
+          "value": 1402,
+          "params": {
+            "address": 1402,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1402",
+            "value": 1402
+          }
+        },
+        "1403": {
+          "value": 1403,
+          "params": {
+            "address": 1403,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1403",
+            "value": 1403
+          }
+        },
+        "1404": {
+          "value": 1404,
+          "params": {
+            "address": 1404,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1404",
+            "value": 1404
+          }
+        },
+        "1405": {
+          "value": 1405,
+          "params": {
+            "address": 1405,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1405",
+            "value": 1405
+          }
+        },
+        "1406": {
+          "value": 1406,
+          "params": {
+            "address": 1406,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1406",
+            "value": 1406
+          }
+        },
+        "1407": {
+          "value": 1407,
+          "params": {
+            "address": 1407,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1407",
+            "value": 1407
+          }
+        },
+        "1408": {
+          "value": 1408,
+          "params": {
+            "address": 1408,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1408",
+            "value": 1408
+          }
+        },
+        "1409": {
+          "value": 1409,
+          "params": {
+            "address": 1409,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1409",
+            "value": 1409
+          }
+        },
+        "1410": {
+          "value": 1410,
+          "params": {
+            "address": 1410,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1410",
+            "value": 1410
+          }
+        },
+        "1411": {
+          "value": 1411,
+          "params": {
+            "address": 1411,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1411",
+            "value": 1411
+          }
+        },
+        "1412": {
+          "value": 1412,
+          "params": {
+            "address": 1412,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1412",
+            "value": 1412
+          }
+        },
+        "1413": {
+          "value": 1413,
+          "params": {
+            "address": 1413,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1413",
+            "value": 1413
+          }
+        },
+        "1414": {
+          "value": 1414,
+          "params": {
+            "address": 1414,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1414",
+            "value": 1414
+          }
+        },
+        "1415": {
+          "value": 1415,
+          "params": {
+            "address": 1415,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1415",
+            "value": 1415
+          }
+        },
+        "1416": {
+          "value": 1416,
+          "params": {
+            "address": 1416,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1416",
+            "value": 1416
+          }
+        },
+        "1417": {
+          "value": 1417,
+          "params": {
+            "address": 1417,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1417",
+            "value": 1417
+          }
+        },
+        "1418": {
+          "value": 1418,
+          "params": {
+            "address": 1418,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1418",
+            "value": 1418
+          }
+        },
+        "1419": {
+          "value": 1419,
+          "params": {
+            "address": 1419,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1419",
+            "value": 1419
+          }
+        },
+        "1420": {
+          "value": 1420,
+          "params": {
+            "address": 1420,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1420",
+            "value": 1420
+          }
+        },
+        "1421": {
+          "value": 1421,
+          "params": {
+            "address": 1421,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1421",
+            "value": 1421
+          }
+        },
+        "1422": {
+          "value": 1422,
+          "params": {
+            "address": 1422,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1422",
+            "value": 1422
+          }
+        },
+        "1423": {
+          "value": 1423,
+          "params": {
+            "address": 1423,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1423",
+            "value": 1423
+          }
+        },
+        "1424": {
+          "value": 1424,
+          "params": {
+            "address": 1424,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1424",
+            "value": 1424
+          }
+        },
+        "1425": {
+          "value": 1425,
+          "params": {
+            "address": 1425,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1425",
+            "value": 1425
+          }
+        },
+        "1426": {
+          "value": 1426,
+          "params": {
+            "address": 1426,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1426",
+            "value": 1426
+          }
+        },
+        "1427": {
+          "value": 1427,
+          "params": {
+            "address": 1427,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1427",
+            "value": 1427
+          }
+        },
+        "1428": {
+          "value": 1428,
+          "params": {
+            "address": 1428,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1428",
+            "value": 1428
+          }
+        },
+        "1429": {
+          "value": 1429,
+          "params": {
+            "address": 1429,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1429",
+            "value": 1429
+          }
+        },
+        "1430": {
+          "value": 1430,
+          "params": {
+            "address": 1430,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1430",
+            "value": 1430
+          }
+        },
+        "1431": {
+          "value": 1431,
+          "params": {
+            "address": 1431,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1431",
+            "value": 1431
+          }
+        },
+        "1432": {
+          "value": 1432,
+          "params": {
+            "address": 1432,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1432",
+            "value": 1432
+          }
+        },
+        "1433": {
+          "value": 1433,
+          "params": {
+            "address": 1433,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1433",
+            "value": 1433
+          }
+        },
+        "1434": {
+          "value": 1434,
+          "params": {
+            "address": 1434,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1434",
+            "value": 1434
+          }
+        },
+        "1435": {
+          "value": 1435,
+          "params": {
+            "address": 1435,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1435",
+            "value": 1435
+          }
+        },
+        "1436": {
+          "value": 1436,
+          "params": {
+            "address": 1436,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1436",
+            "value": 1436
+          }
+        },
+        "1437": {
+          "value": 1437,
+          "params": {
+            "address": 1437,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1437",
+            "value": 1437
+          }
+        },
+        "1438": {
+          "value": 1438,
+          "params": {
+            "address": 1438,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1438",
+            "value": 1438
+          }
+        },
+        "1439": {
+          "value": 1439,
+          "params": {
+            "address": 1439,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1439",
+            "value": 1439
+          }
+        },
+        "1440": {
+          "value": 1440,
+          "params": {
+            "address": 1440,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1440",
+            "value": 1440
+          }
+        },
+        "1441": {
+          "value": 1441,
+          "params": {
+            "address": 1441,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1441",
+            "value": 1441
+          }
+        },
+        "1442": {
+          "value": 1442,
+          "params": {
+            "address": 1442,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1442",
+            "value": 1442
+          }
+        },
+        "1443": {
+          "value": 1443,
+          "params": {
+            "address": 1443,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1443",
+            "value": 1443
+          }
+        },
+        "1444": {
+          "value": 1444,
+          "params": {
+            "address": 1444,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1444",
+            "value": 1444
+          }
+        },
+        "1445": {
+          "value": 1445,
+          "params": {
+            "address": 1445,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1445",
+            "value": 1445
+          }
+        },
+        "1446": {
+          "value": 1446,
+          "params": {
+            "address": 1446,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1446",
+            "value": 1446
+          }
+        },
+        "1447": {
+          "value": 1447,
+          "params": {
+            "address": 1447,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1447",
+            "value": 1447
+          }
+        },
+        "1448": {
+          "value": 1448,
+          "params": {
+            "address": 1448,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1448",
+            "value": 1448
+          }
+        },
+        "1449": {
+          "value": 1449,
+          "params": {
+            "address": 1449,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1449",
+            "value": 1449
+          }
+        },
+        "1450": {
+          "value": 1450,
+          "params": {
+            "address": 1450,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1450",
+            "value": 1450
+          }
+        },
+        "1451": {
+          "value": 1451,
+          "params": {
+            "address": 1451,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1451",
+            "value": 1451
+          }
+        },
+        "1452": {
+          "value": 1452,
+          "params": {
+            "address": 1452,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1452",
+            "value": 1452
+          }
+        },
+        "1453": {
+          "value": 1453,
+          "params": {
+            "address": 1453,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1453",
+            "value": 1453
+          }
+        },
+        "1454": {
+          "value": 1454,
+          "params": {
+            "address": 1454,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1454",
+            "value": 1454
+          }
+        },
+        "1455": {
+          "value": 1455,
+          "params": {
+            "address": 1455,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1455",
+            "value": 1455
+          }
+        },
+        "1456": {
+          "value": 1456,
+          "params": {
+            "address": 1456,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1456",
+            "value": 1456
+          }
+        },
+        "1457": {
+          "value": 1457,
+          "params": {
+            "address": 1457,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1457",
+            "value": 1457
+          }
+        },
+        "1458": {
+          "value": 1458,
+          "params": {
+            "address": 1458,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1458",
+            "value": 1458
+          }
+        },
+        "1459": {
+          "value": 1459,
+          "params": {
+            "address": 1459,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1459",
+            "value": 1459
+          }
+        },
+        "1460": {
+          "value": 1460,
+          "params": {
+            "address": 1460,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1460",
+            "value": 1460
+          }
+        },
+        "1461": {
+          "value": 1461,
+          "params": {
+            "address": 1461,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1461",
+            "value": 1461
+          }
+        },
+        "1462": {
+          "value": 1462,
+          "params": {
+            "address": 1462,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1462",
+            "value": 1462
+          }
+        },
+        "1463": {
+          "value": 1463,
+          "params": {
+            "address": 1463,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1463",
+            "value": 1463
+          }
+        },
+        "1464": {
+          "value": 1464,
+          "params": {
+            "address": 1464,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1464",
+            "value": 1464
+          }
+        },
+        "1465": {
+          "value": 1465,
+          "params": {
+            "address": 1465,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1465",
+            "value": 1465
+          }
+        },
+        "1466": {
+          "value": 1466,
+          "params": {
+            "address": 1466,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1466",
+            "value": 1466
+          }
+        },
+        "1467": {
+          "value": 1467,
+          "params": {
+            "address": 1467,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1467",
+            "value": 1467
+          }
+        },
+        "1468": {
+          "value": 1468,
+          "params": {
+            "address": 1468,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1468",
+            "value": 1468
+          }
+        },
+        "1469": {
+          "value": 1469,
+          "params": {
+            "address": 1469,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1469",
+            "value": 1469
+          }
+        },
+        "1470": {
+          "value": 1470,
+          "params": {
+            "address": 1470,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1470",
+            "value": 1470
+          }
+        },
+        "1471": {
+          "value": 1471,
+          "params": {
+            "address": 1471,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1471",
+            "value": 1471
+          }
+        },
+        "1472": {
+          "value": 1472,
+          "params": {
+            "address": 1472,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1472",
+            "value": 1472
+          }
+        },
+        "1473": {
+          "value": 1473,
+          "params": {
+            "address": 1473,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1473",
+            "value": 1473
+          }
+        },
+        "1474": {
+          "value": 1474,
+          "params": {
+            "address": 1474,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1474",
+            "value": 1474
+          }
+        },
+        "1475": {
+          "value": 1475,
+          "params": {
+            "address": 1475,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1475",
+            "value": 1475
+          }
+        },
+        "1476": {
+          "value": 1476,
+          "params": {
+            "address": 1476,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1476",
+            "value": 1476
+          }
+        },
+        "1477": {
+          "value": 1477,
+          "params": {
+            "address": 1477,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1477",
+            "value": 1477
+          }
+        },
+        "1478": {
+          "value": 1478,
+          "params": {
+            "address": 1478,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1478",
+            "value": 1478
+          }
+        },
+        "1479": {
+          "value": 1479,
+          "params": {
+            "address": 1479,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1479",
+            "value": 1479
+          }
+        },
+        "1480": {
+          "value": 1480,
+          "params": {
+            "address": 1480,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1480",
+            "value": 1480
+          }
+        },
+        "1481": {
+          "value": 1481,
+          "params": {
+            "address": 1481,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1481",
+            "value": 1481
+          }
+        },
+        "1482": {
+          "value": 1482,
+          "params": {
+            "address": 1482,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1482",
+            "value": 1482
+          }
+        },
+        "1483": {
+          "value": 1483,
+          "params": {
+            "address": 1483,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1483",
+            "value": 1483
+          }
+        },
+        "1484": {
+          "value": 1484,
+          "params": {
+            "address": 1484,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1484",
+            "value": 1484
+          }
+        },
+        "1485": {
+          "value": 1485,
+          "params": {
+            "address": 1485,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1485",
+            "value": 1485
+          }
+        },
+        "1486": {
+          "value": 1486,
+          "params": {
+            "address": 1486,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1486",
+            "value": 1486
+          }
+        },
+        "1487": {
+          "value": 1487,
+          "params": {
+            "address": 1487,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1487",
+            "value": 1487
+          }
+        },
+        "1488": {
+          "value": 1488,
+          "params": {
+            "address": 1488,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1488",
+            "value": 1488
+          }
+        },
+        "1489": {
+          "value": 1489,
+          "params": {
+            "address": 1489,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1489",
+            "value": 1489
+          }
+        },
+        "1490": {
+          "value": 1490,
+          "params": {
+            "address": 1490,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1490",
+            "value": 1490
+          }
+        },
+        "1491": {
+          "value": 1491,
+          "params": {
+            "address": 1491,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1491",
+            "value": 1491
+          }
+        },
+        "1492": {
+          "value": 1492,
+          "params": {
+            "address": 1492,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1492",
+            "value": 1492
+          }
+        },
+        "1493": {
+          "value": 1493,
+          "params": {
+            "address": 1493,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1493",
+            "value": 1493
+          }
+        },
+        "1494": {
+          "value": 1494,
+          "params": {
+            "address": 1494,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1494",
+            "value": 1494
+          }
+        },
+        "1495": {
+          "value": 1495,
+          "params": {
+            "address": 1495,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1495",
+            "value": 1495
+          }
+        },
+        "1496": {
+          "value": 1496,
+          "params": {
+            "address": 1496,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1496",
+            "value": 1496
+          }
+        },
+        "1497": {
+          "value": 1497,
+          "params": {
+            "address": 1497,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1497",
+            "value": 1497
+          }
+        },
+        "1498": {
+          "value": 1498,
+          "params": {
+            "address": 1498,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1498",
+            "value": 1498
+          }
+        },
+        "1499": {
+          "value": 1499,
+          "params": {
+            "address": 1499,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1499",
+            "value": 1499
+          }
+        },
+        "1500": {
+          "value": 1000,
+          "params": {
+            "address": 1500,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1500",
+            "value": 1000
+          }
+        },
+        "1501": {
+          "value": 1001,
+          "params": {
+            "address": 1501,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1501",
+            "value": 1001
+          }
+        },
+        "1502": {
+          "value": 1002,
+          "params": {
+            "address": 1502,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1502",
+            "value": 1002
+          }
+        },
+        "1503": {
+          "value": 1003,
+          "params": {
+            "address": 1503,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1503",
+            "value": 1003
+          }
+        },
+        "1504": {
+          "value": 1004,
+          "params": {
+            "address": 1504,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1504",
+            "value": 1004
+          }
+        },
+        "1505": {
+          "value": 1005,
+          "params": {
+            "address": 1505,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1505",
+            "value": 1005
+          }
+        },
+        "1506": {
+          "value": 1006,
+          "params": {
+            "address": 1506,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1506",
+            "value": 1006
+          }
+        },
+        "1507": {
+          "value": 1007,
+          "params": {
+            "address": 1507,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1507",
+            "value": 1007
+          }
+        },
+        "1508": {
+          "value": 1008,
+          "params": {
+            "address": 1508,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1508",
+            "value": 1008
+          }
+        },
+        "1509": {
+          "value": 1009,
+          "params": {
+            "address": 1509,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1509",
+            "value": 1009
+          }
+        },
+        "1510": {
+          "value": 1010,
+          "params": {
+            "address": 1510,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1510",
+            "value": 1010
+          }
+        },
+        "1511": {
+          "value": 1011,
+          "params": {
+            "address": 1511,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1511",
+            "value": 1011
+          }
+        },
+        "1512": {
+          "value": 1012,
+          "params": {
+            "address": 1512,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1512",
+            "value": 1012
+          }
+        },
+        "1513": {
+          "value": 1013,
+          "params": {
+            "address": 1513,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1513",
+            "value": 1013
+          }
+        },
+        "1514": {
+          "value": 1014,
+          "params": {
+            "address": 1514,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1514",
+            "value": 1014
+          }
+        },
+        "1515": {
+          "value": 1015,
+          "params": {
+            "address": 1515,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1515",
+            "value": 1015
+          }
+        },
+        "1516": {
+          "value": 1016,
+          "params": {
+            "address": 1516,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1516",
+            "value": 1016
+          }
+        },
+        "1517": {
+          "value": 1017,
+          "params": {
+            "address": 1517,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1517",
+            "value": 1017
+          }
+        },
+        "1518": {
+          "value": 1018,
+          "params": {
+            "address": 1518,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1518",
+            "value": 1018
+          }
+        },
+        "1519": {
+          "value": 1019,
+          "params": {
+            "address": 1519,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1519",
+            "value": 1019
+          }
+        },
+        "1520": {
+          "value": 1020,
+          "params": {
+            "address": 1520,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1520",
+            "value": 1020
+          }
+        },
+        "1521": {
+          "value": 1021,
+          "params": {
+            "address": 1521,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1521",
+            "value": 1021
+          }
+        },
+        "1522": {
+          "value": 1022,
+          "params": {
+            "address": 1522,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1522",
+            "value": 1022
+          }
+        },
+        "1523": {
+          "value": 1023,
+          "params": {
+            "address": 1523,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1523",
+            "value": 1023
+          }
+        },
+        "1524": {
+          "value": 1024,
+          "params": {
+            "address": 1524,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1524",
+            "value": 1024
+          }
+        },
+        "1525": {
+          "value": 1025,
+          "params": {
+            "address": 1525,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1525",
+            "value": 1025
+          }
+        },
+        "1526": {
+          "value": 1026,
+          "params": {
+            "address": 1526,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1526",
+            "value": 1026
+          }
+        },
+        "1527": {
+          "value": 1027,
+          "params": {
+            "address": 1527,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1527",
+            "value": 1027
+          }
+        },
+        "1528": {
+          "value": 1028,
+          "params": {
+            "address": 1528,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1528",
+            "value": 1028
+          }
+        },
+        "1529": {
+          "value": 1029,
+          "params": {
+            "address": 1529,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1529",
+            "value": 1029
+          }
+        },
+        "1530": {
+          "value": 1030,
+          "params": {
+            "address": 1530,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1530",
+            "value": 1030
+          }
+        },
+        "1531": {
+          "value": 1031,
+          "params": {
+            "address": 1531,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1531",
+            "value": 1031
+          }
+        },
+        "1532": {
+          "value": 1032,
+          "params": {
+            "address": 1532,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1532",
+            "value": 1032
+          }
+        },
+        "1533": {
+          "value": 1033,
+          "params": {
+            "address": 1533,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1533",
+            "value": 1033
+          }
+        },
+        "1534": {
+          "value": 1034,
+          "params": {
+            "address": 1534,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1534",
+            "value": 1034
+          }
+        },
+        "1535": {
+          "value": 1035,
+          "params": {
+            "address": 1535,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1535",
+            "value": 1035
+          }
+        },
+        "1536": {
+          "value": 1036,
+          "params": {
+            "address": 1536,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1536",
+            "value": 1036
+          }
+        },
+        "1537": {
+          "value": 1037,
+          "params": {
+            "address": 1537,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1537",
+            "value": 1037
+          }
+        },
+        "1538": {
+          "value": 1038,
+          "params": {
+            "address": 1538,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1538",
+            "value": 1038
+          }
+        },
+        "1539": {
+          "value": 1039,
+          "params": {
+            "address": 1539,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1539",
+            "value": 1039
+          }
+        },
+        "1540": {
+          "value": 1040,
+          "params": {
+            "address": 1540,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1540",
+            "value": 1040
+          }
+        },
+        "1541": {
+          "value": 1041,
+          "params": {
+            "address": 1541,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1541",
+            "value": 1041
+          }
+        },
+        "1542": {
+          "value": 1042,
+          "params": {
+            "address": 1542,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1542",
+            "value": 1042
+          }
+        },
+        "1543": {
+          "value": 1043,
+          "params": {
+            "address": 1543,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1543",
+            "value": 1043
+          }
+        },
+        "1544": {
+          "value": 1044,
+          "params": {
+            "address": 1544,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1544",
+            "value": 1044
+          }
+        },
+        "1545": {
+          "value": 1045,
+          "params": {
+            "address": 1545,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1545",
+            "value": 1045
+          }
+        },
+        "1546": {
+          "value": 1046,
+          "params": {
+            "address": 1546,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1546",
+            "value": 1046
+          }
+        },
+        "1547": {
+          "value": 1047,
+          "params": {
+            "address": 1547,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1547",
+            "value": 1047
+          }
+        },
+        "1548": {
+          "value": 1048,
+          "params": {
+            "address": 1548,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1548",
+            "value": 1048
+          }
+        },
+        "1549": {
+          "value": 1049,
+          "params": {
+            "address": 1549,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1549",
+            "value": 1049
+          }
+        },
+        "1550": {
+          "value": 1050,
+          "params": {
+            "address": 1550,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1550",
+            "value": 1050
+          }
+        },
+        "1551": {
+          "value": 1051,
+          "params": {
+            "address": 1551,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1551",
+            "value": 1051
+          }
+        },
+        "1552": {
+          "value": 1052,
+          "params": {
+            "address": 1552,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1552",
+            "value": 1052
+          }
+        },
+        "1553": {
+          "value": 1053,
+          "params": {
+            "address": 1553,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1553",
+            "value": 1053
+          }
+        },
+        "1554": {
+          "value": 1054,
+          "params": {
+            "address": 1554,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1554",
+            "value": 1054
+          }
+        },
+        "1555": {
+          "value": 1055,
+          "params": {
+            "address": 1555,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1555",
+            "value": 1055
+          }
+        },
+        "1556": {
+          "value": 1056,
+          "params": {
+            "address": 1556,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1556",
+            "value": 1056
+          }
+        },
+        "1557": {
+          "value": 1057,
+          "params": {
+            "address": 1557,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1557",
+            "value": 1057
+          }
+        },
+        "1558": {
+          "value": 1058,
+          "params": {
+            "address": 1558,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1558",
+            "value": 1058
+          }
+        },
+        "1559": {
+          "value": 1059,
+          "params": {
+            "address": 1559,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1559",
+            "value": 1059
+          }
+        },
+        "1560": {
+          "value": 1060,
+          "params": {
+            "address": 1560,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1560",
+            "value": 1060
+          }
+        },
+        "1561": {
+          "value": 1061,
+          "params": {
+            "address": 1561,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1561",
+            "value": 1061
+          }
+        },
+        "1562": {
+          "value": 1062,
+          "params": {
+            "address": 1562,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1562",
+            "value": 1062
+          }
+        },
+        "1563": {
+          "value": 1063,
+          "params": {
+            "address": 1563,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1563",
+            "value": 1063
+          }
+        },
+        "1564": {
+          "value": 1064,
+          "params": {
+            "address": 1564,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1564",
+            "value": 1064
+          }
+        },
+        "1565": {
+          "value": 1065,
+          "params": {
+            "address": 1565,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1565",
+            "value": 1065
+          }
+        },
+        "1566": {
+          "value": 1066,
+          "params": {
+            "address": 1566,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1566",
+            "value": 1066
+          }
+        },
+        "1567": {
+          "value": 1067,
+          "params": {
+            "address": 1567,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1567",
+            "value": 1067
+          }
+        },
+        "1568": {
+          "value": 1068,
+          "params": {
+            "address": 1568,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1568",
+            "value": 1068
+          }
+        },
+        "1569": {
+          "value": 1069,
+          "params": {
+            "address": 1569,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1569",
+            "value": 1069
+          }
+        },
+        "1570": {
+          "value": 1070,
+          "params": {
+            "address": 1570,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1570",
+            "value": 1070
+          }
+        },
+        "1571": {
+          "value": 1071,
+          "params": {
+            "address": 1571,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1571",
+            "value": 1071
+          }
+        },
+        "1572": {
+          "value": 1072,
+          "params": {
+            "address": 1572,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1572",
+            "value": 1072
+          }
+        },
+        "1573": {
+          "value": 1073,
+          "params": {
+            "address": 1573,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1573",
+            "value": 1073
+          }
+        },
+        "1574": {
+          "value": 1074,
+          "params": {
+            "address": 1574,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1574",
+            "value": 1074
+          }
+        },
+        "1575": {
+          "value": 1075,
+          "params": {
+            "address": 1575,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1575",
+            "value": 1075
+          }
+        },
+        "1576": {
+          "value": 1076,
+          "params": {
+            "address": 1576,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1576",
+            "value": 1076
+          }
+        },
+        "1577": {
+          "value": 1077,
+          "params": {
+            "address": 1577,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1577",
+            "value": 1077
+          }
+        },
+        "1578": {
+          "value": 1078,
+          "params": {
+            "address": 1578,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1578",
+            "value": 1078
+          }
+        },
+        "1579": {
+          "value": 1079,
+          "params": {
+            "address": 1579,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1579",
+            "value": 1079
+          }
+        },
+        "1580": {
+          "value": 1080,
+          "params": {
+            "address": 1580,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1580",
+            "value": 1080
+          }
+        },
+        "1581": {
+          "value": 1081,
+          "params": {
+            "address": 1581,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1581",
+            "value": 1081
+          }
+        },
+        "1582": {
+          "value": 1082,
+          "params": {
+            "address": 1582,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1582",
+            "value": 1082
+          }
+        },
+        "1583": {
+          "value": 1083,
+          "params": {
+            "address": 1583,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1583",
+            "value": 1083
+          }
+        },
+        "1584": {
+          "value": 1084,
+          "params": {
+            "address": 1584,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1584",
+            "value": 1084
+          }
+        },
+        "1585": {
+          "value": 1085,
+          "params": {
+            "address": 1585,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1585",
+            "value": 1085
+          }
+        },
+        "1586": {
+          "value": 1086,
+          "params": {
+            "address": 1586,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1586",
+            "value": 1086
+          }
+        },
+        "1587": {
+          "value": 1087,
+          "params": {
+            "address": 1587,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1587",
+            "value": 1087
+          }
+        },
+        "1588": {
+          "value": 1088,
+          "params": {
+            "address": 1588,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1588",
+            "value": 1088
+          }
+        },
+        "1589": {
+          "value": 1089,
+          "params": {
+            "address": 1589,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1589",
+            "value": 1089
+          }
+        },
+        "1590": {
+          "value": 1090,
+          "params": {
+            "address": 1590,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1590",
+            "value": 1090
+          }
+        },
+        "1591": {
+          "value": 1091,
+          "params": {
+            "address": 1591,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1591",
+            "value": 1091
+          }
+        },
+        "1592": {
+          "value": 1092,
+          "params": {
+            "address": 1592,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1592",
+            "value": 1092
+          }
+        },
+        "1593": {
+          "value": 1093,
+          "params": {
+            "address": 1593,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1593",
+            "value": 1093
+          }
+        },
+        "1594": {
+          "value": 1094,
+          "params": {
+            "address": 1594,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1594",
+            "value": 1094
+          }
+        },
+        "1595": {
+          "value": 1095,
+          "params": {
+            "address": 1595,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1595",
+            "value": 1095
+          }
+        },
+        "1596": {
+          "value": 1096,
+          "params": {
+            "address": 1596,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1596",
+            "value": 1096
+          }
+        },
+        "1597": {
+          "value": 1097,
+          "params": {
+            "address": 1597,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1597",
+            "value": 1097
+          }
+        },
+        "1598": {
+          "value": 1098,
+          "params": {
+            "address": 1598,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1598",
+            "value": 1098
+          }
+        },
+        "1599": {
+          "value": 1099,
+          "params": {
+            "address": 1599,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1599",
+            "value": 1099
+          }
+        },
+        "1600": {
+          "value": 1100,
+          "params": {
+            "address": 1600,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1600",
+            "value": 1100
+          }
+        },
+        "1601": {
+          "value": 1101,
+          "params": {
+            "address": 1601,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1601",
+            "value": 1101
+          }
+        },
+        "1602": {
+          "value": 1102,
+          "params": {
+            "address": 1602,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1602",
+            "value": 1102
+          }
+        },
+        "1603": {
+          "value": 1103,
+          "params": {
+            "address": 1603,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1603",
+            "value": 1103
+          }
+        },
+        "1604": {
+          "value": 1104,
+          "params": {
+            "address": 1604,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1604",
+            "value": 1104
+          }
+        },
+        "1605": {
+          "value": 1105,
+          "params": {
+            "address": 1605,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1605",
+            "value": 1105
+          }
+        },
+        "1606": {
+          "value": 1106,
+          "params": {
+            "address": 1606,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1606",
+            "value": 1106
+          }
+        },
+        "1607": {
+          "value": 1107,
+          "params": {
+            "address": 1607,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1607",
+            "value": 1107
+          }
+        },
+        "1608": {
+          "value": 1108,
+          "params": {
+            "address": 1608,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1608",
+            "value": 1108
+          }
+        },
+        "1609": {
+          "value": 1109,
+          "params": {
+            "address": 1609,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1609",
+            "value": 1109
+          }
+        },
+        "1610": {
+          "value": 1110,
+          "params": {
+            "address": 1610,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1610",
+            "value": 1110
+          }
+        },
+        "1611": {
+          "value": 1111,
+          "params": {
+            "address": 1611,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1611",
+            "value": 1111
+          }
+        },
+        "1612": {
+          "value": 1112,
+          "params": {
+            "address": 1612,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1612",
+            "value": 1112
+          }
+        },
+        "1613": {
+          "value": 1113,
+          "params": {
+            "address": 1613,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1613",
+            "value": 1113
+          }
+        },
+        "1614": {
+          "value": 1114,
+          "params": {
+            "address": 1614,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1614",
+            "value": 1114
+          }
+        },
+        "1615": {
+          "value": 1115,
+          "params": {
+            "address": 1615,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1615",
+            "value": 1115
+          }
+        },
+        "1616": {
+          "value": 1116,
+          "params": {
+            "address": 1616,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1616",
+            "value": 1116
+          }
+        },
+        "1617": {
+          "value": 1117,
+          "params": {
+            "address": 1617,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1617",
+            "value": 1117
+          }
+        },
+        "1618": {
+          "value": 1118,
+          "params": {
+            "address": 1618,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1618",
+            "value": 1118
+          }
+        },
+        "1619": {
+          "value": 1119,
+          "params": {
+            "address": 1619,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1619",
+            "value": 1119
+          }
+        },
+        "1620": {
+          "value": 1120,
+          "params": {
+            "address": 1620,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1620",
+            "value": 1120
+          }
+        },
+        "1621": {
+          "value": 1121,
+          "params": {
+            "address": 1621,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1621",
+            "value": 1121
+          }
+        },
+        "1622": {
+          "value": 1122,
+          "params": {
+            "address": 1622,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1622",
+            "value": 1122
+          }
+        },
+        "1623": {
+          "value": 1123,
+          "params": {
+            "address": 1623,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1623",
+            "value": 1123
+          }
+        },
+        "1624": {
+          "value": 1124,
+          "params": {
+            "address": 1624,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1624",
+            "value": 1124
+          }
+        },
+        "1625": {
+          "value": 1125,
+          "params": {
+            "address": 1625,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1625",
+            "value": 1125
+          }
+        },
+        "1626": {
+          "value": 1126,
+          "params": {
+            "address": 1626,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1626",
+            "value": 1126
+          }
+        },
+        "1627": {
+          "value": 1127,
+          "params": {
+            "address": 1627,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1627",
+            "value": 1127
+          }
+        },
+        "1628": {
+          "value": 1128,
+          "params": {
+            "address": 1628,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1628",
+            "value": 1128
+          }
+        },
+        "1629": {
+          "value": 1129,
+          "params": {
+            "address": 1629,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1629",
+            "value": 1129
+          }
+        },
+        "1630": {
+          "value": 1130,
+          "params": {
+            "address": 1630,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1630",
+            "value": 1130
+          }
+        },
+        "1631": {
+          "value": 1131,
+          "params": {
+            "address": 1631,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1631",
+            "value": 1131
+          }
+        },
+        "1632": {
+          "value": 1132,
+          "params": {
+            "address": 1632,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1632",
+            "value": 1132
+          }
+        },
+        "1633": {
+          "value": 1133,
+          "params": {
+            "address": 1633,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1633",
+            "value": 1133
+          }
+        },
+        "1634": {
+          "value": 1134,
+          "params": {
+            "address": 1634,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1634",
+            "value": 1134
+          }
+        },
+        "1635": {
+          "value": 1135,
+          "params": {
+            "address": 1635,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1635",
+            "value": 1135
+          }
+        },
+        "1636": {
+          "value": 1136,
+          "params": {
+            "address": 1636,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1636",
+            "value": 1136
+          }
+        },
+        "1637": {
+          "value": 1137,
+          "params": {
+            "address": 1637,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1637",
+            "value": 1137
+          }
+        },
+        "1638": {
+          "value": 1138,
+          "params": {
+            "address": 1638,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1638",
+            "value": 1138
+          }
+        },
+        "1639": {
+          "value": 1139,
+          "params": {
+            "address": 1639,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1639",
+            "value": 1139
+          }
+        },
+        "1640": {
+          "value": 1140,
+          "params": {
+            "address": 1640,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1640",
+            "value": 1140
+          }
+        },
+        "1641": {
+          "value": 1141,
+          "params": {
+            "address": 1641,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1641",
+            "value": 1141
+          }
+        },
+        "1642": {
+          "value": 1142,
+          "params": {
+            "address": 1642,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1642",
+            "value": 1142
+          }
+        },
+        "1643": {
+          "value": 1143,
+          "params": {
+            "address": 1643,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1643",
+            "value": 1143
+          }
+        },
+        "1644": {
+          "value": 1144,
+          "params": {
+            "address": 1644,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1644",
+            "value": 1144
+          }
+        },
+        "1645": {
+          "value": 1145,
+          "params": {
+            "address": 1645,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1645",
+            "value": 1145
+          }
+        },
+        "1646": {
+          "value": 1146,
+          "params": {
+            "address": 1646,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1646",
+            "value": 1146
+          }
+        },
+        "1647": {
+          "value": 1147,
+          "params": {
+            "address": 1647,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1647",
+            "value": 1147
+          }
+        },
+        "1648": {
+          "value": 1148,
+          "params": {
+            "address": 1648,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1648",
+            "value": 1148
+          }
+        },
+        "1649": {
+          "value": 1149,
+          "params": {
+            "address": 1649,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1649",
+            "value": 1149
+          }
+        },
+        "1650": {
+          "value": 1150,
+          "params": {
+            "address": 1650,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1650",
+            "value": 1150
+          }
+        },
+        "1651": {
+          "value": 1151,
+          "params": {
+            "address": 1651,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1651",
+            "value": 1151
+          }
+        },
+        "1652": {
+          "value": 1152,
+          "params": {
+            "address": 1652,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1652",
+            "value": 1152
+          }
+        },
+        "1653": {
+          "value": 1153,
+          "params": {
+            "address": 1653,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1653",
+            "value": 1153
+          }
+        },
+        "1654": {
+          "value": 1154,
+          "params": {
+            "address": 1654,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1654",
+            "value": 1154
+          }
+        },
+        "1655": {
+          "value": 1155,
+          "params": {
+            "address": 1655,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1655",
+            "value": 1155
+          }
+        },
+        "1656": {
+          "value": 1156,
+          "params": {
+            "address": 1656,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1656",
+            "value": 1156
+          }
+        },
+        "1657": {
+          "value": 1157,
+          "params": {
+            "address": 1657,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1657",
+            "value": 1157
+          }
+        },
+        "1658": {
+          "value": 1158,
+          "params": {
+            "address": 1658,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1658",
+            "value": 1158
+          }
+        },
+        "1659": {
+          "value": 1159,
+          "params": {
+            "address": 1659,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1659",
+            "value": 1159
+          }
+        },
+        "1660": {
+          "value": 1160,
+          "params": {
+            "address": 1660,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1660",
+            "value": 1160
+          }
+        },
+        "1661": {
+          "value": 1161,
+          "params": {
+            "address": 1661,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1661",
+            "value": 1161
+          }
+        },
+        "1662": {
+          "value": 1162,
+          "params": {
+            "address": 1662,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1662",
+            "value": 1162
+          }
+        },
+        "1663": {
+          "value": 1163,
+          "params": {
+            "address": 1663,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1663",
+            "value": 1163
+          }
+        },
+        "1664": {
+          "value": 1164,
+          "params": {
+            "address": 1664,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1664",
+            "value": 1164
+          }
+        },
+        "1665": {
+          "value": 1165,
+          "params": {
+            "address": 1665,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1665",
+            "value": 1165
+          }
+        },
+        "1666": {
+          "value": 1166,
+          "params": {
+            "address": 1666,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1666",
+            "value": 1166
+          }
+        },
+        "1667": {
+          "value": 1167,
+          "params": {
+            "address": 1667,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1667",
+            "value": 1167
+          }
+        },
+        "1668": {
+          "value": 1168,
+          "params": {
+            "address": 1668,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1668",
+            "value": 1168
+          }
+        },
+        "1669": {
+          "value": 1169,
+          "params": {
+            "address": 1669,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1669",
+            "value": 1169
+          }
+        },
+        "1670": {
+          "value": 1170,
+          "params": {
+            "address": 1670,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1670",
+            "value": 1170
+          }
+        },
+        "1671": {
+          "value": 1171,
+          "params": {
+            "address": 1671,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1671",
+            "value": 1171
+          }
+        },
+        "1672": {
+          "value": 1172,
+          "params": {
+            "address": 1672,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1672",
+            "value": 1172
+          }
+        },
+        "1673": {
+          "value": 1173,
+          "params": {
+            "address": 1673,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1673",
+            "value": 1173
+          }
+        },
+        "1674": {
+          "value": 1174,
+          "params": {
+            "address": 1674,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1674",
+            "value": 1174
+          }
+        },
+        "1675": {
+          "value": 1175,
+          "params": {
+            "address": 1675,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1675",
+            "value": 1175
+          }
+        },
+        "1676": {
+          "value": 1176,
+          "params": {
+            "address": 1676,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1676",
+            "value": 1176
+          }
+        },
+        "1677": {
+          "value": 1177,
+          "params": {
+            "address": 1677,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1677",
+            "value": 1177
+          }
+        },
+        "1678": {
+          "value": 1178,
+          "params": {
+            "address": 1678,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1678",
+            "value": 1178
+          }
+        },
+        "1679": {
+          "value": 1179,
+          "params": {
+            "address": 1679,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1679",
+            "value": 1179
+          }
+        },
+        "1680": {
+          "value": 1180,
+          "params": {
+            "address": 1680,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1680",
+            "value": 1180
+          }
+        },
+        "1681": {
+          "value": 1181,
+          "params": {
+            "address": 1681,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1681",
+            "value": 1181
+          }
+        },
+        "1682": {
+          "value": 1182,
+          "params": {
+            "address": 1682,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1682",
+            "value": 1182
+          }
+        },
+        "1683": {
+          "value": 1183,
+          "params": {
+            "address": 1683,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1683",
+            "value": 1183
+          }
+        },
+        "1684": {
+          "value": 1184,
+          "params": {
+            "address": 1684,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1684",
+            "value": 1184
+          }
+        },
+        "1685": {
+          "value": 1185,
+          "params": {
+            "address": 1685,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1685",
+            "value": 1185
+          }
+        },
+        "1686": {
+          "value": 1186,
+          "params": {
+            "address": 1686,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1686",
+            "value": 1186
+          }
+        },
+        "1687": {
+          "value": 1187,
+          "params": {
+            "address": 1687,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1687",
+            "value": 1187
+          }
+        },
+        "1688": {
+          "value": 1188,
+          "params": {
+            "address": 1688,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1688",
+            "value": 1188
+          }
+        },
+        "1689": {
+          "value": 1189,
+          "params": {
+            "address": 1689,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1689",
+            "value": 1189
+          }
+        },
+        "1690": {
+          "value": 1190,
+          "params": {
+            "address": 1690,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1690",
+            "value": 1190
+          }
+        },
+        "1691": {
+          "value": 1191,
+          "params": {
+            "address": 1691,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1691",
+            "value": 1191
+          }
+        },
+        "1692": {
+          "value": 1192,
+          "params": {
+            "address": 1692,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1692",
+            "value": 1192
+          }
+        },
+        "1693": {
+          "value": 1193,
+          "params": {
+            "address": 1693,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1693",
+            "value": 1193
+          }
+        },
+        "1694": {
+          "value": 1194,
+          "params": {
+            "address": 1694,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1694",
+            "value": 1194
+          }
+        },
+        "1695": {
+          "value": 1195,
+          "params": {
+            "address": 1695,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1695",
+            "value": 1195
+          }
+        },
+        "1696": {
+          "value": 1196,
+          "params": {
+            "address": 1696,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1696",
+            "value": 1196
+          }
+        },
+        "1697": {
+          "value": 1197,
+          "params": {
+            "address": 1697,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1697",
+            "value": 1197
+          }
+        },
+        "1698": {
+          "value": 1198,
+          "params": {
+            "address": 1698,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1698",
+            "value": 1198
+          }
+        },
+        "1699": {
+          "value": 1199,
+          "params": {
+            "address": 1699,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1699",
+            "value": 1199
+          }
+        },
+        "1700": {
+          "value": 1200,
+          "params": {
+            "address": 1700,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1700",
+            "value": 1200
+          }
+        },
+        "1701": {
+          "value": 1201,
+          "params": {
+            "address": 1701,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1701",
+            "value": 1201
+          }
+        },
+        "1702": {
+          "value": 1202,
+          "params": {
+            "address": 1702,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1702",
+            "value": 1202
+          }
+        },
+        "1703": {
+          "value": 1203,
+          "params": {
+            "address": 1703,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1703",
+            "value": 1203
+          }
+        },
+        "1704": {
+          "value": 1204,
+          "params": {
+            "address": 1704,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1704",
+            "value": 1204
+          }
+        },
+        "1705": {
+          "value": 1205,
+          "params": {
+            "address": 1705,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1705",
+            "value": 1205
+          }
+        },
+        "1706": {
+          "value": 1206,
+          "params": {
+            "address": 1706,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1706",
+            "value": 1206
+          }
+        },
+        "1707": {
+          "value": 1207,
+          "params": {
+            "address": 1707,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1707",
+            "value": 1207
+          }
+        },
+        "1708": {
+          "value": 1208,
+          "params": {
+            "address": 1708,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1708",
+            "value": 1208
+          }
+        },
+        "1709": {
+          "value": 1209,
+          "params": {
+            "address": 1709,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1709",
+            "value": 1209
+          }
+        },
+        "1710": {
+          "value": 1210,
+          "params": {
+            "address": 1710,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1710",
+            "value": 1210
+          }
+        },
+        "1711": {
+          "value": 1211,
+          "params": {
+            "address": 1711,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1711",
+            "value": 1211
+          }
+        },
+        "1712": {
+          "value": 1212,
+          "params": {
+            "address": 1712,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1712",
+            "value": 1212
+          }
+        },
+        "1713": {
+          "value": 1213,
+          "params": {
+            "address": 1713,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1713",
+            "value": 1213
+          }
+        },
+        "1714": {
+          "value": 1214,
+          "params": {
+            "address": 1714,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1714",
+            "value": 1214
+          }
+        },
+        "1715": {
+          "value": 1215,
+          "params": {
+            "address": 1715,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1715",
+            "value": 1215
+          }
+        },
+        "1716": {
+          "value": 1216,
+          "params": {
+            "address": 1716,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1716",
+            "value": 1216
+          }
+        },
+        "1717": {
+          "value": 1217,
+          "params": {
+            "address": 1717,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1717",
+            "value": 1217
+          }
+        },
+        "1718": {
+          "value": 1218,
+          "params": {
+            "address": 1718,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1718",
+            "value": 1218
+          }
+        },
+        "1719": {
+          "value": 1219,
+          "params": {
+            "address": 1719,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1719",
+            "value": 1219
+          }
+        },
+        "1720": {
+          "value": 1220,
+          "params": {
+            "address": 1720,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1720",
+            "value": 1220
+          }
+        },
+        "1721": {
+          "value": 1221,
+          "params": {
+            "address": 1721,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1721",
+            "value": 1221
+          }
+        },
+        "1722": {
+          "value": 1222,
+          "params": {
+            "address": 1722,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1722",
+            "value": 1222
+          }
+        },
+        "1723": {
+          "value": 1223,
+          "params": {
+            "address": 1723,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1723",
+            "value": 1223
+          }
+        },
+        "1724": {
+          "value": 1224,
+          "params": {
+            "address": 1724,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1724",
+            "value": 1224
+          }
+        },
+        "1725": {
+          "value": 1225,
+          "params": {
+            "address": 1725,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1725",
+            "value": 1225
+          }
+        },
+        "1726": {
+          "value": 1226,
+          "params": {
+            "address": 1726,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1726",
+            "value": 1226
+          }
+        },
+        "1727": {
+          "value": 1227,
+          "params": {
+            "address": 1727,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1727",
+            "value": 1227
+          }
+        },
+        "1728": {
+          "value": 1228,
+          "params": {
+            "address": 1728,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1728",
+            "value": 1228
+          }
+        },
+        "1729": {
+          "value": 1229,
+          "params": {
+            "address": 1729,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1729",
+            "value": 1229
+          }
+        },
+        "1730": {
+          "value": 1230,
+          "params": {
+            "address": 1730,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1730",
+            "value": 1230
+          }
+        },
+        "1731": {
+          "value": 1231,
+          "params": {
+            "address": 1731,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1731",
+            "value": 1231
+          }
+        },
+        "1732": {
+          "value": 1232,
+          "params": {
+            "address": 1732,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1732",
+            "value": 1232
+          }
+        },
+        "1733": {
+          "value": 1233,
+          "params": {
+            "address": 1733,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1733",
+            "value": 1233
+          }
+        },
+        "1734": {
+          "value": 1234,
+          "params": {
+            "address": 1734,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1734",
+            "value": 1234
+          }
+        },
+        "1735": {
+          "value": 1235,
+          "params": {
+            "address": 1735,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1735",
+            "value": 1235
+          }
+        },
+        "1736": {
+          "value": 1236,
+          "params": {
+            "address": 1736,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1736",
+            "value": 1236
+          }
+        },
+        "1737": {
+          "value": 1237,
+          "params": {
+            "address": 1737,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1737",
+            "value": 1237
+          }
+        },
+        "1738": {
+          "value": 1238,
+          "params": {
+            "address": 1738,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1738",
+            "value": 1238
+          }
+        },
+        "1739": {
+          "value": 1239,
+          "params": {
+            "address": 1739,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1739",
+            "value": 1239
+          }
+        },
+        "1740": {
+          "value": 1240,
+          "params": {
+            "address": 1740,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1740",
+            "value": 1240
+          }
+        },
+        "1741": {
+          "value": 1241,
+          "params": {
+            "address": 1741,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1741",
+            "value": 1241
+          }
+        },
+        "1742": {
+          "value": 1242,
+          "params": {
+            "address": 1742,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1742",
+            "value": 1242
+          }
+        },
+        "1743": {
+          "value": 1243,
+          "params": {
+            "address": 1743,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1743",
+            "value": 1243
+          }
+        },
+        "1744": {
+          "value": 1244,
+          "params": {
+            "address": 1744,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1744",
+            "value": 1244
+          }
+        },
+        "1745": {
+          "value": 1245,
+          "params": {
+            "address": 1745,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1745",
+            "value": 1245
+          }
+        },
+        "1746": {
+          "value": 1246,
+          "params": {
+            "address": 1746,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1746",
+            "value": 1246
+          }
+        },
+        "1747": {
+          "value": 1247,
+          "params": {
+            "address": 1747,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1747",
+            "value": 1247
+          }
+        },
+        "1748": {
+          "value": 1248,
+          "params": {
+            "address": 1748,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1748",
+            "value": 1248
+          }
+        },
+        "1749": {
+          "value": 1249,
+          "params": {
+            "address": 1749,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1749",
+            "value": 1249
+          }
+        },
+        "1750": {
+          "value": 1250,
+          "params": {
+            "address": 1750,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1750",
+            "value": 1250
+          }
+        },
+        "1751": {
+          "value": 1251,
+          "params": {
+            "address": 1751,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1751",
+            "value": 1251
+          }
+        },
+        "1752": {
+          "value": 1252,
+          "params": {
+            "address": 1752,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1752",
+            "value": 1252
+          }
+        },
+        "1753": {
+          "value": 1253,
+          "params": {
+            "address": 1753,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1753",
+            "value": 1253
+          }
+        },
+        "1754": {
+          "value": 1254,
+          "params": {
+            "address": 1754,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1754",
+            "value": 1254
+          }
+        },
+        "1755": {
+          "value": 1255,
+          "params": {
+            "address": 1755,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1755",
+            "value": 1255
+          }
+        },
+        "1756": {
+          "value": 1256,
+          "params": {
+            "address": 1756,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1756",
+            "value": 1256
+          }
+        },
+        "1757": {
+          "value": 1257,
+          "params": {
+            "address": 1757,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1757",
+            "value": 1257
+          }
+        },
+        "1758": {
+          "value": 1258,
+          "params": {
+            "address": 1758,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1758",
+            "value": 1258
+          }
+        },
+        "1759": {
+          "value": 1259,
+          "params": {
+            "address": 1759,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1759",
+            "value": 1259
+          }
+        },
+        "1760": {
+          "value": 1260,
+          "params": {
+            "address": 1760,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1760",
+            "value": 1260
+          }
+        },
+        "1761": {
+          "value": 1261,
+          "params": {
+            "address": 1761,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1761",
+            "value": 1261
+          }
+        },
+        "1762": {
+          "value": 1262,
+          "params": {
+            "address": 1762,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1762",
+            "value": 1262
+          }
+        },
+        "1763": {
+          "value": 1263,
+          "params": {
+            "address": 1763,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1763",
+            "value": 1263
+          }
+        },
+        "1764": {
+          "value": 1264,
+          "params": {
+            "address": 1764,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1764",
+            "value": 1264
+          }
+        },
+        "1765": {
+          "value": 1265,
+          "params": {
+            "address": 1765,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1765",
+            "value": 1265
+          }
+        },
+        "1766": {
+          "value": 1266,
+          "params": {
+            "address": 1766,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1766",
+            "value": 1266
+          }
+        },
+        "1767": {
+          "value": 1267,
+          "params": {
+            "address": 1767,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1767",
+            "value": 1267
+          }
+        },
+        "1768": {
+          "value": 1268,
+          "params": {
+            "address": 1768,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1768",
+            "value": 1268
+          }
+        },
+        "1769": {
+          "value": 1269,
+          "params": {
+            "address": 1769,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1769",
+            "value": 1269
+          }
+        },
+        "1770": {
+          "value": 1270,
+          "params": {
+            "address": 1770,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1770",
+            "value": 1270
+          }
+        },
+        "1771": {
+          "value": 1271,
+          "params": {
+            "address": 1771,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1771",
+            "value": 1271
+          }
+        },
+        "1772": {
+          "value": 1272,
+          "params": {
+            "address": 1772,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1772",
+            "value": 1272
+          }
+        },
+        "1773": {
+          "value": 1273,
+          "params": {
+            "address": 1773,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1773",
+            "value": 1273
+          }
+        },
+        "1774": {
+          "value": 1274,
+          "params": {
+            "address": 1774,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1774",
+            "value": 1274
+          }
+        },
+        "1775": {
+          "value": 1275,
+          "params": {
+            "address": 1775,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1775",
+            "value": 1275
+          }
+        },
+        "1776": {
+          "value": 1276,
+          "params": {
+            "address": 1776,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1776",
+            "value": 1276
+          }
+        },
+        "1777": {
+          "value": 1277,
+          "params": {
+            "address": 1777,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1777",
+            "value": 1277
+          }
+        },
+        "1778": {
+          "value": 1278,
+          "params": {
+            "address": 1778,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1778",
+            "value": 1278
+          }
+        },
+        "1779": {
+          "value": 1279,
+          "params": {
+            "address": 1779,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1779",
+            "value": 1279
+          }
+        },
+        "1780": {
+          "value": 1280,
+          "params": {
+            "address": 1780,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1780",
+            "value": 1280
+          }
+        },
+        "1781": {
+          "value": 1281,
+          "params": {
+            "address": 1781,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1781",
+            "value": 1281
+          }
+        },
+        "1782": {
+          "value": 1282,
+          "params": {
+            "address": 1782,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1782",
+            "value": 1282
+          }
+        },
+        "1783": {
+          "value": 1283,
+          "params": {
+            "address": 1783,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1783",
+            "value": 1283
+          }
+        },
+        "1784": {
+          "value": 1284,
+          "params": {
+            "address": 1784,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1784",
+            "value": 1284
+          }
+        },
+        "1785": {
+          "value": 1285,
+          "params": {
+            "address": 1785,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1785",
+            "value": 1285
+          }
+        },
+        "1786": {
+          "value": 1286,
+          "params": {
+            "address": 1786,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1786",
+            "value": 1286
+          }
+        },
+        "1787": {
+          "value": 1287,
+          "params": {
+            "address": 1787,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1787",
+            "value": 1287
+          }
+        },
+        "1788": {
+          "value": 1288,
+          "params": {
+            "address": 1788,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1788",
+            "value": 1288
+          }
+        },
+        "1789": {
+          "value": 1289,
+          "params": {
+            "address": 1789,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1789",
+            "value": 1289
+          }
+        },
+        "1790": {
+          "value": 1290,
+          "params": {
+            "address": 1790,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1790",
+            "value": 1290
+          }
+        },
+        "1791": {
+          "value": 1291,
+          "params": {
+            "address": 1791,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1791",
+            "value": 1291
+          }
+        },
+        "1792": {
+          "value": 1292,
+          "params": {
+            "address": 1792,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1792",
+            "value": 1292
+          }
+        },
+        "1793": {
+          "value": 1293,
+          "params": {
+            "address": 1793,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1793",
+            "value": 1293
+          }
+        },
+        "1794": {
+          "value": 1294,
+          "params": {
+            "address": 1794,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1794",
+            "value": 1294
+          }
+        },
+        "1795": {
+          "value": 1295,
+          "params": {
+            "address": 1795,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1795",
+            "value": 1295
+          }
+        },
+        "1796": {
+          "value": 1296,
+          "params": {
+            "address": 1796,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1796",
+            "value": 1296
+          }
+        },
+        "1797": {
+          "value": 1297,
+          "params": {
+            "address": 1797,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1797",
+            "value": 1297
+          }
+        },
+        "1798": {
+          "value": 1298,
+          "params": {
+            "address": 1798,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1798",
+            "value": 1298
+          }
+        },
+        "1799": {
+          "value": 1299,
+          "params": {
+            "address": 1799,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1799",
+            "value": 1299
+          }
+        },
+        "1800": {
+          "value": 1300,
+          "params": {
+            "address": 1800,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1800",
+            "value": 1300
+          }
+        },
+        "1801": {
+          "value": 1301,
+          "params": {
+            "address": 1801,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1801",
+            "value": 1301
+          }
+        },
+        "1802": {
+          "value": 1302,
+          "params": {
+            "address": 1802,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1802",
+            "value": 1302
+          }
+        },
+        "1803": {
+          "value": 1303,
+          "params": {
+            "address": 1803,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1803",
+            "value": 1303
+          }
+        },
+        "1804": {
+          "value": 1304,
+          "params": {
+            "address": 1804,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1804",
+            "value": 1304
+          }
+        },
+        "1805": {
+          "value": 1305,
+          "params": {
+            "address": 1805,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1805",
+            "value": 1305
+          }
+        },
+        "1806": {
+          "value": 1306,
+          "params": {
+            "address": 1806,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1806",
+            "value": 1306
+          }
+        },
+        "1807": {
+          "value": 1307,
+          "params": {
+            "address": 1807,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1807",
+            "value": 1307
+          }
+        },
+        "1808": {
+          "value": 1308,
+          "params": {
+            "address": 1808,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1808",
+            "value": 1308
+          }
+        },
+        "1809": {
+          "value": 1309,
+          "params": {
+            "address": 1809,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1809",
+            "value": 1309
+          }
+        },
+        "1810": {
+          "value": 1310,
+          "params": {
+            "address": 1810,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1810",
+            "value": 1310
+          }
+        },
+        "1811": {
+          "value": 1311,
+          "params": {
+            "address": 1811,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1811",
+            "value": 1311
+          }
+        },
+        "1812": {
+          "value": 1312,
+          "params": {
+            "address": 1812,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1812",
+            "value": 1312
+          }
+        },
+        "1813": {
+          "value": 1313,
+          "params": {
+            "address": 1813,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1813",
+            "value": 1313
+          }
+        },
+        "1814": {
+          "value": 1314,
+          "params": {
+            "address": 1814,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1814",
+            "value": 1314
+          }
+        },
+        "1815": {
+          "value": 1315,
+          "params": {
+            "address": 1815,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1815",
+            "value": 1315
+          }
+        },
+        "1816": {
+          "value": 1316,
+          "params": {
+            "address": 1816,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1816",
+            "value": 1316
+          }
+        },
+        "1817": {
+          "value": 1317,
+          "params": {
+            "address": 1817,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1817",
+            "value": 1317
+          }
+        },
+        "1818": {
+          "value": 1318,
+          "params": {
+            "address": 1818,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1818",
+            "value": 1318
+          }
+        },
+        "1819": {
+          "value": 1319,
+          "params": {
+            "address": 1819,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1819",
+            "value": 1319
+          }
+        },
+        "1820": {
+          "value": 1320,
+          "params": {
+            "address": 1820,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1820",
+            "value": 1320
+          }
+        },
+        "1821": {
+          "value": 1321,
+          "params": {
+            "address": 1821,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1821",
+            "value": 1321
+          }
+        },
+        "1822": {
+          "value": 1322,
+          "params": {
+            "address": 1822,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1822",
+            "value": 1322
+          }
+        },
+        "1823": {
+          "value": 1323,
+          "params": {
+            "address": 1823,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1823",
+            "value": 1323
+          }
+        },
+        "1824": {
+          "value": 1324,
+          "params": {
+            "address": 1824,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1824",
+            "value": 1324
+          }
+        },
+        "1825": {
+          "value": 1325,
+          "params": {
+            "address": 1825,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1825",
+            "value": 1325
+          }
+        },
+        "1826": {
+          "value": 1326,
+          "params": {
+            "address": 1826,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1826",
+            "value": 1326
+          }
+        },
+        "1827": {
+          "value": 1327,
+          "params": {
+            "address": 1827,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1827",
+            "value": 1327
+          }
+        },
+        "1828": {
+          "value": 1328,
+          "params": {
+            "address": 1828,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1828",
+            "value": 1328
+          }
+        },
+        "1829": {
+          "value": 1329,
+          "params": {
+            "address": 1829,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1829",
+            "value": 1329
+          }
+        },
+        "1830": {
+          "value": 1330,
+          "params": {
+            "address": 1830,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1830",
+            "value": 1330
+          }
+        },
+        "1831": {
+          "value": 1331,
+          "params": {
+            "address": 1831,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1831",
+            "value": 1331
+          }
+        },
+        "1832": {
+          "value": 1332,
+          "params": {
+            "address": 1832,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1832",
+            "value": 1332
+          }
+        },
+        "1833": {
+          "value": 1333,
+          "params": {
+            "address": 1833,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1833",
+            "value": 1333
+          }
+        },
+        "1834": {
+          "value": 1334,
+          "params": {
+            "address": 1834,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1834",
+            "value": 1334
+          }
+        },
+        "1835": {
+          "value": 1335,
+          "params": {
+            "address": 1835,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1835",
+            "value": 1335
+          }
+        },
+        "1836": {
+          "value": 1336,
+          "params": {
+            "address": 1836,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1836",
+            "value": 1336
+          }
+        },
+        "1837": {
+          "value": 1337,
+          "params": {
+            "address": 1837,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1837",
+            "value": 1337
+          }
+        },
+        "1838": {
+          "value": 1338,
+          "params": {
+            "address": 1838,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1838",
+            "value": 1338
+          }
+        },
+        "1839": {
+          "value": 1339,
+          "params": {
+            "address": 1839,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1839",
+            "value": 1339
+          }
+        },
+        "1840": {
+          "value": 1340,
+          "params": {
+            "address": 1840,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1840",
+            "value": 1340
+          }
+        },
+        "1841": {
+          "value": 1341,
+          "params": {
+            "address": 1841,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1841",
+            "value": 1341
+          }
+        },
+        "1842": {
+          "value": 1342,
+          "params": {
+            "address": 1842,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1842",
+            "value": 1342
+          }
+        },
+        "1843": {
+          "value": 1343,
+          "params": {
+            "address": 1843,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1843",
+            "value": 1343
+          }
+        },
+        "1844": {
+          "value": 1344,
+          "params": {
+            "address": 1844,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1844",
+            "value": 1344
+          }
+        },
+        "1845": {
+          "value": 1345,
+          "params": {
+            "address": 1845,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1845",
+            "value": 1345
+          }
+        },
+        "1846": {
+          "value": 1346,
+          "params": {
+            "address": 1846,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1846",
+            "value": 1346
+          }
+        },
+        "1847": {
+          "value": 1347,
+          "params": {
+            "address": 1847,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1847",
+            "value": 1347
+          }
+        },
+        "1848": {
+          "value": 1348,
+          "params": {
+            "address": 1848,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1848",
+            "value": 1348
+          }
+        },
+        "1849": {
+          "value": 1349,
+          "params": {
+            "address": 1849,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1849",
+            "value": 1349
+          }
+        },
+        "1850": {
+          "value": 1350,
+          "params": {
+            "address": 1850,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1850",
+            "value": 1350
+          }
+        },
+        "1851": {
+          "value": 1351,
+          "params": {
+            "address": 1851,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1851",
+            "value": 1351
+          }
+        },
+        "1852": {
+          "value": 1352,
+          "params": {
+            "address": 1852,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1852",
+            "value": 1352
+          }
+        },
+        "1853": {
+          "value": 1353,
+          "params": {
+            "address": 1853,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1853",
+            "value": 1353
+          }
+        },
+        "1854": {
+          "value": 1354,
+          "params": {
+            "address": 1854,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1854",
+            "value": 1354
+          }
+        },
+        "1855": {
+          "value": 1355,
+          "params": {
+            "address": 1855,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1855",
+            "value": 1355
+          }
+        },
+        "1856": {
+          "value": 1356,
+          "params": {
+            "address": 1856,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1856",
+            "value": 1356
+          }
+        },
+        "1857": {
+          "value": 1357,
+          "params": {
+            "address": 1857,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1857",
+            "value": 1357
+          }
+        },
+        "1858": {
+          "value": 1358,
+          "params": {
+            "address": 1858,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1858",
+            "value": 1358
+          }
+        },
+        "1859": {
+          "value": 1359,
+          "params": {
+            "address": 1859,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1859",
+            "value": 1359
+          }
+        },
+        "1860": {
+          "value": 1360,
+          "params": {
+            "address": 1860,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1860",
+            "value": 1360
+          }
+        },
+        "1861": {
+          "value": 1361,
+          "params": {
+            "address": 1861,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1861",
+            "value": 1361
+          }
+        },
+        "1862": {
+          "value": 1362,
+          "params": {
+            "address": 1862,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1862",
+            "value": 1362
+          }
+        },
+        "1863": {
+          "value": 1363,
+          "params": {
+            "address": 1863,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1863",
+            "value": 1363
+          }
+        },
+        "1864": {
+          "value": 1364,
+          "params": {
+            "address": 1864,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1864",
+            "value": 1364
+          }
+        },
+        "1865": {
+          "value": 1365,
+          "params": {
+            "address": 1865,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1865",
+            "value": 1365
+          }
+        },
+        "1866": {
+          "value": 1366,
+          "params": {
+            "address": 1866,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1866",
+            "value": 1366
+          }
+        },
+        "1867": {
+          "value": 1367,
+          "params": {
+            "address": 1867,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1867",
+            "value": 1367
+          }
+        },
+        "1868": {
+          "value": 1368,
+          "params": {
+            "address": 1868,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1868",
+            "value": 1368
+          }
+        },
+        "1869": {
+          "value": 1369,
+          "params": {
+            "address": 1869,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1869",
+            "value": 1369
+          }
+        },
+        "1870": {
+          "value": 1370,
+          "params": {
+            "address": 1870,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1870",
+            "value": 1370
+          }
+        },
+        "1871": {
+          "value": 1371,
+          "params": {
+            "address": 1871,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1871",
+            "value": 1371
+          }
+        },
+        "1872": {
+          "value": 1372,
+          "params": {
+            "address": 1872,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1872",
+            "value": 1372
+          }
+        },
+        "1873": {
+          "value": 1373,
+          "params": {
+            "address": 1873,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1873",
+            "value": 1373
+          }
+        },
+        "1874": {
+          "value": 1374,
+          "params": {
+            "address": 1874,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1874",
+            "value": 1374
+          }
+        },
+        "1875": {
+          "value": 1375,
+          "params": {
+            "address": 1875,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1875",
+            "value": 1375
+          }
+        },
+        "1876": {
+          "value": 1376,
+          "params": {
+            "address": 1876,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1876",
+            "value": 1376
+          }
+        },
+        "1877": {
+          "value": 1377,
+          "params": {
+            "address": 1877,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1877",
+            "value": 1377
+          }
+        },
+        "1878": {
+          "value": 1378,
+          "params": {
+            "address": 1878,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1878",
+            "value": 1378
+          }
+        },
+        "1879": {
+          "value": 1379,
+          "params": {
+            "address": 1879,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1879",
+            "value": 1379
+          }
+        },
+        "1880": {
+          "value": 1380,
+          "params": {
+            "address": 1880,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1880",
+            "value": 1380
+          }
+        },
+        "1881": {
+          "value": 1381,
+          "params": {
+            "address": 1881,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1881",
+            "value": 1381
+          }
+        },
+        "1882": {
+          "value": 1382,
+          "params": {
+            "address": 1882,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1882",
+            "value": 1382
+          }
+        },
+        "1883": {
+          "value": 1383,
+          "params": {
+            "address": 1883,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1883",
+            "value": 1383
+          }
+        },
+        "1884": {
+          "value": 1384,
+          "params": {
+            "address": 1884,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1884",
+            "value": 1384
+          }
+        },
+        "1885": {
+          "value": 1385,
+          "params": {
+            "address": 1885,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1885",
+            "value": 1385
+          }
+        },
+        "1886": {
+          "value": 1386,
+          "params": {
+            "address": 1886,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1886",
+            "value": 1386
+          }
+        },
+        "1887": {
+          "value": 1387,
+          "params": {
+            "address": 1887,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1887",
+            "value": 1387
+          }
+        },
+        "1888": {
+          "value": 1388,
+          "params": {
+            "address": 1888,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1888",
+            "value": 1388
+          }
+        },
+        "1889": {
+          "value": 1389,
+          "params": {
+            "address": 1889,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1889",
+            "value": 1389
+          }
+        },
+        "1890": {
+          "value": 1390,
+          "params": {
+            "address": 1890,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1890",
+            "value": 1390
+          }
+        },
+        "1891": {
+          "value": 1391,
+          "params": {
+            "address": 1891,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1891",
+            "value": 1391
+          }
+        },
+        "1892": {
+          "value": 1392,
+          "params": {
+            "address": 1892,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1892",
+            "value": 1392
+          }
+        },
+        "1893": {
+          "value": 1393,
+          "params": {
+            "address": 1893,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1893",
+            "value": 1393
+          }
+        },
+        "1894": {
+          "value": 1394,
+          "params": {
+            "address": 1894,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1894",
+            "value": 1394
+          }
+        },
+        "1895": {
+          "value": 1395,
+          "params": {
+            "address": 1895,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1895",
+            "value": 1395
+          }
+        },
+        "1896": {
+          "value": 1396,
+          "params": {
+            "address": 1896,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1896",
+            "value": 1396
+          }
+        },
+        "1897": {
+          "value": 1397,
+          "params": {
+            "address": 1897,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1897",
+            "value": 1397
+          }
+        },
+        "1898": {
+          "value": 1398,
+          "params": {
+            "address": 1898,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1898",
+            "value": 1398
+          }
+        },
+        "1899": {
+          "value": 1399,
+          "params": {
+            "address": 1899,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1899",
+            "value": 1399
+          }
+        },
+        "1900": {
+          "value": 1400,
+          "params": {
+            "address": 1900,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1900",
+            "value": 1400
+          }
+        },
+        "1901": {
+          "value": 1401,
+          "params": {
+            "address": 1901,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1901",
+            "value": 1401
+          }
+        },
+        "1902": {
+          "value": 1402,
+          "params": {
+            "address": 1902,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1902",
+            "value": 1402
+          }
+        },
+        "1903": {
+          "value": 1403,
+          "params": {
+            "address": 1903,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1903",
+            "value": 1403
+          }
+        },
+        "1904": {
+          "value": 1404,
+          "params": {
+            "address": 1904,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1904",
+            "value": 1404
+          }
+        },
+        "1905": {
+          "value": 1405,
+          "params": {
+            "address": 1905,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1905",
+            "value": 1405
+          }
+        },
+        "1906": {
+          "value": 1406,
+          "params": {
+            "address": 1906,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1906",
+            "value": 1406
+          }
+        },
+        "1907": {
+          "value": 1407,
+          "params": {
+            "address": 1907,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1907",
+            "value": 1407
+          }
+        },
+        "1908": {
+          "value": 1408,
+          "params": {
+            "address": 1908,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1908",
+            "value": 1408
+          }
+        },
+        "1909": {
+          "value": 1409,
+          "params": {
+            "address": 1909,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1909",
+            "value": 1409
+          }
+        },
+        "1910": {
+          "value": 1410,
+          "params": {
+            "address": 1910,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1910",
+            "value": 1410
+          }
+        },
+        "1911": {
+          "value": 1411,
+          "params": {
+            "address": 1911,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1911",
+            "value": 1411
+          }
+        },
+        "1912": {
+          "value": 1412,
+          "params": {
+            "address": 1912,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1912",
+            "value": 1412
+          }
+        },
+        "1913": {
+          "value": 1413,
+          "params": {
+            "address": 1913,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1913",
+            "value": 1413
+          }
+        },
+        "1914": {
+          "value": 1414,
+          "params": {
+            "address": 1914,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1914",
+            "value": 1414
+          }
+        },
+        "1915": {
+          "value": 1415,
+          "params": {
+            "address": 1915,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1915",
+            "value": 1415
+          }
+        },
+        "1916": {
+          "value": 1416,
+          "params": {
+            "address": 1916,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1916",
+            "value": 1416
+          }
+        },
+        "1917": {
+          "value": 1417,
+          "params": {
+            "address": 1917,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1917",
+            "value": 1417
+          }
+        },
+        "1918": {
+          "value": 1418,
+          "params": {
+            "address": 1918,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1918",
+            "value": 1418
+          }
+        },
+        "1919": {
+          "value": 1419,
+          "params": {
+            "address": 1919,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1919",
+            "value": 1419
+          }
+        },
+        "1920": {
+          "value": 1420,
+          "params": {
+            "address": 1920,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1920",
+            "value": 1420
+          }
+        },
+        "1921": {
+          "value": 1421,
+          "params": {
+            "address": 1921,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1921",
+            "value": 1421
+          }
+        },
+        "1922": {
+          "value": 1422,
+          "params": {
+            "address": 1922,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1922",
+            "value": 1422
+          }
+        },
+        "1923": {
+          "value": 1423,
+          "params": {
+            "address": 1923,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1923",
+            "value": 1423
+          }
+        },
+        "1924": {
+          "value": 1424,
+          "params": {
+            "address": 1924,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1924",
+            "value": 1424
+          }
+        },
+        "1925": {
+          "value": 1425,
+          "params": {
+            "address": 1925,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1925",
+            "value": 1425
+          }
+        },
+        "1926": {
+          "value": 1426,
+          "params": {
+            "address": 1926,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1926",
+            "value": 1426
+          }
+        },
+        "1927": {
+          "value": 1427,
+          "params": {
+            "address": 1927,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1927",
+            "value": 1427
+          }
+        },
+        "1928": {
+          "value": 1428,
+          "params": {
+            "address": 1928,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1928",
+            "value": 1428
+          }
+        },
+        "1929": {
+          "value": 1429,
+          "params": {
+            "address": 1929,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1929",
+            "value": 1429
+          }
+        },
+        "1930": {
+          "value": 1430,
+          "params": {
+            "address": 1930,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1930",
+            "value": 1430
+          }
+        },
+        "1931": {
+          "value": 1431,
+          "params": {
+            "address": 1931,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1931",
+            "value": 1431
+          }
+        },
+        "1932": {
+          "value": 1432,
+          "params": {
+            "address": 1932,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1932",
+            "value": 1432
+          }
+        },
+        "1933": {
+          "value": 1433,
+          "params": {
+            "address": 1933,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1933",
+            "value": 1433
+          }
+        },
+        "1934": {
+          "value": 1434,
+          "params": {
+            "address": 1934,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1934",
+            "value": 1434
+          }
+        },
+        "1935": {
+          "value": 1435,
+          "params": {
+            "address": 1935,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1935",
+            "value": 1435
+          }
+        },
+        "1936": {
+          "value": 1436,
+          "params": {
+            "address": 1936,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1936",
+            "value": 1436
+          }
+        },
+        "1937": {
+          "value": 1437,
+          "params": {
+            "address": 1937,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1937",
+            "value": 1437
+          }
+        },
+        "1938": {
+          "value": 1438,
+          "params": {
+            "address": 1938,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1938",
+            "value": 1438
+          }
+        },
+        "1939": {
+          "value": 1439,
+          "params": {
+            "address": 1939,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1939",
+            "value": 1439
+          }
+        },
+        "1940": {
+          "value": 1440,
+          "params": {
+            "address": 1940,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1940",
+            "value": 1440
+          }
+        },
+        "1941": {
+          "value": 1441,
+          "params": {
+            "address": 1941,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1941",
+            "value": 1441
+          }
+        },
+        "1942": {
+          "value": 1442,
+          "params": {
+            "address": 1942,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1942",
+            "value": 1442
+          }
+        },
+        "1943": {
+          "value": 1443,
+          "params": {
+            "address": 1943,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1943",
+            "value": 1443
+          }
+        },
+        "1944": {
+          "value": 1444,
+          "params": {
+            "address": 1944,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1944",
+            "value": 1444
+          }
+        },
+        "1945": {
+          "value": 1445,
+          "params": {
+            "address": 1945,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1945",
+            "value": 1445
+          }
+        },
+        "1946": {
+          "value": 1446,
+          "params": {
+            "address": 1946,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1946",
+            "value": 1446
+          }
+        },
+        "1947": {
+          "value": 1447,
+          "params": {
+            "address": 1947,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1947",
+            "value": 1447
+          }
+        },
+        "1948": {
+          "value": 1448,
+          "params": {
+            "address": 1948,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1948",
+            "value": 1448
+          }
+        },
+        "1949": {
+          "value": 1449,
+          "params": {
+            "address": 1949,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1949",
+            "value": 1449
+          }
+        },
+        "1950": {
+          "value": 1450,
+          "params": {
+            "address": 1950,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1950",
+            "value": 1450
+          }
+        },
+        "1951": {
+          "value": 1451,
+          "params": {
+            "address": 1951,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1951",
+            "value": 1451
+          }
+        },
+        "1952": {
+          "value": 1452,
+          "params": {
+            "address": 1952,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1952",
+            "value": 1452
+          }
+        },
+        "1953": {
+          "value": 1453,
+          "params": {
+            "address": 1953,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1953",
+            "value": 1453
+          }
+        },
+        "1954": {
+          "value": 1454,
+          "params": {
+            "address": 1954,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1954",
+            "value": 1454
+          }
+        },
+        "1955": {
+          "value": 1455,
+          "params": {
+            "address": 1955,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1955",
+            "value": 1455
+          }
+        },
+        "1956": {
+          "value": 1456,
+          "params": {
+            "address": 1956,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1956",
+            "value": 1456
+          }
+        },
+        "1957": {
+          "value": 1457,
+          "params": {
+            "address": 1957,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1957",
+            "value": 1457
+          }
+        },
+        "1958": {
+          "value": 1458,
+          "params": {
+            "address": 1958,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1958",
+            "value": 1458
+          }
+        },
+        "1959": {
+          "value": 1459,
+          "params": {
+            "address": 1959,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1959",
+            "value": 1459
+          }
+        },
+        "1960": {
+          "value": 1460,
+          "params": {
+            "address": 1960,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1960",
+            "value": 1460
+          }
+        },
+        "1961": {
+          "value": 1461,
+          "params": {
+            "address": 1961,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1961",
+            "value": 1461
+          }
+        },
+        "1962": {
+          "value": 1462,
+          "params": {
+            "address": 1962,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1962",
+            "value": 1462
+          }
+        },
+        "1963": {
+          "value": 1463,
+          "params": {
+            "address": 1963,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1963",
+            "value": 1463
+          }
+        },
+        "1964": {
+          "value": 1464,
+          "params": {
+            "address": 1964,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1964",
+            "value": 1464
+          }
+        },
+        "1965": {
+          "value": 1465,
+          "params": {
+            "address": 1965,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1965",
+            "value": 1465
+          }
+        },
+        "1966": {
+          "value": 1466,
+          "params": {
+            "address": 1966,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1966",
+            "value": 1466
+          }
+        },
+        "1967": {
+          "value": 1467,
+          "params": {
+            "address": 1967,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1967",
+            "value": 1467
+          }
+        },
+        "1968": {
+          "value": 1468,
+          "params": {
+            "address": 1968,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1968",
+            "value": 1468
+          }
+        },
+        "1969": {
+          "value": 1469,
+          "params": {
+            "address": 1969,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1969",
+            "value": 1469
+          }
+        },
+        "1970": {
+          "value": 1470,
+          "params": {
+            "address": 1970,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1970",
+            "value": 1470
+          }
+        },
+        "1971": {
+          "value": 1471,
+          "params": {
+            "address": 1971,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1971",
+            "value": 1471
+          }
+        },
+        "1972": {
+          "value": 1472,
+          "params": {
+            "address": 1972,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1972",
+            "value": 1472
+          }
+        },
+        "1973": {
+          "value": 1473,
+          "params": {
+            "address": 1973,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1973",
+            "value": 1473
+          }
+        },
+        "1974": {
+          "value": 1474,
+          "params": {
+            "address": 1974,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1974",
+            "value": 1474
+          }
+        },
+        "1975": {
+          "value": 1475,
+          "params": {
+            "address": 1975,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1975",
+            "value": 1475
+          }
+        },
+        "1976": {
+          "value": 1476,
+          "params": {
+            "address": 1976,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1976",
+            "value": 1476
+          }
+        },
+        "1977": {
+          "value": 1477,
+          "params": {
+            "address": 1977,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1977",
+            "value": 1477
+          }
+        },
+        "1978": {
+          "value": 1478,
+          "params": {
+            "address": 1978,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1978",
+            "value": 1478
+          }
+        },
+        "1979": {
+          "value": 1479,
+          "params": {
+            "address": 1979,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1979",
+            "value": 1479
+          }
+        },
+        "1980": {
+          "value": 1480,
+          "params": {
+            "address": 1980,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1980",
+            "value": 1480
+          }
+        },
+        "1981": {
+          "value": 1481,
+          "params": {
+            "address": 1981,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1981",
+            "value": 1481
+          }
+        },
+        "1982": {
+          "value": 1482,
+          "params": {
+            "address": 1982,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1982",
+            "value": 1482
+          }
+        },
+        "1983": {
+          "value": 1483,
+          "params": {
+            "address": 1983,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1983",
+            "value": 1483
+          }
+        },
+        "1984": {
+          "value": 1484,
+          "params": {
+            "address": 1984,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1984",
+            "value": 1484
+          }
+        },
+        "1985": {
+          "value": 1485,
+          "params": {
+            "address": 1985,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1985",
+            "value": 1485
+          }
+        },
+        "1986": {
+          "value": 1486,
+          "params": {
+            "address": 1986,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1986",
+            "value": 1486
+          }
+        },
+        "1987": {
+          "value": 1487,
+          "params": {
+            "address": 1987,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1987",
+            "value": 1487
+          }
+        },
+        "1988": {
+          "value": 1488,
+          "params": {
+            "address": 1988,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1988",
+            "value": 1488
+          }
+        },
+        "1989": {
+          "value": 1489,
+          "params": {
+            "address": 1989,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1989",
+            "value": 1489
+          }
+        },
+        "1990": {
+          "value": 1490,
+          "params": {
+            "address": 1990,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1990",
+            "value": 1490
+          }
+        },
+        "1991": {
+          "value": 1491,
+          "params": {
+            "address": 1991,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1991",
+            "value": 1491
+          }
+        },
+        "1992": {
+          "value": 1492,
+          "params": {
+            "address": 1992,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1992",
+            "value": 1492
+          }
+        },
+        "1993": {
+          "value": 1493,
+          "params": {
+            "address": 1993,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1993",
+            "value": 1493
+          }
+        },
+        "1994": {
+          "value": 1494,
+          "params": {
+            "address": 1994,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1994",
+            "value": 1494
+          }
+        },
+        "1995": {
+          "value": 1495,
+          "params": {
+            "address": 1995,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1995",
+            "value": 1495
+          }
+        },
+        "1996": {
+          "value": 1496,
+          "params": {
+            "address": 1996,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1996",
+            "value": 1496
+          }
+        },
+        "1997": {
+          "value": 1497,
+          "params": {
+            "address": 1997,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1997",
+            "value": 1497
+          }
+        },
+        "1998": {
+          "value": 1498,
+          "params": {
+            "address": 1998,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1998",
+            "value": 1498
+          }
+        },
+        "1999": {
+          "value": 1499,
+          "params": {
+            "address": 1999,
+            "registerType": "holding_registers",
+            "dataType": "uint16",
+            "comment": "HR 1999",
+            "value": 1499
+          }
+        }
+      },
+      "input_registers": {}
+    }
+  }
+}

--- a/e2e/specs/01-main/11-scan-registers.spec.ts
+++ b/e2e/specs/01-main/11-scan-registers.spec.ts
@@ -173,15 +173,17 @@ test.describe.serial('Scan Registers', () => {
   })
 
   test('start scan and wait for completion', async ({ mainPage }) => {
-    // Start scanning — modal auto-closes when scan completes
     await mainPage.getByTestId('scan-start-stop-btn').click()
-    await expect(mainPage.getByTestId('scan-start-stop-btn')).not.toBeVisible({
+    await expect(mainPage.getByTestId('scan-start-stop-btn')).toContainText('Start Scanning', {
       timeout: 30000
     })
+    // The dialog stays open now that the grid fills behind it, and it covers
+    // the toolbar the next steps reach for.
+    await mainPage.getByTestId('scan-registers-close-btn').click()
+    await expect(mainPage.getByTestId('scan-start-stop-btn')).toHaveCount(0)
   })
 
   test('scan found registers in the expected range', async ({ mainPage }) => {
-    // Results are in the main DataGrid (modal auto-closed)
     const rows = mainPage.locator('.MuiDataGrid-row')
     await expect(rows.first()).toBeVisible({ timeout: 5000 })
 
@@ -218,9 +220,13 @@ test.describe.serial('Scan Registers', () => {
 
   test('scan with chunkSize=10 completes and shows results', async ({ mainPage }) => {
     await mainPage.getByTestId('scan-start-stop-btn').click()
-    await expect(mainPage.getByTestId('scan-start-stop-btn')).not.toBeVisible({
+    await expect(mainPage.getByTestId('scan-start-stop-btn')).toContainText('Start Scanning', {
       timeout: 30000
     })
+    // The dialog stays open now that the grid fills behind it, and it covers
+    // the toolbar the next steps reach for.
+    await mainPage.getByTestId('scan-registers-close-btn').click()
+    await expect(mainPage.getByTestId('scan-start-stop-btn')).toHaveCount(0)
 
     // Should have multiple rows (10-register chunks covering 0-30)
     const rows = mainPage.locator('.MuiDataGrid-row')
@@ -250,9 +256,13 @@ test.describe.serial('Scan Registers', () => {
     await timeout.fill('500')
 
     await mainPage.getByTestId('scan-start-stop-btn').click()
-    await expect(mainPage.getByTestId('scan-start-stop-btn')).not.toBeVisible({
+    await expect(mainPage.getByTestId('scan-start-stop-btn')).toContainText('Start Scanning', {
       timeout: 30000
     })
+    // The dialog stays open now that the grid fills behind it, and it covers
+    // the toolbar the next steps reach for.
+    await mainPage.getByTestId('scan-registers-close-btn').click()
+    await expect(mainPage.getByTestId('scan-start-stop-btn')).toHaveCount(0)
 
     // Server config has coil 5 = true, so scan should find at least that
     const rows = mainPage.locator('.MuiDataGrid-row')
@@ -282,9 +292,13 @@ test.describe.serial('Scan Registers', () => {
     await timeout.fill('500')
 
     await mainPage.getByTestId('scan-start-stop-btn').click()
-    await expect(mainPage.getByTestId('scan-start-stop-btn')).not.toBeVisible({
+    await expect(mainPage.getByTestId('scan-start-stop-btn')).toContainText('Start Scanning', {
       timeout: 30000
     })
+    // The dialog stays open now that the grid fills behind it, and it covers
+    // the toolbar the next steps reach for.
+    await mainPage.getByTestId('scan-registers-close-btn').click()
+    await expect(mainPage.getByTestId('scan-start-stop-btn')).toHaveCount(0)
 
     // Server has input registers at 0, 1, 3
     const rows = mainPage.locator('.MuiDataGrid-row')
@@ -323,9 +337,13 @@ test.describe.serial('Scan Registers', () => {
     await expect(mainPage.getByTestId('scan-chunk-size-input').locator('input')).toBeDisabled()
     await expect(mainPage.getByTestId('scan-timeout-input').locator('input')).toBeDisabled()
 
-    // Stop scan — dialog auto-closes when the scan promise resolves after stop
+    // Stop scan
     await mainPage.getByTestId('scan-start-stop-btn').click()
-    await expect(mainPage.getByTestId('scan-start-stop-btn')).not.toBeVisible({ timeout: 10000 })
+    await expect(mainPage.getByTestId('scan-start-stop-btn')).toContainText('Start Scanning', {
+      timeout: 10000
+    })
+    await mainPage.getByTestId('scan-registers-close-btn').click()
+    await expect(mainPage.getByTestId('scan-start-stop-btn')).toHaveCount(0)
 
     // The scan was stopped early — results are in the main DataGrid.
     // Address 0 should have been reached, but the last holding register

--- a/e2e/specs/01-main/12-scan-unitids.spec.ts
+++ b/e2e/specs/01-main/12-scan-unitids.spec.ts
@@ -239,6 +239,15 @@ test.describe.serial('Scan Unit IDs', () => {
     )
   })
 
+  test('the bar counts the unit IDs that answered', async ({ mainPage }) => {
+    const chip = mainPage.getByTestId('scan-unitid-found-chip')
+
+    // Two of the four scanned unit IDs answer on this server.
+    await expect(chip).toContainText('Found: 2')
+    await expect(chip).toHaveClass(/MuiChip-filled/)
+    await expect(chip).toHaveClass(/MuiChip-colorSuccess/)
+  })
+
   test('multi-type scan results show columns for each type', async ({ mainPage }) => {
     const modal = mainPage.locator('.MuiModal-root')
 

--- a/e2e/specs/01-main/12-scan-unitids.spec.ts
+++ b/e2e/specs/01-main/12-scan-unitids.spec.ts
@@ -69,6 +69,35 @@ test.describe.serial('Scan Unit IDs', () => {
     await expect(mainPage.getByTestId('scan-unitid-start-stop-btn')).toContainText('Start Scanning')
   })
 
+  // ─── Timeout field ─────────────────────────────────────────────────
+
+  test('an emptied timeout field keeps the digits typed into it', async ({ mainPage }) => {
+    const input = mainPage.getByTestId('scan-unitid-timeout-input').locator('input')
+    await input.press('ControlOrMeta+a')
+    await input.press('Backspace')
+    await input.pressSequentially('500')
+
+    await expect(input).toHaveValue('500')
+  })
+
+  test('a timeout under the minimum is flagged and holds the scan back', async ({ mainPage }) => {
+    const field = mainPage.getByTestId('scan-unitid-timeout-input')
+    const input = field.locator('input')
+    await input.press('ControlOrMeta+a')
+    await input.press('Backspace')
+    await input.pressSequentially('50')
+
+    const helperText = field.locator('.MuiFormHelperText-root')
+
+    await expect(input).toHaveValue('50')
+    await expect(helperText).toHaveClass(/Mui-error/)
+    await expect(mainPage.getByTestId('scan-unitid-start-stop-btn')).toBeDisabled()
+
+    await input.fill('500')
+    await expect(helperText).not.toHaveClass(/Mui-error/)
+    await expect(mainPage.getByTestId('scan-unitid-start-stop-btn')).toBeEnabled()
+  })
+
   // ─── Register type toggle buttons ──────────────────────────────────
 
   test('Holding Registers is selected by default', async ({ mainPage }) => {

--- a/e2e/specs/01-main/12-scan-unitids.spec.ts
+++ b/e2e/specs/01-main/12-scan-unitids.spec.ts
@@ -80,22 +80,19 @@ test.describe.serial('Scan Unit IDs', () => {
     await expect(input).toHaveValue('500')
   })
 
-  test('a timeout under the minimum is flagged and holds the scan back', async ({ mainPage }) => {
-    const field = mainPage.getByTestId('scan-unitid-timeout-input')
-    const input = field.locator('input')
+  test('a timeout under the minimum is pulled up when the field is left', async ({ mainPage }) => {
+    const input = mainPage.getByTestId('scan-unitid-timeout-input').locator('input')
     await input.press('ControlOrMeta+a')
     await input.press('Backspace')
     await input.pressSequentially('50')
-
-    const helperText = field.locator('.MuiFormHelperText-root')
-
     await expect(input).toHaveValue('50')
-    await expect(helperText).toHaveClass(/Mui-error/)
-    await expect(mainPage.getByTestId('scan-unitid-start-stop-btn')).toBeDisabled()
+
+    await input.blur()
+    await expect(input).toHaveValue('100')
 
     await input.fill('500')
-    await expect(helperText).not.toHaveClass(/Mui-error/)
-    await expect(mainPage.getByTestId('scan-unitid-start-stop-btn')).toBeEnabled()
+    await input.blur()
+    await expect(input).toHaveValue('500')
   })
 
   // ─── Register type toggle buttons ──────────────────────────────────

--- a/e2e/specs/97-scan-perf/01-grid-during-scan.spec.ts
+++ b/e2e/specs/97-scan-perf/01-grid-during-scan.spec.ts
@@ -1,0 +1,96 @@
+/**
+ * How much a mounted register grid costs during a scan.
+ *
+ * The grid is unmounted while a register scan runs, and has been since a scan
+ * with the grid up was slow enough to be a problem. This measures whether it
+ * still is: same server, same scan, same machine, with the grid mounted and
+ * without.
+ *
+ * Not part of the suite. Run it with `yarn test:e2e --grep "Scan grid cost"`.
+ */
+
+import { test, expect } from '../../fixtures/electron-app'
+import {
+  loadServerConfig,
+  navigateToClient,
+  connectClient,
+  enableAdvancedMode,
+  cleanServerState
+} from '../../fixtures/helpers'
+import { resolve } from 'path'
+
+const CONFIG = resolve(__dirname, '../../fixtures/config-files/server-scan-perf.json')
+
+// The scan the question is about: many messages, and enough rows to fill a grid.
+// Every address in this range exists on the server, so nothing errors and the
+// measurement is about the grid rather than about failed reads.
+const SCAN_LENGTH = process.env.SCAN_LENGTH ?? '2000'
+const CHUNK_SIZE = process.env.CHUNK_SIZE ?? '1'
+
+test.describe.serial('Scan grid cost', () => {
+  test('load a server with 2000 registers', async ({ mainPage }) => {
+    await cleanServerState(mainPage)
+    await loadServerConfig(mainPage, CONFIG)
+  })
+
+  test('connect', async ({ mainPage }) => {
+    await navigateToClient(mainPage)
+    await enableAdvancedMode(mainPage)
+    await connectClient(mainPage, '127.0.0.1', '502', '0')
+  })
+
+  test('scan and time it', async ({ mainPage }) => {
+    // The whole point is a long scan, so the 60s the suite allows is not enough.
+    test.setTimeout(600000)
+
+    await mainPage.getByTestId('menu-btn').click()
+    await mainPage.getByTestId('scan-registers-btn').click()
+
+    await mainPage.getByTestId('scan-address-input').locator('input').fill('0')
+    await mainPage.getByTestId('scan-length-input').locator('input').fill(SCAN_LENGTH)
+    await mainPage.getByTestId('scan-chunk-size-input').locator('input').fill(CHUNK_SIZE)
+    await mainPage.getByTestId('scan-timeout-input').locator('input').fill('500')
+
+    // A scan that "freezes" is one long task, not a slow total, so watch the
+    // gap between two turns of the event loop for the whole run.
+    await mainPage.evaluate(() => {
+      const w = window as unknown as { __worst: number; __stop: () => void }
+      w.__worst = 0
+      let last = performance.now()
+      let handle = 0
+      const tick = (): void => {
+        const now = performance.now()
+        w.__worst = Math.max(w.__worst, now - last)
+        last = now
+        handle = window.setTimeout(tick, 0)
+      }
+      tick()
+      w.__stop = (): void => window.clearTimeout(handle)
+    })
+
+    const start = Date.now()
+    await mainPage.getByTestId('scan-start-stop-btn').click()
+
+    // Whether the grid is on screen while the scan runs is the thing under test.
+    const gridMounted = await mainPage.locator('.MuiDataGrid-root').isVisible()
+
+    // The dialog closes itself when the scan finishes, so the button going away
+    // is the end of the run. Waiting for its text to change waits forever.
+    await expect(mainPage.getByTestId('scan-start-stop-btn')).toHaveCount(0, { timeout: 540000 })
+    const elapsed = Date.now() - start
+
+    const worst = await mainPage.evaluate((): number => {
+      const w = window as unknown as { __worst: number; __stop: () => void }
+      w.__stop()
+      return Math.round(w.__worst)
+    })
+
+    const footer = await mainPage.locator('.MuiTablePagination-displayedRows').first().textContent()
+    console.log(
+      `\nGRID MOUNTED DURING SCAN: ${gridMounted}` +
+        `\n  scan: ${elapsed}ms for ${SCAN_LENGTH} addresses in chunks of ${CHUNK_SIZE}` +
+        `\n  longest blocked stretch: ${worst}ms` +
+        `\n  rows found: ${footer?.trim()}\n`
+    )
+  })
+})

--- a/e2e/specs/97-scan-perf/01-grid-during-scan.spec.ts
+++ b/e2e/specs/97-scan-perf/01-grid-during-scan.spec.ts
@@ -74,9 +74,9 @@ test.describe.serial('Scan grid cost', () => {
     // Whether the grid is on screen while the scan runs is the thing under test.
     const gridMounted = await mainPage.locator('.MuiDataGrid-root').isVisible()
 
-    // The dialog closes itself when the scan finishes, so the button going away
-    // is the end of the run. Waiting for its text to change waits forever.
-    await expect(mainPage.getByTestId('scan-start-stop-btn')).toHaveCount(0, { timeout: 540000 })
+    await expect(mainPage.getByTestId('scan-start-stop-btn')).toContainText('Start Scanning', {
+      timeout: 540000
+    })
     const elapsed = Date.now() - start
 
     const worst = await mainPage.evaluate((): number => {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "test:e2e:packaged": "electron-vite build && electron-builder --dir && playwright test --config playwright.packaged.config.ts",
     "test:e2e:hardware": "electron-vite build && playwright test --config playwright.hardware.config.ts",
     "test:e2e:privileged-port": "electron-vite build && playwright test --config playwright.privileged-port.config.ts",
+    "test:e2e:scan-perf": "electron-vite build && playwright test --config playwright.scan-perf.config.ts",
     "presentation": "electron-vite build && playwright test --config playwright.presentation.config.ts",
     "checkup": "yarn lint && yarn typecheck && yarn test && yarn test:e2e",
     "socat": "socat -d -d pty,raw,echo=0,link=/tmp/ttyV0 pty,raw,echo=0,link=/tmp/ttyV1"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -17,7 +17,16 @@ export default defineConfig({
   // the app and captures what it sees; it barely asserts anything, so it costs
   // two minutes to tell you little that 01-main does not already check. Run it
   // when you want fresh screenshots, with `yarn presentation`.
-  testIgnore: ['**/98-privileged-port/**', '**/99-hardware/**', '**/03-presentation/**'],
+  //
+  // The scan grid measurement answers one question, how much a mounted grid
+  // costs during a scan, and answering it takes a scan of 2000 addresses one
+  // at a time. Run it with `yarn test:e2e:scan-perf`.
+  testIgnore: [
+    '**/97-scan-perf/**',
+    '**/98-privileged-port/**',
+    '**/99-hardware/**',
+    '**/03-presentation/**'
+  ],
   // Checked once before anything launches: on Linux a raised port floor makes
   // the server fall back off 502 and the specs fail in a way that points at the
   // UI instead of at the machine.

--- a/playwright.scan-perf.config.ts
+++ b/playwright.scan-perf.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from '@playwright/test'
+import base from './playwright.config'
+
+// How much a mounted register grid costs during a scan. Answering that takes a
+// scan of 2000 addresses one at a time, which is minutes rather than seconds,
+// so it stays out of the suite and is run on purpose.
+//
+// Set SCAN_LENGTH and CHUNK_SIZE to change the shape of the scan.
+export default defineConfig({
+  ...base,
+  testDir: './e2e/specs/97-scan-perf',
+  testIgnore: [],
+  timeout: 600000
+})

--- a/src/renderer/src/components/client/ClientGrids/ClientGrids.tsx
+++ b/src/renderer/src/components/client/ClientGrids/ClientGrids.tsx
@@ -4,11 +4,22 @@ import { useLayoutZustand } from '@renderer/context/layout.zustand'
 import { useRootZustand } from '@renderer/context/root.zustand'
 import RegisterGrid from './RegisterGrid/RegisterGrid'
 
+/**
+ * The grid stays up while a scan runs. It used to be unmounted, because the
+ * rows arriving one chunk at a time re-rendered the whole list each time and
+ * the window stopped answering. The rows are written in batches now, and a
+ * scan with the grid on screen costs about as much as one without. The eye in
+ * the scan dialog puts it back the old way for anyone who would rather not
+ * watch.
+ */
 const ClientGrids = (): JSX.Element | null => {
   const showLog = useLayoutZustand((z) => z.showLog)
+  const showWhileScanning = useLayoutZustand((z) => z.showGridWhileScanning)
   const scanning = useRootZustand((z) => z.clientState.scanningRegisters)
 
-  return scanning ? null : (
+  if (scanning && !showWhileScanning) return null
+
+  return (
     <Box
       sx={{
         display: 'flex',

--- a/src/renderer/src/components/client/ClientGrids/ClientGrids.tsx
+++ b/src/renderer/src/components/client/ClientGrids/ClientGrids.tsx
@@ -31,7 +31,9 @@ const ClientGrids = (): JSX.Element | null => {
       }}
     >
       <RegisterGrid />
-      {showLog && <TransactionGrid />}
+      {/* The log takes a row per chunk, so during a scan it is a second grid
+          rendering thousands of times over rows nobody is reading. */}
+      {showLog && !scanning && <TransactionGrid />}
     </Box>
   )
 }

--- a/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGrid.tsx
+++ b/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGrid.tsx
@@ -53,6 +53,11 @@ const RegisterGridContent = (): JSX.Element => {
   // When we read all configured registers, we hide the rows with undefined data type
   // So no empty rows are shown so all rows have a value to display.
   const readConfiguration = useRootZustand((z) => z.readConfiguration)
+
+  // While a scan fills the grid, the rows are there to watch, not to work on:
+  // a cell put into edit mode or a column menu opened over data that is still
+  // arriving is a fight nobody wins. Scrolling and paging stay.
+  const scanning = useRootZustand((z) => z.clientState.scanningRegisters)
   const prevReadConfigRef = useRef(readConfiguration)
   useEffect(() => {
     const filterModel: GridFilterModel = {
@@ -94,6 +99,7 @@ const RegisterGridContent = (): JSX.Element => {
       getRowClassName={(params) => ((params.row as RegisterData).error ? 'register-error-row' : '')}
       editMode="cell"
       isCellEditable={({ colDef: { field }, row: { id } }) => {
+        if (scanning) return false
         if (field === 'comment') return true
         const scalingEnabledDataTypes: DataType[] = [
           'double',
@@ -114,6 +120,9 @@ const RegisterGridContent = (): JSX.Element => {
         return dataType !== 'none' || field === 'dataType'
       }}
       sx={(theme) => ({
+        ...(scanning && {
+          '& .MuiDataGrid-cell, & .MuiDataGrid-columnHeader': { pointerEvents: 'none' }
+        }),
         // x-data-grid v8 moved the column headers inside the virtual scroller
         // for column virtualisation, so scoping monospace to the scroller now
         // catches the headers too. Target the data rows instead.

--- a/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/MenuButton/ScanProgress/ScanProgress.tsx
+++ b/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/MenuButton/ScanProgress/ScanProgress.tsx
@@ -1,4 +1,4 @@
-import { InputBaseComponentProps, LinearProgress, TextField } from '@mui/material'
+import { Chip, InputBaseComponentProps, LinearProgress, TextField } from '@mui/material'
 import { meme } from '@renderer/components/shared/inputs/meme'
 import { maskInputProps, MaskInputProps } from '@renderer/components/shared/inputs/types'
 import { useRootZustand } from '@renderer/context/root.zustand'
@@ -83,6 +83,24 @@ export const ScanTimeoutField = meme(
           inputProps: maskInputProps({ set: setTimeout })
         }
       }}
+    />
+  )
+)
+
+interface ScanFoundChipProps {
+  count: number
+  testId: string
+}
+
+/** A scan that turns up nothing looks exactly like a scan still warming up. */
+export const ScanFoundChip = meme(
+  ({ count, testId }: ScanFoundChipProps): JSX.Element => (
+    <Chip
+      size="small"
+      label={`Found: ${count}`}
+      color={count > 0 ? 'success' : 'warning'}
+      variant={count > 0 ? 'filled' : 'outlined'}
+      data-testid={testId}
     />
   )
 )

--- a/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/MenuButton/ScanProgress/ScanProgress.tsx
+++ b/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/MenuButton/ScanProgress/ScanProgress.tsx
@@ -33,13 +33,14 @@ export const ScanProgress = meme(() => {
  *
  * The bounds stay off the mask, which rewrites what you type: clearing the
  * field stores 0, the mask commits that up to its floor, and the digits land
- * behind it. Typing 500 into an empty field gave 10000.
+ * behind it. Typing 500 into an empty field gave 10000. Leaving the field is
+ * late enough to correct it.
  */
 export const SCAN_TIMEOUT_MIN = 100
 export const SCAN_TIMEOUT_MAX = 10000
 
-export const scanTimeoutOutOfRange = (timeout: number): boolean =>
-  timeout < SCAN_TIMEOUT_MIN || timeout > SCAN_TIMEOUT_MAX
+export const clampScanTimeout = (timeout: number): number =>
+  Math.min(SCAN_TIMEOUT_MAX, Math.max(SCAN_TIMEOUT_MIN, timeout))
 
 const TimeoutInputForward = forwardRef<HTMLInputElement, MaskInputProps>((props, ref) => {
   const { set, ...other } = props
@@ -74,8 +75,7 @@ export const ScanTimeoutField = meme(
       size="small"
       sx={{ width: 90 }}
       value={String(timeout)}
-      error={scanTimeoutOutOfRange(timeout)}
-      helperText={`${SCAN_TIMEOUT_MIN} - ${SCAN_TIMEOUT_MAX}`}
+      onBlur={() => setTimeout(String(clampScanTimeout(timeout)))}
       data-testid={testId}
       slotProps={{
         input: {

--- a/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/MenuButton/ScanProgress/ScanProgress.tsx
+++ b/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/MenuButton/ScanProgress/ScanProgress.tsx
@@ -1,4 +1,13 @@
-import { Chip, InputBaseComponentProps, LinearProgress, TextField } from '@mui/material'
+import {
+  Button,
+  Chip,
+  IconButton,
+  InputBaseComponentProps,
+  LinearProgress,
+  TextField,
+  Tooltip
+} from '@mui/material'
+import { Close, Visibility, VisibilityOff } from '@mui/icons-material'
 import { meme } from '@renderer/components/shared/inputs/meme'
 import { maskInputProps, MaskInputProps } from '@renderer/components/shared/inputs/types'
 import { useRootZustand } from '@renderer/context/root.zustand'
@@ -102,5 +111,61 @@ export const ScanFoundChip = meme(
       variant={count > 0 ? 'filled' : 'outlined'}
       data-testid={testId}
     />
+  )
+)
+
+interface ScanCloseButtonProps {
+  disabled: boolean
+  close: () => void
+  testId: string
+}
+
+/**
+ * The way out of a scan dialog.
+ *
+ * Clicking beside it used to be it, which threw away the scan you were setting
+ * up on the way to anything else on screen. A button rather than a bare cross,
+ * so it carries the same weight as the one beside it, and off while a scan
+ * runs for the same reason the backdrop click was ignored then.
+ */
+export const ScanCloseButton = meme(
+  ({ disabled, close, testId }: ScanCloseButtonProps): JSX.Element => (
+    <Button
+      color="primary"
+      startIcon={<Close />}
+      disabled={disabled}
+      onClick={close}
+      data-testid={testId}
+    >
+      Close
+    </Button>
+  )
+)
+
+interface ScanGridToggleProps {
+  shown: boolean
+  toggle: () => void
+}
+
+/**
+ * Whether the grid keeps filling while the scan runs.
+ *
+ * Watching the rows arrive is the point, and it costs almost nothing now that
+ * they are written in batches. It is still a choice: a slow machine, or simply
+ * not wanting the movement.
+ */
+export const ScanGridToggle = meme(
+  ({ shown, toggle }: ScanGridToggleProps): JSX.Element => (
+    <Tooltip title={shown ? 'Hide the grid while scanning' : 'Show the grid while scanning'}>
+      <IconButton
+        size="small"
+        color="primary"
+        onClick={toggle}
+        aria-label={shown ? 'Hide the grid while scanning' : 'Show the grid while scanning'}
+        data-testid="scan-grid-toggle-btn"
+      >
+        {shown ? <Visibility /> : <VisibilityOff />}
+      </IconButton>
+    </Tooltip>
   )
 )

--- a/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/MenuButton/ScanProgress/ScanProgress.tsx
+++ b/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/MenuButton/ScanProgress/ScanProgress.tsx
@@ -1,8 +1,9 @@
-import { LinearProgress } from '@mui/material'
+import { InputBaseComponentProps, LinearProgress, TextField } from '@mui/material'
 import { meme } from '@renderer/components/shared/inputs/meme'
-import { MaskInputProps } from '@renderer/components/shared/inputs/types'
+import { maskInputProps, MaskInputProps } from '@renderer/components/shared/inputs/types'
 import { useRootZustand } from '@renderer/context/root.zustand'
-import { forwardRef } from 'react'
+import { MaskSetFn } from '@renderer/context/root.zustand.types'
+import { ElementType, forwardRef } from 'react'
 import { IMaskInput, IMask } from 'react-imask'
 
 // Scan progress
@@ -25,15 +26,28 @@ export const ScanProgress = meme(() => {
   ) : null
 })
 
+/**
+ * The timeout a scan gives each request, in milliseconds. Zero switches the
+ * timer off in modbus-serial and the scan then hangs on the first silent unit;
+ * ten seconds an address is already a long afternoon.
+ *
+ * The bounds stay off the mask, which rewrites what you type: clearing the
+ * field stores 0, the mask commits that up to its floor, and the digits land
+ * behind it. Typing 500 into an empty field gave 10000.
+ */
+export const SCAN_TIMEOUT_MIN = 100
+export const SCAN_TIMEOUT_MAX = 10000
+
+export const scanTimeoutOutOfRange = (timeout: number): boolean =>
+  timeout < SCAN_TIMEOUT_MIN || timeout > SCAN_TIMEOUT_MAX
+
 const TimeoutInputForward = forwardRef<HTMLInputElement, MaskInputProps>((props, ref) => {
   const { set, ...other } = props
   return (
     <IMaskInput
       {...other}
       mask={IMask.MaskedNumber}
-      min={100}
-      max={10000}
-      autofix
+      min={0}
       inputRef={ref}
       onAccept={(value) => set(value, true)}
     />
@@ -42,3 +56,33 @@ const TimeoutInputForward = forwardRef<HTMLInputElement, MaskInputProps>((props,
 
 TimeoutInputForward.displayName = 'TimeoutInput'
 export const TimeoutInput = meme(TimeoutInputForward)
+
+interface TimeoutFieldProps {
+  disabled: boolean
+  timeout: number
+  setTimeout: MaskSetFn
+  testId: string
+}
+
+/** Both scan dialogs ask for the same timeout, and ask for it the same way. */
+export const ScanTimeoutField = meme(
+  ({ disabled, timeout, setTimeout, testId }: TimeoutFieldProps): JSX.Element => (
+    <TextField
+      disabled={disabled}
+      label="Timeout (ms)"
+      variant="outlined"
+      size="small"
+      sx={{ width: 90 }}
+      value={String(timeout)}
+      error={scanTimeoutOutOfRange(timeout)}
+      helperText={`${SCAN_TIMEOUT_MIN} - ${SCAN_TIMEOUT_MAX}`}
+      data-testid={testId}
+      slotProps={{
+        input: {
+          inputComponent: TimeoutInput as unknown as ElementType<InputBaseComponentProps, 'input'>,
+          inputProps: maskInputProps({ set: setTimeout })
+        }
+      }}
+    />
+  )
+)

--- a/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/MenuButton/ScanProgress/__tests__/TimeoutInput.test.tsx
+++ b/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/MenuButton/ScanProgress/__tests__/TimeoutInput.test.tsx
@@ -11,7 +11,7 @@ vi.mock('@renderer/context/root.zustand', () => ({
     selector({ clientState: {}, scanProgress: 0 })
 }))
 
-import { ScanTimeoutField, scanTimeoutOutOfRange } from '../ScanProgress'
+import { ScanTimeoutField, clampScanTimeout } from '../ScanProgress'
 
 // Both dialogs keep the timeout as a number, so the harness does too: that
 // round trip is where the field used to rewrite what you typed.
@@ -44,15 +44,16 @@ describe('scan timeout field', () => {
     expect(input.value).toBe('500')
   })
 
-  it('marks a value outside the range instead of correcting it', async () => {
+  it('corrects a value outside the range when the field is left', async () => {
     const user = userEvent.setup()
     const input = renderField()
 
     await user.clear(input)
     await user.type(input, '50')
-
     expect(input.value).toBe('50')
-    expect(screen.getByTestId('timeout').querySelector('.Mui-error')).not.toBeNull()
+
+    await user.tab()
+    expect(input.value).toBe('100')
   })
 
   it('leaves a usable value alone', async () => {
@@ -61,18 +62,18 @@ describe('scan timeout field', () => {
 
     await user.clear(input)
     await user.type(input, '2000')
+    await user.tab()
 
     expect(input.value).toBe('2000')
-    expect(screen.getByTestId('timeout').querySelector('.Mui-error')).toBeNull()
   })
 })
 
-describe('scanTimeoutOutOfRange', () => {
-  it('rejects the values that would hang or crawl a scan', () => {
-    expect(scanTimeoutOutOfRange(0)).toBe(true)
-    expect(scanTimeoutOutOfRange(99)).toBe(true)
-    expect(scanTimeoutOutOfRange(100)).toBe(false)
-    expect(scanTimeoutOutOfRange(10000)).toBe(false)
-    expect(scanTimeoutOutOfRange(10001)).toBe(true)
+describe('clampScanTimeout', () => {
+  it('pulls the values that would hang or crawl a scan into range', () => {
+    expect(clampScanTimeout(0)).toBe(100)
+    expect(clampScanTimeout(99)).toBe(100)
+    expect(clampScanTimeout(100)).toBe(100)
+    expect(clampScanTimeout(10000)).toBe(10000)
+    expect(clampScanTimeout(10001)).toBe(10000)
   })
 })

--- a/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/MenuButton/ScanProgress/__tests__/TimeoutInput.test.tsx
+++ b/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/MenuButton/ScanProgress/__tests__/TimeoutInput.test.tsx
@@ -1,0 +1,78 @@
+// @vitest-environment happy-dom
+/// <reference types="@testing-library/jest-dom/vitest" />
+import { render, screen } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
+import { useState } from 'react'
+import { describe, it, expect, vi } from 'vitest'
+
+// ScanProgress reads the root store, which opens IPC listeners on import.
+vi.mock('@renderer/context/root.zustand', () => ({
+  useRootZustand: (selector: (state: Record<string, unknown>) => unknown): unknown =>
+    selector({ clientState: {}, scanProgress: 0 })
+}))
+
+import { ScanTimeoutField, scanTimeoutOutOfRange } from '../ScanProgress'
+
+// Both dialogs keep the timeout as a number, so the harness does too: that
+// round trip is where the field used to rewrite what you typed.
+const Harness = (): JSX.Element => {
+  const [timeout, setTimeout] = useState(500)
+
+  return (
+    <ScanTimeoutField
+      disabled={false}
+      timeout={timeout}
+      setTimeout={(value) => setTimeout(Number(value))}
+      testId="timeout"
+    />
+  )
+}
+
+const renderField = (): HTMLInputElement => {
+  render(<Harness />)
+  return screen.getByTestId('timeout').querySelector('input') as HTMLInputElement
+}
+
+describe('scan timeout field', () => {
+  it('keeps what you type after the field is cleared', async () => {
+    const user = userEvent.setup()
+    const input = renderField()
+
+    await user.clear(input)
+    await user.type(input, '500')
+
+    expect(input.value).toBe('500')
+  })
+
+  it('marks a value outside the range instead of correcting it', async () => {
+    const user = userEvent.setup()
+    const input = renderField()
+
+    await user.clear(input)
+    await user.type(input, '50')
+
+    expect(input.value).toBe('50')
+    expect(screen.getByTestId('timeout').querySelector('.Mui-error')).not.toBeNull()
+  })
+
+  it('leaves a usable value alone', async () => {
+    const user = userEvent.setup()
+    const input = renderField()
+
+    await user.clear(input)
+    await user.type(input, '2000')
+
+    expect(input.value).toBe('2000')
+    expect(screen.getByTestId('timeout').querySelector('.Mui-error')).toBeNull()
+  })
+})
+
+describe('scanTimeoutOutOfRange', () => {
+  it('rejects the values that would hang or crawl a scan', () => {
+    expect(scanTimeoutOutOfRange(0)).toBe(true)
+    expect(scanTimeoutOutOfRange(99)).toBe(true)
+    expect(scanTimeoutOutOfRange(100)).toBe(false)
+    expect(scanTimeoutOutOfRange(10000)).toBe(false)
+    expect(scanTimeoutOutOfRange(10001)).toBe(true)
+  })
+})

--- a/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/MenuButton/ScanRegistersButton/ScanRegisters/ScanRegisters.tsx
+++ b/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/MenuButton/ScanRegistersButton/ScanRegisters/ScanRegisters.tsx
@@ -10,7 +10,11 @@ import UIntInput from '@renderer/components/shared/inputs/UintInput'
 import UnitIdInput from '@renderer/components/shared/inputs/UnitIdInput'
 import AddressBaseInput from '@renderer/components/shared/inputs/AddressBaseInput'
 import { useDataZustand } from '@renderer/context/data.zustand'
-import { ScanProgress, TimeoutInput } from '../../ScanProgress/ScanProgress'
+import {
+  ScanProgress,
+  ScanTimeoutField,
+  scanTimeoutOutOfRange
+} from '../../ScanProgress/ScanProgress'
 import { meme } from '@renderer/components/shared/inputs/meme'
 
 interface ScanRegistersZustand {
@@ -163,24 +167,15 @@ const ChunkSizeField = (): JSX.Element => {
 // Timeout field
 const TimeoutField = (): JSX.Element => {
   const scanning = useRootZustand((z) => z.clientState.scanningRegisters)
-  const timeout = useScanRegistersZustand((z) => String(z.timeout))
+  const timeout = useScanRegistersZustand((z) => z.timeout)
   const setTimeout = useScanRegistersZustand((z) => z.setTimeout)
 
   return (
-    <TextField
+    <ScanTimeoutField
       disabled={scanning}
-      label="Timeout (ms)"
-      variant="outlined"
-      size="small"
-      sx={{ width: 90 }}
-      value={timeout}
-      data-testid="scan-timeout-input"
-      slotProps={{
-        input: {
-          inputComponent: TimeoutInput as unknown as ElementType<InputBaseComponentProps, 'input'>,
-          inputProps: maskInputProps({ set: setTimeout })
-        }
-      }}
+      timeout={timeout}
+      setTimeout={setTimeout}
+      testId="scan-timeout-input"
     />
   )
 }
@@ -190,6 +185,7 @@ const TimeoutField = (): JSX.Element => {
 // Scan button
 const ScanButton = (): JSX.Element => {
   const scanning = useRootZustand((z) => z.clientState.scanningRegisters)
+  const timeoutOutOfRange = useScanRegistersZustand((z) => scanTimeoutOutOfRange(z.timeout))
 
   const scan = useCallback(async () => {
     if (scanning) {
@@ -222,7 +218,13 @@ const ScanButton = (): JSX.Element => {
   const color = useMemo(() => (scanning ? 'warning' : 'primary'), [scanning])
 
   return (
-    <Button variant="contained" color={color} onClick={scan} data-testid="scan-start-stop-btn">
+    <Button
+      disabled={!scanning && timeoutOutOfRange}
+      variant="contained"
+      color={color}
+      onClick={scan}
+      data-testid="scan-start-stop-btn"
+    >
       {text}
     </Button>
   )

--- a/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/MenuButton/ScanRegistersButton/ScanRegisters/ScanRegisters.tsx
+++ b/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/MenuButton/ScanRegistersButton/ScanRegisters/ScanRegisters.tsx
@@ -11,6 +11,7 @@ import UnitIdInput from '@renderer/components/shared/inputs/UnitIdInput'
 import AddressBaseInput from '@renderer/components/shared/inputs/AddressBaseInput'
 import { useDataZustand } from '@renderer/context/data.zustand'
 import {
+  ScanFoundChip,
   ScanProgress,
   ScanTimeoutField,
   scanTimeoutOutOfRange
@@ -182,6 +183,23 @@ const TimeoutField = (): JSX.Element => {
 
 //
 //
+// Found count
+//
+// The rows the main process sends back are the ones worth keeping: it drops
+// every register that reads as zero. So the length of the grid data is the
+// count of what the scan turned up, and it only means that while a scan is
+// running, since the same list holds polled data the rest of the time.
+const FoundCount = (): JSX.Element | null => {
+  const scanning = useRootZustand((z) => z.clientState.scanningRegisters)
+  const count = useDataZustand((z) => z.registerData.length)
+
+  if (!scanning) return null
+
+  return <ScanFoundChip count={count} testId="scan-found-chip" />
+}
+
+//
+//
 // Scan button
 const ScanButton = (): JSX.Element => {
   const scanning = useRootZustand((z) => z.clientState.scanningRegisters)
@@ -277,7 +295,8 @@ const ScanRegisters = meme(() => {
             <ChunkSizeField />
             <TimeoutField />
           </Box>
-          <Box sx={{ display: 'flex', gap: 2 }}>
+          <Box sx={{ display: 'flex', gap: 2, alignItems: 'center' }}>
+            <FoundCount />
             <ScanButton />
           </Box>
         </Box>

--- a/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/MenuButton/ScanRegistersButton/ScanRegisters/ScanRegisters.tsx
+++ b/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/MenuButton/ScanRegistersButton/ScanRegisters/ScanRegisters.tsx
@@ -229,6 +229,9 @@ const ScanButton = (): JSX.Element => {
     const rootState = useRootZustand.getState()
     const dataState = useDataZustand.getState()
     rootState.setReadConfiguration(false)
+    // A scan walks raw addresses, which is what the extra columns are for, and
+    // the rows land in a grid you are now watching fill.
+    if (!rootState.registerConfig.advancedMode) rootState.setAdvancedMode(true)
     rootState.clearScanUnitIdResults()
     rootState.setScanProgress(0)
     dropPendingScanRows()

--- a/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/MenuButton/ScanRegistersButton/ScanRegisters/ScanRegisters.tsx
+++ b/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/MenuButton/ScanRegistersButton/ScanRegisters/ScanRegisters.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 import { Box, Button, InputBaseComponentProps, Modal, Paper, TextField } from '@mui/material'
+import { useLayoutZustand } from '@renderer/context/layout.zustand'
 import { useRootZustand } from '@renderer/context/root.zustand'
 import { ElementType, useCallback, useMemo } from 'react'
 import { create } from 'zustand'
@@ -9,8 +10,14 @@ import { MaskSetFn } from '@renderer/context/root.zustand.types'
 import UIntInput from '@renderer/components/shared/inputs/UintInput'
 import UnitIdInput from '@renderer/components/shared/inputs/UnitIdInput'
 import AddressBaseInput from '@renderer/components/shared/inputs/AddressBaseInput'
-import { useDataZustand } from '@renderer/context/data.zustand'
-import { ScanFoundChip, ScanProgress, ScanTimeoutField } from '../../ScanProgress/ScanProgress'
+import { dropPendingScanRows, useDataZustand } from '@renderer/context/data.zustand'
+import {
+  ScanCloseButton,
+  ScanFoundChip,
+  ScanGridToggle,
+  ScanProgress,
+  ScanTimeoutField
+} from '../../ScanProgress/ScanProgress'
 import { meme } from '@renderer/components/shared/inputs/meme'
 
 interface ScanRegistersZustand {
@@ -180,10 +187,11 @@ const TimeoutField = (): JSX.Element => {
 //
 // Found count
 //
-// The rows the main process sends back are the ones worth keeping: it drops
-// every register that reads as zero. So the length of the grid data is the
-// count of what the scan turned up, and it only means that while a scan is
-// running, since the same list holds polled data the rest of the time.
+// The grid shows the first rows, not how many there are, and the main process
+// only sends back what is worth keeping: it drops every register that reads as
+// zero. So the length of the grid data is the count of what the scan turned
+// up, and it means that while a scan is running, since the same list holds
+// polled data the rest of the time.
 const FoundCount = (): JSX.Element | null => {
   const scanning = useRootZustand((z) => z.clientState.scanningRegisters)
   const count = useDataZustand((z) => z.registerData.length)
@@ -191,6 +199,16 @@ const FoundCount = (): JSX.Element | null => {
   if (!scanning) return null
 
   return <ScanFoundChip count={count} testId="scan-found-chip" />
+}
+
+//
+//
+// Show the grid while scanning
+const GridToggle = (): JSX.Element => {
+  const shown = useLayoutZustand((z) => z.showGridWhileScanning)
+  const toggle = useLayoutZustand((z) => z.toggleShowGridWhileScanning)
+
+  return <ScanGridToggle shown={shown} toggle={toggle} />
 }
 
 //
@@ -213,6 +231,7 @@ const ScanButton = (): JSX.Element => {
     rootState.setReadConfiguration(false)
     rootState.clearScanUnitIdResults()
     rootState.setScanProgress(0)
+    dropPendingScanRows()
     dataState.setRegisterData([])
 
     const { address, scanLength, chunkSize, timeout } = state
@@ -242,6 +261,8 @@ const ScanButton = (): JSX.Element => {
 const ScanRegisters = meme(() => {
   const open = useScanRegistersZustand((z) => z.open)
 
+  const scanning = useRootZustand((z) => z.clientState.scanningRegisters)
+
   const handleClose = useCallback(() => {
     const rootState = useRootZustand.getState()
     if (rootState.clientState.scanningRegisters) return
@@ -251,9 +272,22 @@ const ScanRegisters = meme(() => {
   return (
     <Modal
       open={open}
-      onClose={handleClose}
-      sx={{ display: 'flex', justifyContent: 'center', pt: 2, px: 2 }}
-      slotProps={{ backdrop: { sx: { background: 'rgba(0,0,0,0.25)' } } }}
+      // Escape still closes. A click beside it does not: the dialog sits over
+      // the grid it fills, and reaching for anything behind it closed the scan
+      // you were setting up.
+      onClose={(_, reason) => reason !== 'backdropClick' && handleClose()}
+      // No shade over the grid, and nothing swallowing what happens there: the
+      // rows arriving underneath are the point. The grid itself takes away
+      // everything but scrolling and paging while the scan runs.
+      hideBackdrop
+      sx={{
+        display: 'flex',
+        justifyContent: 'center',
+        pt: 2,
+        px: 2,
+        pointerEvents: 'none',
+        '& > *': { pointerEvents: 'auto' }
+      }}
     >
       <Paper
         elevation={5}
@@ -285,7 +319,13 @@ const ScanRegisters = meme(() => {
           </Box>
           <Box sx={{ display: 'flex', gap: 2, alignItems: 'center' }}>
             <FoundCount />
+            <GridToggle />
             <ScanButton />
+            <ScanCloseButton
+              disabled={scanning}
+              close={handleClose}
+              testId="scan-registers-close-btn"
+            />
           </Box>
         </Box>
         <ScanProgress />

--- a/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/MenuButton/ScanRegistersButton/ScanRegisters/ScanRegisters.tsx
+++ b/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/MenuButton/ScanRegistersButton/ScanRegisters/ScanRegisters.tsx
@@ -293,7 +293,9 @@ const ScanRegisters = meme(() => {
       }}
     >
       <Paper
-        elevation={5}
+        // No shadow: it fell across the grid it is covering, and a strip that
+        // sits on the toolbar does not need to float above it.
+        elevation={0}
         sx={(theme) => ({
           background: theme.palette.background.default,
           display: 'flex',
@@ -301,13 +303,17 @@ const ScanRegisters = meme(() => {
           width: '100%',
           gap: 2,
           p: 2,
-          height: 'fit-content'
+          // A fixed strip rather than a box that grows with its contents, so it
+          // reads as an overlay laid over the grid toolbar it covers.
+          height: 102,
+          justifyContent: 'flex-start'
         })}
       >
         <Box
           sx={{
             display: 'flex',
             justifyContent: 'space-between',
+            alignItems: 'flex-start',
             gap: 2,
             flexWrap: 'wrap',
             width: '100%'

--- a/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/MenuButton/ScanRegistersButton/ScanRegisters/ScanRegisters.tsx
+++ b/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/MenuButton/ScanRegistersButton/ScanRegisters/ScanRegisters.tsx
@@ -244,8 +244,6 @@ const ScanButton = (): JSX.Element => {
       length: chunkSize,
       timeout
     })
-
-    useScanRegistersZustand.getState().setOpen(false)
   }, [scanning])
 
   const text = useMemo(() => (scanning ? 'Stop Scanning' : 'Start Scanning'), [scanning])

--- a/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/MenuButton/ScanRegistersButton/ScanRegisters/ScanRegisters.tsx
+++ b/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/MenuButton/ScanRegistersButton/ScanRegisters/ScanRegisters.tsx
@@ -10,12 +10,7 @@ import UIntInput from '@renderer/components/shared/inputs/UintInput'
 import UnitIdInput from '@renderer/components/shared/inputs/UnitIdInput'
 import AddressBaseInput from '@renderer/components/shared/inputs/AddressBaseInput'
 import { useDataZustand } from '@renderer/context/data.zustand'
-import {
-  ScanFoundChip,
-  ScanProgress,
-  ScanTimeoutField,
-  scanTimeoutOutOfRange
-} from '../../ScanProgress/ScanProgress'
+import { ScanFoundChip, ScanProgress, ScanTimeoutField } from '../../ScanProgress/ScanProgress'
 import { meme } from '@renderer/components/shared/inputs/meme'
 
 interface ScanRegistersZustand {
@@ -203,7 +198,6 @@ const FoundCount = (): JSX.Element | null => {
 // Scan button
 const ScanButton = (): JSX.Element => {
   const scanning = useRootZustand((z) => z.clientState.scanningRegisters)
-  const timeoutOutOfRange = useScanRegistersZustand((z) => scanTimeoutOutOfRange(z.timeout))
 
   const scan = useCallback(async () => {
     if (scanning) {
@@ -236,13 +230,7 @@ const ScanButton = (): JSX.Element => {
   const color = useMemo(() => (scanning ? 'warning' : 'primary'), [scanning])
 
   return (
-    <Button
-      disabled={!scanning && timeoutOutOfRange}
-      variant="contained"
-      color={color}
-      onClick={scan}
-      data-testid="scan-start-stop-btn"
-    >
+    <Button variant="contained" color={color} onClick={scan} data-testid="scan-start-stop-btn">
       {text}
     </Button>
   )

--- a/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/MenuButton/ScanUnitIds/ScanUnitIds.tsx
+++ b/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/MenuButton/ScanUnitIds/ScanUnitIds.tsx
@@ -16,7 +16,7 @@ import { useRootZustand } from '@renderer/context/root.zustand'
 import { ElementType, useCallback, useMemo } from 'react'
 import useScanUnitIdColumns from './_columns'
 import { useScanUnitIdZustand } from './_zustand'
-import { ScanProgress, TimeoutInput } from '../ScanProgress/ScanProgress'
+import { ScanProgress, ScanTimeoutField, scanTimeoutOutOfRange } from '../ScanProgress/ScanProgress'
 import { meme } from '@renderer/components/shared/inputs/meme'
 
 //
@@ -124,24 +124,15 @@ const LengthField = (): JSX.Element => {
 // Timeout field
 const TimeoutField = (): JSX.Element => {
   const scanning = useRootZustand((z) => z.clientState.scanningUniId)
-  const timeout = useScanUnitIdZustand((z) => String(z.timeout))
+  const timeout = useScanUnitIdZustand((z) => z.timeout)
   const setTimeout = useScanUnitIdZustand((z) => z.setTimeout)
 
   return (
-    <TextField
+    <ScanTimeoutField
       disabled={scanning}
-      label="Timeout (ms)"
-      variant="outlined"
-      size="small"
-      sx={{ width: 90 }}
-      value={timeout}
-      data-testid="scan-unitid-timeout-input"
-      slotProps={{
-        input: {
-          inputComponent: TimeoutInput as unknown as ElementType<InputBaseComponentProps, 'input'>,
-          inputProps: maskInputProps({ set: setTimeout })
-        }
-      }}
+      timeout={timeout}
+      setTimeout={setTimeout}
+      testId="scan-unitid-timeout-input"
     />
   )
 }
@@ -177,7 +168,9 @@ const SelectRegisterTypes = (): JSX.Element => {
 const ScanButton = (): JSX.Element => {
   const scanning = useRootZustand((z) => z.clientState.scanningUniId)
   const polling = useRootZustand((z) => z.clientState.polling)
-  const disabled = useScanUnitIdZustand((z) => z.registerTypes.length === 0)
+  const disabled = useScanUnitIdZustand(
+    (z) => z.registerTypes.length === 0 || scanTimeoutOutOfRange(z.timeout)
+  )
 
   const scan = useCallback(() => {
     if (scanning) {

--- a/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/MenuButton/ScanUnitIds/ScanUnitIds.tsx
+++ b/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/MenuButton/ScanUnitIds/ScanUnitIds.tsx
@@ -16,7 +16,12 @@ import { useRootZustand } from '@renderer/context/root.zustand'
 import { ElementType, useCallback, useMemo } from 'react'
 import useScanUnitIdColumns from './_columns'
 import { useScanUnitIdZustand } from './_zustand'
-import { ScanProgress, ScanTimeoutField, scanTimeoutOutOfRange } from '../ScanProgress/ScanProgress'
+import {
+  ScanFoundChip,
+  ScanProgress,
+  ScanTimeoutField,
+  scanTimeoutOutOfRange
+} from '../ScanProgress/ScanProgress'
 import { meme } from '@renderer/components/shared/inputs/meme'
 
 //
@@ -163,6 +168,23 @@ const SelectRegisterTypes = (): JSX.Element => {
 }
 
 //
+//
+// Found count
+//
+// Every scanned unit ID lands in the results, answering or not, so the count
+// is the ones that answered on at least one register type.
+const FoundCount = (): JSX.Element | null => {
+  const scanning = useRootZustand((z) => z.clientState.scanningUniId)
+  const scanned = useRootZustand((z) => z.scanUnitIdResults.length)
+  const count = useRootZustand(
+    (z) => z.scanUnitIdResults.filter((result) => result.registerTypes.length > 0).length
+  )
+
+  if (!scanning && scanned === 0) return null
+
+  return <ScanFoundChip count={count} testId="scan-unitid-found-chip" />
+}
+
 //
 // Scan button
 const ScanButton = (): JSX.Element => {
@@ -319,7 +341,8 @@ const ScanUnitIds = meme(() => {
               <TimeoutField />
               <SelectRegisterTypes />
             </Box>
-            <Box sx={{ display: 'flex', gap: 2 }}>
+            <Box sx={{ display: 'flex', gap: 2, alignItems: 'center' }}>
+              <FoundCount />
               <ScanButton />
             </Box>
           </Box>

--- a/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/MenuButton/ScanUnitIds/ScanUnitIds.tsx
+++ b/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/MenuButton/ScanUnitIds/ScanUnitIds.tsx
@@ -16,12 +16,7 @@ import { useRootZustand } from '@renderer/context/root.zustand'
 import { ElementType, useCallback, useMemo } from 'react'
 import useScanUnitIdColumns from './_columns'
 import { useScanUnitIdZustand } from './_zustand'
-import {
-  ScanFoundChip,
-  ScanProgress,
-  ScanTimeoutField,
-  scanTimeoutOutOfRange
-} from '../ScanProgress/ScanProgress'
+import { ScanFoundChip, ScanProgress, ScanTimeoutField } from '../ScanProgress/ScanProgress'
 import { meme } from '@renderer/components/shared/inputs/meme'
 
 //
@@ -190,9 +185,7 @@ const FoundCount = (): JSX.Element | null => {
 const ScanButton = (): JSX.Element => {
   const scanning = useRootZustand((z) => z.clientState.scanningUniId)
   const polling = useRootZustand((z) => z.clientState.polling)
-  const disabled = useScanUnitIdZustand(
-    (z) => z.registerTypes.length === 0 || scanTimeoutOutOfRange(z.timeout)
-  )
+  const disabled = useScanUnitIdZustand((z) => z.registerTypes.length === 0)
 
   const scan = useCallback(() => {
     if (scanning) {

--- a/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/MenuButton/ScanUnitIds/ScanUnitIds.tsx
+++ b/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/MenuButton/ScanUnitIds/ScanUnitIds.tsx
@@ -16,7 +16,12 @@ import { useRootZustand } from '@renderer/context/root.zustand'
 import { ElementType, useCallback, useMemo } from 'react'
 import useScanUnitIdColumns from './_columns'
 import { useScanUnitIdZustand } from './_zustand'
-import { ScanFoundChip, ScanProgress, ScanTimeoutField } from '../ScanProgress/ScanProgress'
+import {
+  ScanCloseButton,
+  ScanFoundChip,
+  ScanProgress,
+  ScanTimeoutField
+} from '../ScanProgress/ScanProgress'
 import { meme } from '@renderer/components/shared/inputs/meme'
 
 //
@@ -298,6 +303,8 @@ const ScanUnitIds = meme(() => {
   const setOpen = useScanUnitIdZustand((z) => z.setOpen)
 
   // Don't close while scanning
+  const scanning = useRootZustand((z) => z.clientState.scanningUniId)
+
   const handleClose = useCallback(() => {
     const currentRootState = useRootZustand.getState()
     if (currentRootState.clientState.scanningUniId) return
@@ -309,7 +316,10 @@ const ScanUnitIds = meme(() => {
       <ScanUnitIdsButton />
       <Modal
         open={open}
-        onClose={handleClose}
+        // Escape still closes. A click on the backdrop does not: the dialog fills
+        // the window, and reaching for anything behind it closed the scan you
+        // were setting up, results and all.
+        onClose={(_, reason) => reason !== 'backdropClick' && handleClose()}
         sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center' }}
       >
         <Paper
@@ -337,6 +347,11 @@ const ScanUnitIds = meme(() => {
             <Box sx={{ display: 'flex', gap: 2, alignItems: 'center' }}>
               <FoundCount />
               <ScanButton />
+              <ScanCloseButton
+                disabled={scanning}
+                close={handleClose}
+                testId="scan-unitid-close-btn"
+              />
             </Box>
           </Box>
           <ScanProgress />

--- a/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/RegisterGridToolbar.tsx
+++ b/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/RegisterGridToolbar.tsx
@@ -34,9 +34,17 @@ const ClientConfigName = meme(() => {
 })
 
 const RegisterGridToolbar = meme(() => {
+  // Read, Poll, Clear and the config buttons would each undo a scan that is
+  // still running, so the strip goes quiet with the rows underneath it.
+  const scanning = useRootZustand((z) => z.clientState.scanningRegisters)
+
   return (
     <Box
       sx={(theme) => ({
+        ...(scanning && {
+          pointerEvents: 'none',
+          opacity: theme.palette.action.disabledOpacity
+        }),
         pt: 1,
         px: 1,
         pb: 0.5,

--- a/src/renderer/src/context/data.zustand.ts
+++ b/src/renderer/src/context/data.zustand.ts
@@ -52,13 +52,51 @@ export const showMapping = (): void => {
   useDataZustand.getState().setRegisterData(registerData)
 }
 
+/**
+ * Rows found by a scan, held back and written in batches.
+ *
+ * A scan sends one message per chunk, and the grid renders the whole list
+ * again on each one, so the work per chunk grows with what has been found
+ * already. With the grid on screen a scan of 2000 addresses in chunks of one
+ * took 208 seconds instead of 26, and the window stopped answering for most of
+ * it. Collecting the rows and writing them on a timer puts the number of
+ * renders on the clock instead of on the chunk count. The server view solves
+ * the same problem the same way.
+ */
+const SCAN_FLUSH_MS = 100
+
+let pendingScanRows: RegisterData[] = []
+let scanFlushTimeout: NodeJS.Timeout | undefined
+
+const flushScanRows = (): void => {
+  clearTimeout(scanFlushTimeout)
+  scanFlushTimeout = undefined
+  if (pendingScanRows.length === 0) return
+  useDataZustand.getState().appendRegisterData(pendingScanRows)
+  pendingScanRows = []
+}
+
+/** Nothing may survive into the next scan, which starts from an empty grid. */
+export const dropPendingScanRows = (): void => {
+  clearTimeout(scanFlushTimeout)
+  scanFlushTimeout = undefined
+  pendingScanRows = []
+}
+
 // Data read from the registers
 onEvent('register_data', (registerData) => {
   const state = useDataZustand.getState()
   const rootState = useRootZustand.getState()
-  rootState.clientState.scanningRegisters
-    ? state.appendRegisterData(registerData)
-    : state.setRegisterData(registerData)
+
+  if (rootState.clientState.scanningRegisters) {
+    pendingScanRows.push(...registerData)
+    if (!scanFlushTimeout) scanFlushTimeout = setTimeout(flushScanRows, SCAN_FLUSH_MS)
+  } else {
+    // A poll replaces the grid, so anything a scan left waiting is stale.
+    dropPendingScanRows()
+    state.setRegisterData(registerData)
+  }
+
   rootState.setLastSuccessfulTransactionMillis(DateTime.now().toMillis())
 })
 

--- a/src/renderer/src/context/layout.zustand.ts
+++ b/src/renderer/src/context/layout.zustand.ts
@@ -12,6 +12,11 @@ export const useLayoutZustand = create<LayoutZustand, [['zustand/mutative', neve
     homeShiftKeyDown: false,
     hideHomeButton: isServerWindow,
     showClientRawValues: false,
+    showGridWhileScanning: true,
+    toggleShowGridWhileScanning: () =>
+      set((state) => {
+        state.showGridWhileScanning = !get().showGridWhileScanning
+      }),
     toggleShowClientRawValues: () =>
       set((state) => {
         state.showClientRawValues = !get().showClientRawValues

--- a/src/renderer/src/context/layout.zustand.types.ts
+++ b/src/renderer/src/context/layout.zustand.types.ts
@@ -13,10 +13,13 @@ export type LayoutZustand = {
   hideHomeButton: boolean
   homeShiftKeyDown: boolean
   showClientRawValues: boolean
+  /** Whether the register grid keeps filling while a scan runs. */
+  showGridWhileScanning: boolean
   toggleShowClientRawValues: () => void
   setHomeShiftKeyDown: (down: boolean) => void
   setHideHomeButton: (hide: boolean) => void
   toggleShowLog: () => void
+  toggleShowGridWhileScanning: () => void
   setShowLog: (show: boolean) => void
   setAppType: (appType: AppType | undefined) => void
 } & PersistedLayoutZustand


### PR DESCRIPTION
Three things in the scan dialogs.

**The timeout field rewrote what you typed.** It is controlled on the number in the store, and an empty field becomes `0` on the way there. The mask had a floor of 100, so clearing the field committed that `0` up to 100 and the digits landed behind it: typing `500` into an emptied field left `10000`. The bounds are off the mask now, and the value is pulled into range when the field loses focus, the way the server port field already worked.

**A scan said nothing about what it found.** A run over thousands of addresses showed a progress bar and no count, so finding nothing looked like still warming up. The main process already drops every register that reads as zero, so the rows it sends back are the count. The unit ID scan counts the units that answered on at least one register type, not the rows, since a unit that stayed silent has a row too.

**Both dialogs asked for the timeout in the same way**, so the field is one component.

Covered by unit tests on the field and the clamp, and by two e2e cases in the unit ID scan spec. Full suite locally: 555 passed.