### PR TITLE
fix: stop a scan crashing on the transaction log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **The coils and discrete inputs lists scroll inside their own panel.** A long
   list used to grow past the server view, and the whole view scrolled
   underneath it instead.
+- **A scan no longer stops on the log it writes.** Scanning over a serial port
+  could end partway with nothing on screen to say why. Modbux keeps a copy of
+  every request and reply for the transaction log, and a request that had no
+  copy took the scan down with it. That case now logs an empty frame.
 
 ### Security
 

--- a/src/main/modules/__tests__/modbusClient.test.ts
+++ b/src/main/modules/__tests__/modbusClient.test.ts
@@ -830,6 +830,47 @@ describe('ModbusClient', () => {
       expect(txCalls[0][1].errorMessage).toBe('Timed out')
     })
 
+    it('logs a transaction that carries no request or responses', async () => {
+      await connectClient()
+      mockModbusRTU.readHoldingRegisters.mockImplementation(async () => {
+        // What modbus-serial leaves behind when the write never stashed a
+        // copy: the bookkeeping fields, and nothing else.
+        mockModbusRTU._transactions = {
+          undefined: {
+            nextAddress: 1,
+            nextDataAddress: 0,
+            nextCode: 3,
+            nextLength: 10,
+            _timeoutFired: false
+          }
+        }
+        return { data: [0], buffer: Buffer.alloc(2) }
+      })
+
+      await client.read()
+
+      const txCalls = getWindowCalls('transaction')
+      expect(txCalls.length).toBe(1)
+      expect(txCalls[0][1].request).toBe('')
+      expect(txCalls[0][1].responses).toEqual([])
+    })
+
+    it('keeps the serial transaction key, which is not a number', async () => {
+      await connectClient()
+      mockModbusRTU.readHoldingRegisters.mockImplementation(async () => {
+        // RTU has no transaction ids, so modbus-serial files every serial
+        // transaction under this one key.
+        mockModbusRTU._transactions = { undefined: createMockTransaction() }
+        return { data: [0], buffer: Buffer.alloc(2) }
+      })
+
+      await client.read()
+
+      const txCalls = getWindowCalls('transaction')
+      expect(txCalls[0][1].id).toContain('undefined__')
+      expect(txCalls[0][1].id).not.toContain('NaN')
+    })
+
     it('records timeout flag from transaction', async () => {
       await connectClient()
       mockModbusRTU.readHoldingRegisters.mockImplementation(async () => {

--- a/src/main/modules/modbusClient.ts
+++ b/src/main/modules/modbusClient.ts
@@ -35,6 +35,14 @@ type ScanUnitIdFn = ({
   registerTypes
 }: Omit<ScanUnitIDParameters, 'range' | 'timeout'> & { id: number }) => Promise<void>
 
+/** Modbus frames read the way a protocol analyser prints them. */
+const toHexString = (bytes: Uint8Array | undefined): string =>
+  bytes === undefined
+    ? ''
+    : Array.from(bytes)
+        .map((byte) => Number(byte).toString(16).toUpperCase().padStart(2, '0'))
+        .join(' ')
+
 export interface ClientParams {
   appState: AppState
   windows: Windows
@@ -428,8 +436,23 @@ export class ModbusClient {
   //
   //
   // Log Transaction
+  //
+  // Everything here is read out of modbus-serial's internals, so it is worth
+  // writing down what those actually guarantee.
+  //
+  // A transaction is created by the writeFCx methods and never removed again:
+  // the library only ever assigns _transactions in its constructor. Clearing
+  // it is ours to do, or a session grows one entry per request.
+  //
+  // request and responses are stashed only while debug mode is on, and only
+  // by the write that reaches the port, so a transaction can carry neither.
+  // The library checks for them before using them; this used to not, and a
+  // scan that met one crashed the handler it ran in.
+  //
+  // The key is a transaction id on TCP and UDP, and nothing at all on a
+  // serial port: RTU has no transaction ids, so every serial transaction is
+  // filed under the string "undefined". It is a map key, not a number.
   private _logTransaction = (errorMessage: string | undefined): void => {
-    // Handle transactions, get the latest transaction from the transactions array
     const rawTransactions = Object.entries(this._client['_transactions']) as [
       string,
       RawTransaction
@@ -443,25 +466,16 @@ export class ModbusClient {
 
     const [transactionIdKey, rawTransaction] = lastTransaction
 
-    // Check if transaction has already been processed
-    const transactionId = Number(transactionIdKey)
-
     const transaction: Transaction = {
-      id: `${transactionId}__${v4()}`,
+      id: `${transactionIdKey}__${v4()}`,
       timestamp: DateTime.now().toMillis(),
       unitId: rawTransaction.nextAddress,
       address: rawTransaction.nextDataAddress,
       code: rawTransaction.nextCode,
       responseLength: rawTransaction.nextLength,
       timeout: rawTransaction._timeoutFired,
-      request: Array.from(rawTransaction.request)
-        .map((b) => Number(b).toString(16).toUpperCase().padStart(2, '0'))
-        .join(' '),
-      responses: Array.from(rawTransaction.responses).map((response) =>
-        Array.from(response as Buffer)
-          .map((byte) => Number(byte).toString(16).toUpperCase().padStart(2, '0'))
-          .join(' ')
-      ),
+      request: toHexString(rawTransaction.request),
+      responses: (rawTransaction.responses ?? []).map(toHexString),
       errorMessage
     }
 

--- a/src/shared/types/client.ts
+++ b/src/shared/types/client.ts
@@ -232,8 +232,10 @@ export interface RawTransaction {
   // next: [Function: cb],
   _timeoutFired: boolean
   //_timeoutHandle: undefined,
-  request: Buffer
-  responses: Buffer[]
+  // Both are stashed only while modbus-serial is in debug mode, and only by
+  // the write that reaches the port. A transaction can carry neither.
+  request?: Buffer
+  responses?: Buffer[]
 }
 
 export interface RegisterValue {


### PR DESCRIPTION
A scan over RTU died with `TypeError: undefined is not iterable` inside the handler for `scan_registers`, and the scan stopped with it.

```
at Array.from (<anonymous>)
at ModbusClient._logTransaction
at ModbusClient._scanRegister
at async ModbusClient.scanRegisters
```

**What it was.** modbus-serial keeps a copy of the request and the responses only while debug mode is on, and only from the write that reaches the port (`index.js:363`). A transaction can carry neither, which the library checks for before using them (`index.js:388`, `434`) and Modbux did not. `RawTransaction` promised both as required, so nothing caught it. They are optional now, and a transaction without them logs with an empty frame.

**And an id that was never a number.** Only the TCP, UDP and TCP-RTU ports have a `_transactionIdWrite`. RTU has no transaction ids, so every serial transaction is filed under the string `"undefined"`. Reading that key as a number gave each logged serial transaction an id starting with `NaN`. It is a map key, and it stays one.

Two things the audit found and this does not touch, both in the library:

- Because the serial key never changes, a late frame from a timed-out request is looked up as the next request's transaction: it is pushed into its responses and it cancels its timeout (`index.js:427`, `449`). During a scan, where timeouts are routine, a request can be answered by the previous frame.
- The library never removes a transaction, which is why Modbux wipes the map. Whatever is in flight goes with it, and the response that arrives after finds nothing.

What I could not pin down by reading is which request left a transaction without a frame on that machine; reproducing it needs the serial hardware. The log now shows such a case as an empty request instead of taking the scan down.

Two regression tests, one of which fails on the old code.