### PR TITLE
fix: refuse 0 as a server port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **The coils and discrete inputs lists scroll inside their own panel.** A long
   list used to grow past the server view, and the whole view scrolled
   underneath it instead.
+- **The server port can no longer be set to 0.** Typing 0 left the view saying
+  "Port 0" while the server was answering on 502. Zero is not a port, it is a
+  request for whichever one is free. A port is between 1 and 65535, and asking
+  for anything else leaves the server where it is.
 
 ### Security
 

--- a/src/main/modules/__tests__/modbusServer.test.ts
+++ b/src/main/modules/__tests__/modbusServer.test.ts
@@ -896,6 +896,17 @@ describe('ModbusServer', () => {
     })
   })
 
+  describe('createServer with a stored port that is not a port', () => {
+    it('starts on the default instead', async () => {
+      const port = await server.createServer({ uuid, port: 0 })
+      expect(port).toBe(502)
+      expect(ServerTCP).toHaveBeenCalledWith(expect.any(Object), {
+        host: '0.0.0.0',
+        port: 502
+      })
+    })
+  })
+
   describe('deleteServer', () => {
     it('deletes an existing server', async () => {
       await server.createServer({ uuid, port: 5020 })
@@ -1032,6 +1043,29 @@ describe('ModbusServer', () => {
       expect(ServerTCP).not.toHaveBeenCalled()
       const messages = getWindowCalls('backend_message')
       expect(messages.some((m) => m[1].message === 'Port 5020 is already in use')).toBe(true)
+    })
+
+    it('refuses port 0 and keeps the server where it is', async () => {
+      await server.createServer({ uuid, port: 5020 })
+      ;(windows.send as ReturnType<typeof vi.fn>).mockClear()
+      const callsBefore = vi.mocked(ServerTCP).mock.calls.length
+
+      // Listening on 0 succeeds: the kernel hands out a free port, the server
+      // moves somewhere nobody can name, and the view is told it is on 0.
+      const port = await server.setPort({ uuid, port: 0 })
+
+      expect(port).toBe(5020)
+      expect(vi.mocked(ServerTCP).mock.calls.length).toBe(callsBefore)
+      const messages = getWindowCalls('backend_message')
+      expect(
+        messages.some((m) => m[1].message === 'A server needs a port between 1 and 65535')
+      ).toBe(true)
+    })
+
+    it('refuses port 0 with no server yet and answers with the default', async () => {
+      const port = await server.setPort({ uuid, port: 0 })
+      expect(port).toBe(502)
+      expect(ServerTCP).not.toHaveBeenCalled()
     })
 
     it('closes existing server before binding new port', async () => {

--- a/src/main/modules/mobusServer.ts
+++ b/src/main/modules/mobusServer.ts
@@ -53,6 +53,10 @@ export const GATEWAY_PATH_UNAVAILABLE = 10
 export const GATEWAY_TARGET_FAILED = 11
 export const DEFAULT_MOBUS_PORT = 502
 
+/** 0 is a port number the way "any" is a name: the kernel picks, and it listens. */
+export const isPort = (port: number): boolean =>
+  Number.isInteger(port) && port >= 1 && port <= 65535
+
 type ServerDataUnitMap = Map<UnitIdString, ServerData>
 type ValueGeneratorsUnitMap = Map<UnitIdString, ValueGenerators>
 
@@ -175,7 +179,9 @@ export class ModbusServer {
    * Returns the actual port used (may differ from requested if taken).
    */
   public createServer = async ({ uuid, port }: CreateServerParams): Promise<number> => {
-    let actualPort = port ?? DEFAULT_MOBUS_PORT
+    // A stored 0 from before this was refused would send the server to a port
+    // nobody can name, so it starts where it would have started without one.
+    let actualPort = port !== undefined && isPort(port) ? port : DEFAULT_MOBUS_PORT
     const maxAttempts = 10000
     let server: ServerTCP | undefined
 
@@ -589,6 +595,15 @@ export class ModbusServer {
   public setPort = async ({ uuid, port }: CreateServerParams): Promise<number> => {
     const requestedPort = port ?? DEFAULT_MOBUS_PORT
     const currentPort = this._port.get(uuid) ?? requestedPort
+
+    // Port 0 is not a port, it is a request for whichever one is free, and
+    // listening on it succeeds. The server would move somewhere nobody can
+    // name, and the number sent back to the view would be the 0 it asked for.
+    if (!isPort(requestedPort)) {
+      this._emitMessage({ message: 'A server needs a port between 1 and 65535', variant: 'error' })
+      return this._port.get(uuid) ?? DEFAULT_MOBUS_PORT
+    }
+
     const result = await this._isPortAvailable(requestedPort)
     if (!result.available) {
       const message =


### PR DESCRIPTION
Typing `0` into the server port left the view saying "Port 0" while port 502 kept answering, and setting it back to 502 then said the port was already in use.

## What actually happened

```js
// node_modules/modbus-serial/servers/servertcp.js:223
modbus._server.listen({
    port: options.port || MODBUS_PORT,   // MODBUS_PORT = 502
```

`0 || 502` is 502, so asking for port 0 puts the server straight back on 502. Measured with a plain node process, which may not have 502:

```console
$ node portprobe.mjs
serverError: EACCES listen EACCES: permission denied 127.0.0.1:502
```

It asked for 0 and tried 502.

Modbux's own check passes on the way in for a different reason: `net.createServer().listen(0)` succeeds, because zero is not a port, it is a request for whichever one is free. So the old server was closed, a new one came up on 502, and `setPort` returned the `0` it was asked for. That `0` is the number in the label, the client found 502 because that is genuinely where the server was, and 502 was refused afterwards by the app's own listener.

`ServerTCP.close()` was not part of it: it frees the port, with a client connected, and its callback fires.

## What this changes

A port is between 1 and 65535. Anything else is refused with a message and the server stays where it is. `createServer` applies the same rule to a stored port, so a setup that already caught this comes back on 502 instead of wandering off at startup.

Three tests, all of which fail on the old code.

## Left alone

Nothing listens to the TCP server's `serverError` or `initialized`. Between `_isPortAvailable` and `new ServerTCP` another process can take the port, and the bind then fails silently while Modbux records a port nothing is listening on. Same shape as this one, rarer, and not fixed here.