### PR TITLE
feat: what a unit ID scan actually found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **A unit that refuses is no longer painted as a unit that is not there.** In
+  the unit ID scan, a Modbus exception is a reply: the unit exists and it
+  answered the question with no. It used to get the same red as a unit that
+  stayed silent. The result cells now say OK, EXCEPTION or NO REPLY, in green,
+  amber and red, and the message beside them carries the same colour. Filtering
+  a column offers those three answers rather than a text box.
 - **Only the columns worth filtering still offer a filter.** Addr., Bit and BIN
   lost theirs: a filter over an address or a row of LEDs answers nothing anyone
   asks. HEX and the value columns keep theirs, because a status word or a fault

--- a/e2e/specs/01-main/12-scan-unitids.spec.ts
+++ b/e2e/specs/01-main/12-scan-unitids.spec.ts
@@ -99,9 +99,7 @@ test.describe.serial('Scan Unit IDs', () => {
 
   test('Holding Registers is selected by default', async ({ mainPage }) => {
     const modal = mainPage.locator('.MuiModal-root')
-    const holdingBtn = modal.locator('button.MuiToggleButton-root', {
-      hasText: 'Holding Registers'
-    })
+    const holdingBtn = modal.getByTestId('scan-unitid-type-holding-registers')
     await expect(holdingBtn).toHaveClass(/Mui-selected/)
   })
 
@@ -109,9 +107,9 @@ test.describe.serial('Scan Unit IDs', () => {
     mainPage
   }) => {
     const modal = mainPage.locator('.MuiModal-root')
-    const coilsBtn = modal.locator('button.MuiToggleButton-root', { hasText: 'Coils' })
-    const diBtn = modal.locator('button.MuiToggleButton-root', { hasText: 'Discrete Inputs' })
-    const irBtn = modal.locator('button.MuiToggleButton-root', { hasText: 'Input Registers' })
+    const coilsBtn = modal.getByTestId('scan-unitid-type-coils')
+    const diBtn = modal.getByTestId('scan-unitid-type-discrete-inputs')
+    const irBtn = modal.getByTestId('scan-unitid-type-input-registers')
 
     await expect(coilsBtn).not.toHaveClass(/Mui-selected/)
     await expect(diBtn).not.toHaveClass(/Mui-selected/)
@@ -120,15 +118,13 @@ test.describe.serial('Scan Unit IDs', () => {
 
   test('can select multiple register types', async ({ mainPage }) => {
     const modal = mainPage.locator('.MuiModal-root')
-    const coilsBtn = modal.locator('button.MuiToggleButton-root', { hasText: 'Coils' })
+    const coilsBtn = modal.getByTestId('scan-unitid-type-coils')
 
     await coilsBtn.click()
     await expect(coilsBtn).toHaveClass(/Mui-selected/)
 
     // Holding should still be selected (multi-select)
-    const holdingBtn = modal.locator('button.MuiToggleButton-root', {
-      hasText: 'Holding Registers'
-    })
+    const holdingBtn = modal.getByTestId('scan-unitid-type-holding-registers')
     await expect(holdingBtn).toHaveClass(/Mui-selected/)
 
     // Deselect coils again for clean state
@@ -138,9 +134,7 @@ test.describe.serial('Scan Unit IDs', () => {
 
   test('start button is disabled when no register types selected', async ({ mainPage }) => {
     const modal = mainPage.locator('.MuiModal-root')
-    const holdingBtn = modal.locator('button.MuiToggleButton-root', {
-      hasText: 'Holding Registers'
-    })
+    const holdingBtn = modal.getByTestId('scan-unitid-type-holding-registers')
 
     // Deselect the only selected type
     await holdingBtn.click()
@@ -197,11 +191,26 @@ test.describe.serial('Scan Unit IDs', () => {
     await expect(modal.locator('.MuiDataGrid-row[data-id="1"]')).toBeVisible()
   })
 
-  test('results show OK chip for responding unit IDs', async ({ mainPage }) => {
+  test('a unit that answered is green and says so', async ({ mainPage }) => {
     const modal = mainPage.locator('.MuiModal-root')
-    // Unit 0 has holding registers — should show OK chip
+    // Unit 0 has holding registers, so it answered with data.
     const row0 = modal.locator('.MuiDataGrid-row[data-id="0"]')
-    await expect(row0.locator('.MuiChip-colorSuccess')).toBeVisible()
+    await expect(row0.locator('.scan-answered').first()).toBeVisible()
+    await expect(row0.locator('.scan-answered').first()).toContainText('OK')
+  })
+
+  test('a unit that refused is amber, not the red of one that said nothing', async ({
+    mainPage
+  }) => {
+    const modal = mainPage.locator('.MuiModal-root')
+
+    // Modbux answers for every unit ID it is asked about, and refuses the ones
+    // it holds no data for, so the rows past the configured units carry a
+    // refusal rather than silence.
+    const refused = modal.locator('.scan-refused')
+    await expect(refused.first()).toBeVisible()
+    await expect(refused.first()).toContainText('EXCEPTION')
+    await expect(modal.locator('.scan-silent')).toHaveCount(0)
   })
 
   // ─── Scan with multiple register types ──────────────────────────────
@@ -210,9 +219,9 @@ test.describe.serial('Scan Unit IDs', () => {
     test.setTimeout(60000)
 
     const modal = mainPage.locator('.MuiModal-root')
-    const coilsBtn = modal.locator('button.MuiToggleButton-root', { hasText: 'Coils' })
-    const diBtn = modal.locator('button.MuiToggleButton-root', { hasText: 'Discrete Inputs' })
-    const irBtn = modal.locator('button.MuiToggleButton-root', { hasText: 'Input Registers' })
+    const coilsBtn = modal.getByTestId('scan-unitid-type-coils')
+    const diBtn = modal.getByTestId('scan-unitid-type-discrete-inputs')
+    const irBtn = modal.getByTestId('scan-unitid-type-input-registers')
 
     await coilsBtn.click()
     await diBtn.click()
@@ -236,15 +245,6 @@ test.describe.serial('Scan Unit IDs', () => {
     )
   })
 
-  test('the bar counts the unit IDs that answered', async ({ mainPage }) => {
-    const chip = mainPage.getByTestId('scan-unitid-found-chip')
-
-    // Two of the four scanned unit IDs answer on this server.
-    await expect(chip).toContainText('Found: 2')
-    await expect(chip).toHaveClass(/MuiChip-filled/)
-    await expect(chip).toHaveClass(/MuiChip-colorSuccess/)
-  })
-
   test('multi-type scan results show columns for each type', async ({ mainPage }) => {
     const modal = mainPage.locator('.MuiModal-root')
 
@@ -259,23 +259,23 @@ test.describe.serial('Scan Unit IDs', () => {
     expect(headerText).toContain('Holding')
   })
 
-  test('unit 0 shows OK for all four types', async ({ mainPage }) => {
+  test('unit 0 answered for all four types', async ({ mainPage }) => {
     const modal = mainPage.locator('.MuiModal-root')
     const row0 = modal.locator('.MuiDataGrid-row[data-id="0"]')
 
     // Unit 0 has coils, discrete inputs, holding registers and input registers
-    const okChips = row0.locator('.MuiChip-colorSuccess')
-    const count = await okChips.count()
+    const answered = row0.locator('.scan-answered')
+    const count = await answered.count()
     expect(count).toBe(4)
   })
 
-  test('unit 1 shows OK for holding, input, and coils', async ({ mainPage }) => {
+  test('unit 1 answered for holding, input and coils', async ({ mainPage }) => {
     const modal = mainPage.locator('.MuiModal-root')
     const row1 = modal.locator('.MuiDataGrid-row[data-id="1"]')
 
     // Unit 1 has holding registers, input registers, and coils
-    const okChips = row1.locator('.MuiChip-colorSuccess')
-    const count = await okChips.count()
+    const answered = row1.locator('.scan-answered')
+    const count = await answered.count()
     expect(count).toBeGreaterThanOrEqual(3)
   })
 

--- a/src/main/modules/modbusClient.ts
+++ b/src/main/modules/modbusClient.ts
@@ -35,6 +35,18 @@ type ScanUnitIdFn = ({
   registerTypes
 }: Omit<ScanUnitIDParameters, 'range' | 'timeout'> & { id: number }) => Promise<void>
 
+/**
+ * An exception reply rather than silence.
+ *
+ * modbus-serial hangs `modbusCode` on the error it builds from an exception
+ * frame, and nothing else it throws carries one: a timeout is a
+ * TransactionTimedOutError, a closed port is a PortNotOpenError. So the code
+ * is the whole test, and it separates a unit that refused a request from a
+ * unit that was never there.
+ */
+const isModbusException = (error: unknown): boolean =>
+  typeof (error as { modbusCode?: unknown })?.modbusCode === 'number'
+
 /** Modbus frames read the way a protocol analyser prints them. */
 const toHexString = (bytes: Uint8Array | undefined): string =>
   bytes === undefined
@@ -738,6 +750,7 @@ export class ModbusClient {
     const result: ScanUnitIDResult = {
       id,
       registerTypes: [],
+      refusedRegisterTypes: [],
       requestedRegisterTypes: registerTypes,
       errorMessage: {
         coils: '',
@@ -759,6 +772,7 @@ export class ModbusClient {
         result.registerTypes.push('coils')
       } catch (error) {
         result.errorMessage['coils'] = (error as Error).message
+        if (isModbusException(error)) result.refusedRegisterTypes.push('coils')
       }
       await this._sendScanProgress()
     }
@@ -775,6 +789,7 @@ export class ModbusClient {
         result.registerTypes.push('discrete_inputs')
       } catch (error) {
         result.errorMessage['discrete_inputs'] = (error as Error).message
+        if (isModbusException(error)) result.refusedRegisterTypes.push('discrete_inputs')
       }
       await this._sendScanProgress()
     }
@@ -790,6 +805,7 @@ export class ModbusClient {
         result.registerTypes.push('holding_registers')
       } catch (error) {
         result.errorMessage['holding_registers'] = (error as Error).message
+        if (isModbusException(error)) result.refusedRegisterTypes.push('holding_registers')
       }
       await this._sendScanProgress()
     }
@@ -806,6 +822,7 @@ export class ModbusClient {
         result.registerTypes.push('input_registers')
       } catch (error) {
         result.errorMessage['input_registers'] = (error as Error).message
+        if (isModbusException(error)) result.refusedRegisterTypes.push('input_registers')
       }
       await this._sendScanProgress()
     }

--- a/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/MenuButton/MenuButton.tsx
+++ b/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/MenuButton/MenuButton.tsx
@@ -5,7 +5,7 @@ import LoadDummyDataButton from './LoadDummyDataButton/LoadDummyDataButton'
 import MenuConnectionOptions from './MenuConnectionOptions/MenuConnectionOptions'
 import MenuRegisterOptions from './MenuRegisterOptions/MenuRegisterOptions'
 import ScanRegistersButton, { SetAnchorProps } from './ScanRegistersButton/ScanRegistersButton'
-import ScanUnitIds from './ScanUnitIds/ScanUnitIds'
+import { ScanUnitIdsButton } from './ScanUnitIds/ScanUnitIds'
 import FormGroup from '@mui/material/FormGroup'
 import Button from '@mui/material/Button'
 import { Settings } from '@mui/icons-material'
@@ -16,7 +16,7 @@ const MenuContent = meme(({ setAnchor }: SetAnchorProps) => {
     <FormGroup>
       <MenuRegisterOptions />
       <MenuConnectionOptions />
-      <ScanUnitIds />
+      <ScanUnitIdsButton setAnchor={setAnchor} />
       <ScanRegistersButton setAnchor={setAnchor} />
       <LoadDummyDataButton setAnchor={setAnchor} />
     </FormGroup>

--- a/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/MenuButton/ScanProgress/ScanProgress.tsx
+++ b/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/MenuButton/ScanProgress/ScanProgress.tsx
@@ -1,13 +1,13 @@
 import {
   Button,
-  Chip,
   IconButton,
   InputBaseComponentProps,
   LinearProgress,
   TextField,
-  Tooltip
+  Tooltip,
+  Typography
 } from '@mui/material'
-import { Close, Visibility, VisibilityOff } from '@mui/icons-material'
+import { Visibility, VisibilityOff } from '@mui/icons-material'
 import { meme } from '@renderer/components/shared/inputs/meme'
 import { maskInputProps, MaskInputProps } from '@renderer/components/shared/inputs/types'
 import { useRootZustand } from '@renderer/context/root.zustand'
@@ -96,21 +96,34 @@ export const ScanTimeoutField = meme(
   )
 )
 
-interface ScanFoundChipProps {
+interface ScanFoundCountProps {
   count: number
   testId: string
 }
 
-/** A scan that turns up nothing looks exactly like a scan still warming up. */
-export const ScanFoundChip = meme(
-  ({ count, testId }: ScanFoundChipProps): JSX.Element => (
-    <Chip
-      size="small"
-      label={`Found: ${count}`}
-      color={count > 0 ? 'success' : 'warning'}
-      variant={count > 0 ? 'filled' : 'outlined'}
+/**
+ * A scan that turns up nothing looks exactly like a scan still warming up, and
+ * the grid behind shows the first rows rather than how many there are.
+ *
+ * Plain text rather than a chip. A chip is a badge on something, and this is a
+ * reading: it belongs beside the buttons the way a number belongs on a gauge.
+ * The colour carries the same thing the text does, so `data-found` says it
+ * once for anything reading the page.
+ */
+export const ScanFoundCount = meme(
+  ({ count, testId }: ScanFoundCountProps): JSX.Element => (
+    <Typography
+      variant="body2"
+      sx={(theme) => ({
+        fontFamily: 'monospace',
+        whiteSpace: 'nowrap',
+        color: count > 0 ? theme.palette.success.main : theme.palette.warning.main
+      })}
       data-testid={testId}
-    />
+      data-found={count > 0}
+    >
+      Found: {count}
+    </Typography>
   )
 )
 
@@ -124,19 +137,13 @@ interface ScanCloseButtonProps {
  * The way out of a scan dialog.
  *
  * Clicking beside it used to be it, which threw away the scan you were setting
- * up on the way to anything else on screen. A button rather than a bare cross,
- * so it carries the same weight as the one beside it, and off while a scan
- * runs for the same reason the backdrop click was ignored then.
+ * up on the way to anything else on screen. A button rather than a cross, so
+ * it carries the same weight as the one beside it, and off while a scan runs
+ * for the same reason the backdrop click was ignored then.
  */
 export const ScanCloseButton = meme(
   ({ disabled, close, testId }: ScanCloseButtonProps): JSX.Element => (
-    <Button
-      color="primary"
-      startIcon={<Close />}
-      disabled={disabled}
-      onClick={close}
-      data-testid={testId}
-    >
+    <Button color="primary" disabled={disabled} onClick={close} data-testid={testId}>
       Close
     </Button>
   )

--- a/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/MenuButton/ScanRegistersButton/ScanRegisters/ScanRegisters.tsx
+++ b/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/MenuButton/ScanRegistersButton/ScanRegisters/ScanRegisters.tsx
@@ -13,7 +13,7 @@ import AddressBaseInput from '@renderer/components/shared/inputs/AddressBaseInpu
 import { dropPendingScanRows, useDataZustand } from '@renderer/context/data.zustand'
 import {
   ScanCloseButton,
-  ScanFoundChip,
+  ScanFoundCount,
   ScanGridToggle,
   ScanProgress,
   ScanTimeoutField
@@ -198,7 +198,7 @@ const FoundCount = (): JSX.Element | null => {
 
   if (!scanning) return null
 
-  return <ScanFoundChip count={count} testId="scan-found-chip" />
+  return <ScanFoundCount count={count} testId="scan-found-count" />
 }
 
 //

--- a/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/MenuButton/ScanUnitIds/ScanUnitIds.tsx
+++ b/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/MenuButton/ScanUnitIds/ScanUnitIds.tsx
@@ -1,4 +1,5 @@
 import {
+  alpha,
   Box,
   Button,
   InputBaseComponentProps,
@@ -16,13 +17,9 @@ import { useRootZustand } from '@renderer/context/root.zustand'
 import { ElementType, useCallback, useMemo } from 'react'
 import useScanUnitIdColumns from './_columns'
 import { useScanUnitIdZustand } from './_zustand'
-import {
-  ScanCloseButton,
-  ScanFoundChip,
-  ScanProgress,
-  ScanTimeoutField
-} from '../ScanProgress/ScanProgress'
+import { ScanCloseButton, ScanProgress, ScanTimeoutField } from '../ScanProgress/ScanProgress'
 import { meme } from '@renderer/components/shared/inputs/meme'
+import { SetAnchorProps } from '../ScanRegistersButton/ScanRegistersButton'
 
 //
 //
@@ -157,32 +154,37 @@ const SelectRegisterTypes = (): JSX.Element => {
       size="small"
       value={registerTypes}
       onChange={(_, rt) => setRegisterTypes(rt)}
-      aria-label="text formatting"
+      aria-label="Register types to scan"
     >
-      <ToggleButton value={'coils'}>Coils</ToggleButton>
-      <ToggleButton value={'discrete_inputs'}>Discrete Inputs</ToggleButton>
-      <ToggleButton value={'input_registers'}>Input Registers</ToggleButton>
-      <ToggleButton value={'holding_registers'}>Holding Registers</ToggleButton>
+      {/* The same short names the result columns carry, so the button you
+          press and the column it produces read the same. The full name is on
+          each one for anything reading the page out. */}
+      <ToggleButton value={'coils'} aria-label="Coils" data-testid="scan-unitid-type-coils">
+        Coils
+      </ToggleButton>
+      <ToggleButton
+        value={'discrete_inputs'}
+        aria-label="Discrete inputs"
+        data-testid="scan-unitid-type-discrete-inputs"
+      >
+        Inputs
+      </ToggleButton>
+      <ToggleButton
+        value={'input_registers'}
+        aria-label="Input registers"
+        data-testid="scan-unitid-type-input-registers"
+      >
+        Input Reg.
+      </ToggleButton>
+      <ToggleButton
+        value={'holding_registers'}
+        aria-label="Holding registers"
+        data-testid="scan-unitid-type-holding-registers"
+      >
+        Holding
+      </ToggleButton>
     </ToggleButtonGroup>
   )
-}
-
-//
-//
-// Found count
-//
-// Every scanned unit ID lands in the results, answering or not, so the count
-// is the ones that answered on at least one register type.
-const FoundCount = (): JSX.Element | null => {
-  const scanning = useRootZustand((z) => z.clientState.scanningUniId)
-  const scanned = useRootZustand((z) => z.scanUnitIdResults.length)
-  const count = useRootZustand(
-    (z) => z.scanUnitIdResults.filter((result) => result.registerTypes.length > 0).length
-  )
-
-  if (!scanning && scanned === 0) return null
-
-  return <ScanFoundChip count={count} testId="scan-unitid-found-chip" />
 }
 
 //
@@ -237,11 +239,17 @@ const ScanButton = (): JSX.Element => {
 // Scan result grid
 const ScanResultGrid = meme(() => {
   const scanResults = useRootZustand((z) => z.scanUnitIdResults)
+  const registerTypes = useScanUnitIdZustand((z) => z.registerTypes)
 
   const columns = useScanUnitIdColumns()
 
   return (
     <DataGrid
+      // Turning a register type on or off changes which columns exist, and the
+      // grid carries width state across that: the error column is the only one
+      // on flex, and it came back at zero often enough to look like it had
+      // disappeared. A new column set is a new grid.
+      key={registerTypes.join('|')}
       rows={scanResults}
       columns={columns}
       autoHeight={false}
@@ -254,7 +262,13 @@ const ScanResultGrid = meme(() => {
       // "only units that answered for holding registers" is useful; reordering
       // them is not.
       disableColumnSorting
-      sx={{
+      sx={(theme) => ({
+        // The answer is the cell, not a badge inside it: green for a reply
+        // with data, amber for a unit that answered by refusing, red for one
+        // that said nothing at all.
+        '& .scan-answered': { backgroundColor: alpha(theme.palette.success.main, 0.22) },
+        '& .scan-refused': { backgroundColor: alpha(theme.palette.warning.main, 0.22) },
+        '& .scan-silent': { backgroundColor: alpha(theme.palette.error.main, 0.22) },
         // x-data-grid v8 moved the column headers inside the virtual scroller
         // for column virtualisation, so scoping monospace to the scroller now
         // catches the headers too. Target the data rows instead.
@@ -267,7 +281,7 @@ const ScanResultGrid = meme(() => {
           height: 36,
           overflow: 'hidden'
         }
-      }}
+      })}
       localeText={{
         noRowsLabel: 'No scan results yet'
       }}
@@ -278,16 +292,23 @@ const ScanResultGrid = meme(() => {
 //
 //
 // Scan unit ids button
-const ScanUnitIdsButton = (): JSX.Element => {
+export const ScanUnitIdsButton = ({ setAnchor }: SetAnchorProps): JSX.Element => {
   const disabled = useRootZustand((z) => z.clientState.connectState !== 'connected')
-  const setScanUnitIdsOpen = useScanUnitIdZustand((z) => z.setOpen)
+
+  // Close the menu behind it, the way scanning registers does. Otherwise it is
+  // still hanging there when you close the dialog again.
+  const handleOpen = useCallback(() => {
+    useScanUnitIdZustand.getState().setOpen(true)
+    setAnchor(null)
+  }, [setAnchor])
+
   return (
     <Button
       disabled={disabled}
       sx={{ my: 1 }}
       size="small"
       variant="outlined"
-      onClick={() => setScanUnitIdsOpen(true)}
+      onClick={handleOpen}
       data-testid="scan-unitids-btn"
     >
       Scan Unit ID{`'`}s
@@ -298,6 +319,11 @@ const ScanUnitIdsButton = (): JSX.Element => {
 //
 //
 // MAIN
+/**
+ * The dialog only. It is mounted beside the client view rather than inside the
+ * menu that opens it: a Popover unmounts its children when it closes, so a
+ * dialog rendered in there goes with the menu the moment the menu does.
+ */
 const ScanUnitIds = meme(() => {
   const open = useScanUnitIdZustand((z) => z.open)
   const setOpen = useScanUnitIdZustand((z) => z.setOpen)
@@ -308,59 +334,58 @@ const ScanUnitIds = meme(() => {
   const handleClose = useCallback(() => {
     const currentRootState = useRootZustand.getState()
     if (currentRootState.clientState.scanningUniId) return
+    // The results belong to the dialog. Leaving them behind means the next
+    // scan opens on the last one and fills in around it.
+    currentRootState.clearScanUnitIdResults()
     setOpen(false)
   }, [setOpen])
 
   return (
-    <>
-      <ScanUnitIdsButton />
-      <Modal
-        open={open}
-        // Escape still closes. A click on the backdrop does not: the dialog fills
-        // the window, and reaching for anything behind it closed the scan you
-        // were setting up, results and all.
-        onClose={(_, reason) => reason !== 'backdropClick' && handleClose()}
-        sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center' }}
+    <Modal
+      open={open}
+      // Escape still closes. A click on the backdrop does not: the dialog fills
+      // the window, and reaching for anything behind it closed the scan you
+      // were setting up, results and all.
+      onClose={(_, reason) => reason !== 'backdropClick' && handleClose()}
+      sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center' }}
+    >
+      <Paper
+        elevation={5}
+        sx={(theme) => ({
+          background: theme.palette.background.default,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 2,
+          p: 3,
+          height: '90dvh',
+          width: '90dvw',
+          minHeight: 0
+        })}
       >
-        <Paper
-          elevation={5}
-          sx={(theme) => ({
-            background: theme.palette.background.default,
-            display: 'flex',
-            flexDirection: 'column',
-            gap: 2,
-            p: 3,
-            height: '90dvh',
-            width: '90dvw',
-            minHeight: 0
-          })}
-        >
-          <Box sx={{ display: 'flex', justifyContent: 'space-between', gap: 2, flexWrap: 'wrap' }}>
-            <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
-              <StartUnitIdField />
-              <CountField />
-              <AddressField />
-              <LengthField />
-              <TimeoutField />
-              <SelectRegisterTypes />
-            </Box>
-            <Box sx={{ display: 'flex', gap: 2, alignItems: 'center' }}>
-              <FoundCount />
-              <ScanButton />
-              <ScanCloseButton
-                disabled={scanning}
-                close={handleClose}
-                testId="scan-unitid-close-btn"
-              />
-            </Box>
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', gap: 2, flexWrap: 'wrap' }}>
+          <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
+            <StartUnitIdField />
+            <CountField />
+            <AddressField />
+            <LengthField />
+            <TimeoutField />
+            <SelectRegisterTypes />
           </Box>
-          <ScanProgress />
-          <Paper sx={{ flex: 1, height: '100%', minHeight: 0 }}>
-            <ScanResultGrid />
-          </Paper>
+          <Box sx={{ display: 'flex', gap: 2, alignItems: 'center' }}>
+            <ScanButton />
+            <ScanCloseButton
+              disabled={scanning}
+              close={handleClose}
+              testId="scan-unitid-close-btn"
+            />
+          </Box>
+        </Box>
+        <ScanProgress />
+        <Paper sx={{ flex: 1, height: '100%', minHeight: 0 }}>
+          <ScanResultGrid />
         </Paper>
-      </Modal>
-    </>
+      </Paper>
+    </Modal>
   )
 })
 export default ScanUnitIds

--- a/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/MenuButton/ScanUnitIds/_columns.tsx
+++ b/src/renderer/src/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/MenuButton/ScanUnitIds/_columns.tsx
@@ -2,8 +2,36 @@ import { GridColDef } from '@mui/x-data-grid'
 import { RegisterType, ScanUnitIDResult } from '@shared'
 import { useMemo } from 'react'
 import { useScanUnitIdZustand } from './_zustand'
-import { Box, Chip } from '@mui/material'
-import { CheckCircle, ErrorRounded } from '@mui/icons-material'
+import { Box } from '@mui/material'
+
+/**
+ * What a unit ID did with one request.
+ *
+ * A refusal is not a silence. An exception reply means the unit is there and
+ * talking, and it answered this particular question with no; nothing coming
+ * back at all means there is no unit at that address. Both used to be red.
+ */
+export type ScanOutcome = 'answered' | 'refused' | 'silent' | 'unasked'
+
+export const outcomeOf = (row: ScanUnitIDResult, type: RegisterType): ScanOutcome =>
+  row.registerTypes.includes(type)
+    ? 'answered'
+    : row.refusedRegisterTypes.includes(type)
+      ? 'refused'
+      : row.requestedRegisterTypes.includes(type)
+        ? 'silent'
+        : 'unasked'
+
+const OUTCOME_LABEL: Record<ScanOutcome, string> = {
+  answered: 'OK',
+  refused: 'EXCEPTION',
+  silent: 'NO REPLY',
+  unasked: ''
+}
+
+/** The class the grid paints the cell with. Styled where the grid is built. */
+export const outcomeClass = (outcome: ScanOutcome): string =>
+  outcome === 'unasked' ? '' : `scan-${outcome}`
 
 const unitIdColumn: GridColDef<ScanUnitIDResult, number, number> = {
   field: 'id',
@@ -15,21 +43,32 @@ const unitIdColumn: GridColDef<ScanUnitIDResult, number, number> = {
 
 const typeColumn = (registerType: RegisterType, name: string): GridColDef<ScanUnitIDResult> => ({
   field: registerType,
-  type: 'boolean',
   headerName: name,
   disableColumnMenu: false,
-  width: 90,
-  valueGetter: (_, row) => row.registerTypes.includes(registerType),
-  renderCell: ({ value, row }) => (
-    <Box sx={{ width: '100%', display: 'flex' }}>
-      {value ? (
-        <Chip icon={<CheckCircle />} label="OK" size="small" color="success" />
-      ) : row.requestedRegisterTypes.includes(registerType) ? (
-        <Chip icon={<ErrorRounded />} label="ERROR" size="small" color="error" />
-      ) : null}
-    </Box>
-  )
+  width: 100,
+  // The whole cell carries the answer, so the value is the word in it. A
+  // single select rather than free text: there are three answers a unit can
+  // give, and the filter should offer those three rather than ask you to type
+  // one. Nothing here is editable; the column type is for the filter.
+  type: 'singleSelect',
+  valueOptions: [
+    { value: 'answered', label: OUTCOME_LABEL.answered },
+    { value: 'refused', label: OUTCOME_LABEL.refused },
+    { value: 'silent', label: OUTCOME_LABEL.silent }
+  ],
+  valueGetter: (_, row): ScanOutcome | null => {
+    const outcome = outcomeOf(row, registerType)
+    return outcome === 'unasked' ? null : outcome
+  },
+  cellClassName: ({ row }) => outcomeClass(outcomeOf(row, registerType))
 })
+
+const FUNCTION_CODE: Record<string, string> = {
+  coils: 'FC1',
+  discrete_inputs: 'FC2',
+  holding_registers: 'FC3',
+  input_registers: 'FC4'
+}
 
 const errorColumn: GridColDef<ScanUnitIDResult> = {
   field: 'errorMessage',
@@ -37,26 +76,30 @@ const errorColumn: GridColDef<ScanUnitIDResult> = {
   flex: 1,
   minWidth: 150,
   disableColumnMenu: true,
-  renderCell: ({ value }) =>
+  renderCell: ({ value, row }) =>
     value === null ? null : (
       <Box sx={{ width: '100%', height: '100%', display: 'flex', flexDirection: 'column' }}>
-        {Object.entries(value).map(([k, v]) => {
-          return String(v).length === 0 ? null : (
-            <Box key={k} sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
-              <span>
-                {k === 'coils'
-                  ? 'FC1'
-                  : k === 'discrete_inputs'
-                    ? 'FC2'
-                    : k === 'holding_registers'
-                      ? 'FC3'
-                      : 'FC4'}
-                :
-              </span>
-              <span>{String(v)}</span>
+        {Object.entries(value).map(([type, message]) =>
+          String(message).length === 0 ? null : (
+            <Box
+              key={type}
+              // The same three states as the cells to the left, so a line here
+              // and the cell it belongs to never disagree.
+              sx={(theme) => ({
+                display: 'flex',
+                alignItems: 'center',
+                gap: 2,
+                color:
+                  outcomeOf(row, type as RegisterType) === 'refused'
+                    ? theme.palette.warning.main
+                    : theme.palette.error.main
+              })}
+            >
+              <span>{FUNCTION_CODE[type]}:</span>
+              <span>{String(message)}</span>
             </Box>
           )
-        })}
+        )}
       </Box>
     )
 }

--- a/src/renderer/src/containers/Client.tsx
+++ b/src/renderer/src/containers/Client.tsx
@@ -7,6 +7,7 @@ import RegisterConfig from '../components/client/RegisterConfig/RegisterConfig'
 import ClientGrids from '@renderer/components/client/ClientGrids/ClientGrids'
 import ConnectionConfig from '@renderer/components/client/ConnectionConfig/ConnectionConfig'
 import ScanRegisters from '@renderer/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/MenuButton/ScanRegistersButton/ScanRegisters/ScanRegisters'
+import ScanUnitIds from '@renderer/components/client/ClientGrids/RegisterGrid/RegisterGridToolbar/MenuButton/ScanUnitIds/ScanUnitIds'
 import { useRootZustand } from '@renderer/context/root.zustand'
 
 const Client = meme(() => {
@@ -33,6 +34,7 @@ const Client = meme(() => {
         </Box>
         <ClientGrids />
         <ScanRegisters />
+        <ScanUnitIds />
       </Box>
     </Fade>
   )

--- a/src/shared/types/scan.ts
+++ b/src/shared/types/scan.ts
@@ -28,7 +28,14 @@ const ScanUnitIdErrorMessageSchema = z.object({
 
 export const ScanUnitIDResultSchema = z.object({
   id: z.number(),
+  /** Answered with data. */
   registerTypes: z.array(RegisterTypeSchema),
+  /**
+   * Answered with a Modbus exception. A refusal is still an answer: the unit
+   * is there and talking, which is the opposite of the silence a unit ID that
+   * is not on the bus gives back.
+   */
+  refusedRegisterTypes: z.array(RegisterTypeSchema).default([]),
   requestedRegisterTypes: z.array(RegisterTypeSchema),
   errorMessage: ScanUnitIdErrorMessageSchema
 })


### PR DESCRIPTION
A unit that answers with a Modbus exception is a unit that is there and talking: it answered the question with no. One that says nothing is not on the bus. Both used to be the same red chip.

## Telling them apart

modbus-serial hangs `modbusCode` on the error it builds from an exception frame, and on nothing else it throws: a timeout is a `TransactionTimedOutError`, a closed port a `PortNotOpenError`. So the code is the whole test, and the result now carries the types that refused beside the ones that answered.

## In the grid

The cell carries the answer instead of a chip inside it: green `OK`, amber `EXCEPTION`, red `NO REPLY`, and the matching line in the error column takes the same colour, so the two cannot disagree. The columns are single selects, so filtering offers those three answers rather than a text box. Nothing is editable; the type is for the filter.

The register type toggles carry the short names the columns use, and the count is gone from this dialog: the grid lists every unit it asked, which is more than a number can say. It stays in the register scan, where you only see the first rows.

## Manners

The cog menu stayed open behind this dialog, because only the register scan closed it, and the dialog was rendered inside that menu: a Popover unmounts its children when it closes, so closing the menu took the dialog with it. It is mounted beside the client view now, where the register dialog already was. Closing clears the results. The close button lost its cross.

The grid is keyed on the chosen register types, because it carries width state across a change of columns and the error column, the only one on flex, came back at zero often enough to look like it had vanished.

## What was run

Lint, typecheck, 573 unit tests, and the full e2e suite at 556. One of the new specs pins down something worth knowing: against Modbux's own server every scanned unit ID answers, so the results come back amber and never red. `ServerTCP` and `ServerSerial` ignore a request whose unit ID is not theirs unless theirs is 255, and Modbux passes none, which is right for a server holding several units. Testing a real silence needs an opponent that can be told to stay quiet.