### PR TITLE
chore: 2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Modbux will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.3.0] - 2026-08-30
 
 ### Added
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "modbux",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "A Modbus Client/Server tool",
   "main": "./out/main/index.js",
   "author": {


### PR DESCRIPTION
The version the app reports, and the changelog heading that was still `Unreleased`. Everything under it landed today.

The home screen reads the version from `package.json`, so this has to be in place before the screenshot tour produces the set that goes with the release.

The date moves if the tag slips.