### PR TITLE
docs: the unit ID scan has no count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,9 +42,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   scan walks raw addresses, and the dialog stays open when the scan ends rather
   than closing to reveal what you were already watching. The eye beside the
   scan button puts it all back the old way.
-- **A scan says how many it found.** The grid shows the first rows, not the
-  total, so the count sits beside the scan button. The unit ID scan counts the
-  units that answered, since its results list every unit it asked.
+- **A scan says how many registers it found.** The grid shows the first rows,
+  not the total, so the count sits beside the scan button.
 
 ### Changed
 


### PR DESCRIPTION
The changelog promised a count on the unit ID scan. It had one for an afternoon; the results list every unit it asked, which says more than a number, so it went out again in #47 and the entry kept the sentence.

The line at the `v2.3.0` tag keeps the old wording. Moving a tag over one sentence costs more than the sentence.